### PR TITLE
Adpated InVesalius to run in wxpython3

### DIFF
--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*- 
+# -*- coding: UTF-8 -*-
 #--------------------------------------------------------------------------
 # Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
 # Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
@@ -22,9 +22,9 @@ import sys
 import platform
 
 try:
-    from PIL import Image
-except(ImportError):
     import Image
+except ImportError:
+    from PIL import Image
 
 import wx
 import wx.grid
@@ -54,9 +54,8 @@ LOCATION = {const.SURFACE: _(u"3D"),
 # Panel that initializes notebook and related tabs
 class NotebookPanel(wx.Panel):
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(0, 50),
-                            size=wx.Size(256, 200))
-                        
+        wx.Panel.__init__(self, parent)
+
         book = wx.Notebook(self, -1,style= wx.BK_DEFAULT)
         # TODO: check under Windows and Linux
         # this was necessary under cOS:
@@ -68,13 +67,13 @@ class NotebookPanel(wx.Panel):
         book.AddPage(SurfacePage(book), _("3D surfaces"))
         book.AddPage(MeasurePage(book), _("Measures"))
         #book.AddPage(AnnotationsListCtrlPanel(book), _("Notes"))
-        
+
         book.SetSelection(0)
-        
+
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(book, 1, wx.EXPAND)
+        sizer.Add(book, 0, wx.EXPAND)
         self.SetSizer(sizer)
-        
+
         book.Refresh()
         self.book = book
 
@@ -117,8 +116,7 @@ class MeasurePage(wx.Panel):
     Page related to mask items.
     """
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(0, 50),
-                            size=wx.Size(256, 140))
+        wx.Panel.__init__(self, parent)
         self.__init_gui()
 
     def __init_gui(self):
@@ -148,7 +146,7 @@ class MeasureButtonControlPanel(wx.Panel):
         self.__init_gui()
 
     def __init_gui(self):
-        
+
         # Bitmaps to be used in plate buttons
         BMP_NEW = wx.Bitmap("../icons/data_new.png",
                             wx.BITMAP_TYPE_PNG)
@@ -162,16 +160,16 @@ class MeasureButtonControlPanel(wx.Panel):
         button_new = pbtn.PlateButton(self, BTN_NEW, "",
                                      BMP_NEW,
                                      style=button_style,
-                                     size = wx.Size(18, 18))
+                                     size = wx.Size(24, 20))
         self.button_new = button_new
         button_remove = pbtn.PlateButton(self, BTN_REMOVE, "",
                                          BMP_REMOVE,
                                          style=button_style,
-                                         size = wx.Size(18, 18))
+                                         size = wx.Size(24, 20))
         button_duplicate = pbtn.PlateButton(self, BTN_DUPLICATE, "",
                                             BMP_DUPLICATE,
                                             style=button_style,
-                                            size = wx.Size(18, 18))
+                                            size = wx.Size(24, 20))
         button_duplicate.Disable()
 
         # Add all controls to gui
@@ -206,7 +204,7 @@ class MeasureButtonControlPanel(wx.Panel):
 
     def OnNew(self):
         self.PopupMenu(self.menu)
-        
+
     def OnMenu(self, evt):
         id = evt.GetId()
         if id == const.MEASURE_LINEAR:
@@ -222,7 +220,7 @@ class MeasureButtonControlPanel(wx.Panel):
         if selected_items:
             Publisher.sendMessage('Duplicate measurement', selected_items)
         else:
-           dlg.MaskSelectionRequiredForDuplication() 
+           dlg.MaskSelectionRequiredForDuplication()
 
 
 
@@ -233,8 +231,7 @@ class MaskPage(wx.Panel):
     Page related to mask items.
     """
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(0, 50),
-                            size=wx.Size(256, 140))
+        wx.Panel.__init__(self, parent)
         self.__init_gui()
 
     def __init_gui(self):
@@ -262,7 +259,7 @@ class ButtonControlPanel(wx.Panel):
         self.__init_gui()
 
     def __init_gui(self):
-        
+
         # Bitmaps to be used in plate buttons
         BMP_NEW = wx.Bitmap("../icons/data_new.png",
                             wx.BITMAP_TYPE_PNG)
@@ -276,15 +273,15 @@ class ButtonControlPanel(wx.Panel):
         button_new = pbtn.PlateButton(self, BTN_NEW, "",
                                      BMP_NEW,
                                      style=button_style,
-                                     size = wx.Size(18, 18))
+                                     size = wx.Size(24, 20))
         button_remove = pbtn.PlateButton(self, BTN_REMOVE, "",
                                          BMP_REMOVE,
                                          style=button_style,
-                                         size = wx.Size(18, 18))
+                                         size = wx.Size(24, 20))
         button_duplicate = pbtn.PlateButton(self, BTN_DUPLICATE, "",
                                             BMP_DUPLICATE,
                                             style=button_style,
-                                            size = wx.Size(18, 18))
+                                            size = wx.Size(24, 20))
 
         # Add all controls to gui
         sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -332,17 +329,17 @@ class ButtonControlPanel(wx.Panel):
         if selected_items:
             Publisher.sendMessage('Duplicate masks', selected_items)
         else:
-           dlg.MaskSelectionRequiredForDuplication() 
+           dlg.MaskSelectionRequiredForDuplication()
 
 class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 
     def __init__(self, parent, ID=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.LC_REPORT):
-        
+
         # native look and feel for MacOS
         #if wx.Platform == "__WXMAC__":
         #    wx.SystemOptions.SetOptionInt("mac.listctrl.always_use_generic", 0)
-        
+
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style=wx.LC_REPORT)
         listmix.TextEditMixin.__init__(self)
         self.mask_list_index = {}
@@ -351,13 +348,13 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         self.__init_image_list()
         self.__bind_events_wx()
         self.__bind_events()
-        
+
     def __bind_events_wx(self):
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemActivated)
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.OnEditLabel)
         self.Bind(wx.EVT_KEY_UP, self.OnKeyEvent)
 
- 
+
     def __bind_events(self):
         Publisher.subscribe(self.AddMask, 'Add mask')
         Publisher.subscribe(self.EditMaskThreshold,
@@ -376,7 +373,7 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             self.RemoveMasks()
         elif (keycode == wx.WXK_DELETE):
             self.RemoveMasks()
-    
+
     def RemoveMasks(self):
         """
         Remove selected items.
@@ -403,7 +400,7 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
                         new_dict[i-1] = old_dict[i]
                 old_dict = new_dict
             self.mask_list_index = new_dict
-       
+
         if new_dict:
             if index == self.current_index:
                 self.SetItemImage(0, 1)
@@ -421,7 +418,7 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def OnCloseProject(self, pubsub_evt):
         self.DeleteAllItems()
         self.mask_list_index = {}
- 
+
     def OnChangeCurrentMask(self, pubsub_evt):
         mask_index = pubsub_evt.data
         try:
@@ -439,15 +436,15 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         self.SetItemImage(self.current_index, 0)
 
     def __init_columns(self):
-        
+
         self.InsertColumn(0, "", wx.LIST_FORMAT_CENTER)
         self.InsertColumn(1, _("Name"))
         self.InsertColumn(2, _("Threshold"), wx.LIST_FORMAT_RIGHT)
-        
-        self.SetColumnWidth(0, 20)
+
+        self.SetColumnWidth(0, 25)
         self.SetColumnWidth(1, 120)
         self.SetColumnWidth(2, 90)
-        
+
     def __init_image_list(self):
         self.imagelist = wx.ImageList(16, 16)
 
@@ -466,7 +463,7 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         self.SetImageList(self.imagelist,wx.IMAGE_LIST_SMALL)
 
         self.image_gray = Image.open("../icons/object_colour.jpg")
-        
+
     def OnEditLabel(self, evt):
         Publisher.sendMessage('Change mask name',
                                    (evt.GetIndex(), evt.GetLabel()))
@@ -474,7 +471,7 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 
     def OnItemActivated(self, evt):
         self.ToggleItem(evt.m_itemIndex)
-        
+
     def OnCheckItem(self, index, flag):
         if flag:
             for key in self.mask_list_index.keys():
@@ -505,22 +502,22 @@ class MasksListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def InsertNewItem(self, index=0, label=_("Mask"), threshold="(1000, 4500)",
                       colour=None):
         self.InsertStringItem(index, "")
-        self.SetStringItem(index, 1, label, 
-                           imageId=self.mask_list_index[index]) 
+        self.SetStringItem(index, 1, label,
+                           imageId=self.mask_list_index[index])
         self.SetStringItem(index, 2, threshold)
         self.SetItemImage(index, 1)
         for key in self.mask_list_index.keys():
             if key != index:
                 self.SetItemImage(key, 0)
         self.current_index = index
-        
+
     def AddMask(self, pubsub_evt):
         index, mask_name, threshold_range, colour = pubsub_evt.data
         image = self.CreateColourBitmap(colour)
         image_index = self.imagelist.Add(image)
         self.mask_list_index[index] = image_index
         self.InsertNewItem(index, mask_name, str(threshold_range))
-                
+
     def EditMaskThreshold(self, pubsub_evt):
         index, threshold_range = pubsub_evt.data
         self.SetStringItem(index, 2, str(threshold_range))
@@ -553,8 +550,7 @@ class SurfacePage(wx.Panel):
     Page related to mask items.
     """
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(0, 50),
-                            size=wx.Size(256, 140))
+        wx.Panel.__init__(self, parent)
         self.__init_gui()
 
     def __init_gui(self):
@@ -581,7 +577,7 @@ class SurfaceButtonControlPanel(wx.Panel):
         self.__init_gui()
 
     def __init_gui(self):
-        
+
         # Bitmaps to be used in plate buttons
         BMP_NEW = wx.Bitmap("../icons/data_new.png",
                             wx.BITMAP_TYPE_PNG)
@@ -595,15 +591,15 @@ class SurfaceButtonControlPanel(wx.Panel):
         button_new = pbtn.PlateButton(self, BTN_NEW, "",
                                      BMP_NEW,
                                      style=button_style,
-                                     size = wx.Size(18, 18))
+                                     size = wx.Size(24, 20))
         button_remove = pbtn.PlateButton(self, BTN_REMOVE, "",
                                          BMP_REMOVE,
                                          style=button_style,
-                                         size = wx.Size(18, 18))
+                                         size = wx.Size(24, 20))
         button_duplicate = pbtn.PlateButton(self, BTN_DUPLICATE, "",
                                             BMP_DUPLICATE,
                                             style=button_style,
-                                            size = wx.Size(18, 18))
+                                            size = wx.Size(24, 20))
 
         # Add all controls to gui
         sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -627,7 +623,7 @@ class SurfaceButtonControlPanel(wx.Panel):
 
     def OnNew(self):
         sl = slice_.Slice()
-        dialog = dlg.SurfaceCreationDialog(None, -1, 
+        dialog = dlg.SurfaceCreationDialog(None, -1,
                             _('New surface'),
                             mask_edited=sl.current_mask.was_edited)
         try:
@@ -653,18 +649,18 @@ class SurfaceButtonControlPanel(wx.Panel):
         if selected_items:
             Publisher.sendMessage('Duplicate surfaces', selected_items)
         else:
-           dlg.SurfaceSelectionRequiredForDuplication() 
+           dlg.SurfaceSelectionRequiredForDuplication()
 
 
 class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 
     def __init__(self, parent, ID=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.LC_REPORT):
-        
+
         # native look and feel for MacOS
         #if wx.Platform == "__WXMAC__":
         #    wx.SystemOptions.SetOptionInt("mac.listctrl.always_use_generic", 0)
-        
+
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style=wx.LC_REPORT)
         listmix.TextEditMixin.__init__(self)
 
@@ -686,7 +682,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         Publisher.subscribe(self.OnHideSurface, 'Hide surface items')
 
         Publisher.subscribe(self.OnShowSingle, 'Show single surface')
-        Publisher.subscribe(self.OnShowMultiple, 'Show multiple surfaces') 
+        Publisher.subscribe(self.OnShowMultiple, 'Show multiple surfaces')
 
     def __bind_events_wx(self):
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemActivated)
@@ -730,7 +726,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 
             Publisher.sendMessage('Remove surfaces', selected_items)
         else:
-           dlg.SurfaceSelectionRequiredForRemoval() 
+           dlg.SurfaceSelectionRequiredForRemoval()
 
     def OnCloseProject(self, pubsub_evt):
         self.DeleteAllItems()
@@ -762,17 +758,17 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         return selected
 
     def __init_columns(self):
-        
+
         self.InsertColumn(0, "", wx.LIST_FORMAT_CENTER)
         self.InsertColumn(1, _("Name"))
         self.InsertColumn(2, _(u"Volume (mm³)"))
         self.InsertColumn(3, _("Transparency"), wx.LIST_FORMAT_RIGHT)
-        
-        self.SetColumnWidth(0, 20)
+
+        self.SetColumnWidth(0, 25)
         self.SetColumnWidth(1, 85)
         self.SetColumnWidth(2, 85)
         self.SetColumnWidth(3, 80)
-        
+
     def __init_image_list(self):
         self.imagelist = wx.ImageList(16, 16)
 
@@ -787,7 +783,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         bitmap.SetWidth(16)
         bitmap.SetHeight(16)
         img_check = self.imagelist.Add(bitmap)
-        
+
         self.SetImageList(self.imagelist,wx.IMAGE_LIST_SMALL)
 
         self.image_gray = Image.open("../icons/object_colour.jpg")
@@ -795,13 +791,13 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def OnEditLabel(self, evt):
         Publisher.sendMessage('Change surface name', (evt.GetIndex(), evt.GetLabel()))
         evt.Skip()
-        
+
     def OnItemActivated(self, evt):
         self.ToggleItem(evt.m_itemIndex)
         evt.Skip()
-        
+
     def OnCheckItem(self, index, flag):
-        Publisher.sendMessage('Show surface', (index, flag)) 
+        Publisher.sendMessage('Show surface', (index, flag))
 
     def OnShowSingle(self, pubsub_evt):
         index, visibility = pubsub_evt.data
@@ -809,7 +805,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             if key != index:
                 self.SetItemImage(key, not visibility)
                 Publisher.sendMessage('Show surface',
-                                            (key, not visibility)) 
+                                            (key, not visibility))
         self.SetItemImage(index, visibility)
         Publisher.sendMessage('Show surface',
                                    (index, visibility))
@@ -820,7 +816,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             if key not in index_list:
                 self.SetItemImage(key, not visibility)
                 Publisher.sendMessage('Show surface',
-                                            (key, not visibility)) 
+                                            (key, not visibility))
         for index in index_list:
             self.SetItemImage(index, visibility)
             Publisher.sendMessage('Show surface',
@@ -832,7 +828,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         colour = pubsub_evt.data[2]
         volume = "%.3f"%pubsub_evt.data[3]
         transparency = "%d%%"%(int(100*pubsub_evt.data[4]))
-       
+
         if index not in self.surface_list_index:
             image = self.CreateColourBitmap(colour)
             image_index = self.imagelist.Add(image)
@@ -849,7 +845,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
                       transparency="0%%", colour=None):
         self.InsertStringItem(index, "")
         self.SetStringItem(index, 1, label,
-                            imageId = self.surface_list_index[index]) 
+                            imageId = self.surface_list_index[index])
         self.SetStringItem(index, 2, volume)
         self.SetStringItem(index, 3, transparency)
         self.SetItemImage(index, 1)
@@ -857,11 +853,11 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def UpdateItemInfo(self, index=0, label="Surface 1", volume="0 mm3",
                       transparency="0%%", colour=None):
         self.SetStringItem(index, 1, label,
-                            imageId = self.surface_list_index[index]) 
+                            imageId = self.surface_list_index[index])
         self.SetStringItem(index, 2, volume)
         self.SetStringItem(index, 3, transparency)
         self.SetItemImage(index, 1)
-        
+
     def CreateColourBitmap(self, colour):
         """
         Create a wx Image with a mask colour.
@@ -887,7 +883,7 @@ class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         """
         index, value = pubsub_evt.data
         self.SetStringItem(index, 3, "%d%%"%(int(value*100)))
-        
+
     def EditSurfaceColour(self, pubsub_evt):
         """
         """
@@ -905,11 +901,11 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 
     def __init__(self, parent, ID=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.LC_REPORT):
-        
+
         # native look and feel for MacOS
         #if wx.Platform == "__WXMAC__":
         #    wx.SystemOptions.SetOptionInt("mac.listctrl.always_use_generic", 0)
-        
+
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style=wx.LC_REPORT)
         listmix.TextEditMixin.__init__(self)
 
@@ -927,7 +923,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
                                  'Set measurement colour')
         Publisher.subscribe(self.OnCloseProject, 'Close project data')
         Publisher.subscribe(self.OnShowSingle, 'Show single measurement')
-        Publisher.subscribe(self.OnShowMultiple, 'Show multiple measurements') 
+        Publisher.subscribe(self.OnShowMultiple, 'Show multiple measurements')
         Publisher.subscribe(self.OnLoadData, 'Load measurement dict')
 
     def __bind_events_wx(self):
@@ -1007,13 +1003,13 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         self.InsertColumn(2, _("Location"))
         self.InsertColumn(3, _("Type"))
         self.InsertColumn(4, _("Value"), wx.LIST_FORMAT_RIGHT)
-        
-        self.SetColumnWidth(0, 20)
+
+        self.SetColumnWidth(0, 25)
         self.SetColumnWidth(1, 65)
         self.SetColumnWidth(2, 55)
         self.SetColumnWidth(3, 50)
         self.SetColumnWidth(4, 75)
- 
+
     def __init_image_list(self):
         self.imagelist = wx.ImageList(16, 16)
 
@@ -1028,7 +1024,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         bitmap.SetWidth(16)
         bitmap.SetHeight(16)
         img_check = self.imagelist.Add(bitmap)
-        
+
         self.SetImageList(self.imagelist,wx.IMAGE_LIST_SMALL)
 
         self.image_gray = Image.open("../icons/object_colour.jpg")
@@ -1037,14 +1033,14 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def OnEditLabel(self, evt):
         Publisher.sendMessage('Change measurement name', (evt.GetIndex(), evt.GetLabel()))
         evt.Skip()
-        
+
     def OnItemActivated(self, evt):
         self.ToggleItem(evt.m_itemIndex)
         evt.Skip()
 
-        
+
     def OnCheckItem(self, index, flag):
-        Publisher.sendMessage('Show measurement', (index, flag)) 
+        Publisher.sendMessage('Show measurement', (index, flag))
 
     def OnShowSingle(self, pubsub_evt):
         index, visibility = pubsub_evt.data
@@ -1052,7 +1048,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             if key != index:
                 self.SetItemImage(key, not visibility)
                 Publisher.sendMessage('Show measurement',
-                                            (key, not visibility)) 
+                                            (key, not visibility))
         self.SetItemImage(index, visibility)
         Publisher.sendMessage('Show measurement',
                                    (index, visibility))
@@ -1063,7 +1059,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             if key not in index_list:
                 self.SetItemImage(key, not visibility)
                 Publisher.sendMessage('Show measurement',
-                                            (key, not visibility)) 
+                                            (key, not visibility))
         for index in index_list:
             self.SetItemImage(index, visibility)
             Publisher.sendMessage('Show measurement',
@@ -1078,7 +1074,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
             m = items_dict[i]
             image = self.CreateColourBitmap(m.colour)
             image_index = self.imagelist.Add(image)
-        
+
             index_list = self._list_index.keys()
             self._list_index[m.index] = image_index
 
@@ -1105,7 +1101,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         if index not in self._list_index:
             image = self.CreateColourBitmap(colour)
             image_index = self.imagelist.Add(image)
-        
+
             index_list = self._list_index.keys()
             self._list_index[index] = image_index
 
@@ -1120,7 +1116,7 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
                        location="SURFACE", type_="LINEAR", value="0 mm"):
         self.InsertStringItem(index, "")
         self.SetStringItem(index, 1, label,
-                            imageId = self._list_index[index]) 
+                            imageId = self._list_index[index])
         self.SetStringItem(index, 2, location)
         self.SetStringItem(index, 3, type_)
         self.SetStringItem(index, 4, value)
@@ -1130,13 +1126,13 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def UpdateItemInfo(self, index=0, label="Measurement 1", colour=None,
                       type_="LINEAR", location="SURFACE", value="0 mm"):
         self.SetStringItem(index, 1, label,
-                            imageId = self._list_index[index]) 
+                            imageId = self._list_index[index])
         self.SetStringItem(index, 2, type_)
         self.SetStringItem(index, 3, location)
         self.SetStringItem(index, 4, value)
         self.SetItemImage(index, 1)
         self.Refresh()
-        
+
     def CreateColourBitmap(self, colour):
         """
         Create a wx Image with a mask colour.
@@ -1169,41 +1165,41 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
 #*******************************************************************
 #*******************************************************************
 
-    
+
 class AnnotationsListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     # TODO: Remove edimixin, allow only visible and invisible
     def __init__(self, parent, ID=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.LC_REPORT):
-        
+
         # native look and feel for MacOS
         #if wx.Platform == "__WXMAC__":
         #    wx.SystemOptions.SetOptionInt("mac.listctrl.always_use_generic", 0)
-        
+
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style=wx.LC_REPORT)
         listmix.TextEditMixin.__init__(self)
 
         self.__init_columns()
         self.__init_image_list()
         self.__init_evt()
-        
+
         # just testing
         self.Populate()
-        
+
     def __init_evt(self):
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemActivated)
 
     def __init_columns(self):
-        
+
         self.InsertColumn(0, "", wx.LIST_FORMAT_CENTER)
         self.InsertColumn(1, _("Name"))
         self.InsertColumn(2, _("Type"), wx.LIST_FORMAT_CENTER)
         self.InsertColumn(3, _("Value"))
-        
-        self.SetColumnWidth(0, 20)
+
+        self.SetColumnWidth(0, 25)
         self.SetColumnWidth(1, 90)
         self.SetColumnWidth(2, 50)
         self.SetColumnWidth(3, 120)
-        
+
     def __init_image_list(self):
         self.imagelist = wx.ImageList(16, 16)
 
@@ -1212,7 +1208,7 @@ class AnnotationsListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         bitmap.SetWidth(16)
         bitmap.SetHeight(16)
         img_check = self.imagelist.Add(bitmap)
-        
+
         image = wx.Image("../icons/object_invisible.jpg")
         bitmap = wx.BitmapFromImage(image.Scale(16, 16))
         bitmap.SetWidth(16)
@@ -1224,13 +1220,13 @@ class AnnotationsListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
         bitmap.SetWidth(16)
         bitmap.SetHeight(16)
         self.img_colour = self.imagelist.Add(bitmap)
-        
+
         self.SetImageList(self.imagelist,wx.IMAGE_LIST_SMALL)
 
-        
+
     def OnItemActivated(self, evt):
         self.ToggleItem(evt.m_itemIndex)
-        
+
     def OnCheckItem(self, index, flag):
         # TODO: use pubsub to communicate to models
         if flag:
@@ -1241,10 +1237,10 @@ class AnnotationsListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
     def InsertNewItem(self, index=0, name="Axial 1", type_="2d",
                       value="bla", colour=None):
         self.InsertStringItem(index, "")
-        self.SetStringItem(index, 1, name, imageId = self.img_colour) 
+        self.SetStringItem(index, 1, name, imageId = self.img_colour)
         self.SetStringItem(index, 2, type_)
         self.SetStringItem(index, 3, value)
-        
+
     def Populate(self):
         dict = ((0, "Axial 1", "2D", "blalbalblabllablalbla"),
                 (1, "Coronal 1", "2D", "hello here we are again"),

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -100,32 +100,47 @@ class Panel(wx.Panel):
         wx.Panel.__init__(self, parent, pos=wx.Point(5, 5),
                           size=wx.Size(280, 656))
 
-        sizer = wx.BoxSizer(wx.VERTICAL)
+        #sizer = wx.BoxSizer(wx.VERTICAL)
+        gbs = wx.GridBagSizer(5,5)
         #sizer.Add(UpperTaskPanel(self), 5, wx.EXPAND|wx.GROW)
-        sizer.Add(UpperTaskPanel(self), 16, wx.EXPAND|wx.GROW)
+        gbs.Add(UpperTaskPanel(self), (0, 0), flag=wx.EXPAND)
 
         #sizer.Add(LowerTaskPanel(self), 3, wx.EXPAND|wx.GROW)
-        sizer.Add(LowerTaskPanel(self), 6, wx.EXPAND|wx.GROW)
+        gbs.Add(LowerTaskPanel(self), (1, 0), flag=wx.EXPAND | wx.ALIGN_BOTTOM)
 
+        gbs.AddGrowableCol(0)
 
+        gbs.AddGrowableRow(0, 1)
+        gbs.AddGrowableRow(1, 0)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(gbs, 1, wx.EXPAND)
+
+        self.gbs = gbs
+
+        #self.SetSizerAndFit(sizer)
         self.SetSizer(sizer)
+
 
 # Lower fold panel
 class LowerTaskPanel(wx.Panel):
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(5, 5),
-        #                  size=wx.Size(280, 700))
-                           size=wx.Size(280, 420))
+        wx.Panel.__init__(self, parent, size=(150, -1))
+        fold_panel = fpb.FoldPanelBar(self, -1,
+                                      style=FPB_DEFAULT_STYLE,
+                                      agwStyle=fpb.FPB_COLLAPSE_TO_BOTTOM)
 
-        fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
-                                      self.GetSize(),FPB_DEFAULT_STYLE,
-                                      fpb.FPB_COLLAPSE_TO_BOTTOM)
+        self.fold_panel = fold_panel
 
         self.enable_items = []
         self.overwrite = False
 
+        gbs = wx.GridBagSizer(5,5)
+        gbs.AddGrowableCol(0, 1)
+        self.gbs = gbs
+
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(fold_panel, 1, wx.GROW|wx.EXPAND)
+        sizer.Add(gbs, 1, wx.GROW|wx.EXPAND)
         self.SetSizer(sizer)
 
         image_list = wx.ImageList(16,16)
@@ -139,26 +154,49 @@ class LowerTaskPanel(wx.Panel):
         col = style.GetFirstColour()
         self.enable_items.append(item)
 
-        fold_panel.AddFoldPanelWindow(item, nb.NotebookPanel(item), #Spacing= 0,
-                                      leftSpacing=0, rightSpacing=0)
-        fold_panel.Expand(fold_panel.GetFoldPanel(0))
+        #npanel = wx.Panel(self, -1)
+        self.npanel = nb.NotebookPanel(item)
 
-        # Fold 2 - Tools
-        # Measures
-        # Text Annotations
-        #item = fold_panel.AddFoldPanel(_("Tools"), collapsed=False,
-        #                               foldIcons=image_list)
-        #style = fold_panel.GetCaptionStyle(item)
-        #col = style.GetFirstColour()
-        #elf.enable_items.append(item)
-        #
-        #fold_panel.AddFoldPanelWindow(item, tools.TaskPanel(item), Spacing= 0,
-        #                              leftSpacing=0, rightSpacing=0)
-        #fold_panel.Expand(fold_panel.GetFoldPanel(1))
+        self.__calc_best_size(self.npanel)
+
+        fold_panel.AddFoldPanelWindow(item, self.npanel, #fpb.FPB_ALIGN_WIDTH, #Spacing= 0,
+                                      leftSpacing=0, rightSpacing=0)
+
+        gbs.AddGrowableRow(0, 1)
+        gbs.Add(fold_panel, (0, 0), flag=wx.EXPAND)
+        gbs.Layout()
+        item.ResizePanel()
+
+        sizer.Fit(self)
+        self.Fit()
 
         self.SetStateProjectClose()
         self.__bind_events()
 
+
+    def __calc_best_size(self, panel):
+        parent = panel.GetParent()
+        panel.Reparent(self)
+
+        gbs = self.gbs
+        fold_panel = self.fold_panel
+
+        # Calculating the size
+        gbs.AddGrowableRow(1, 1)
+        #gbs.AddGrowableRow(0, 1)
+        gbs.Add(fold_panel, (0, 0), flag=wx.EXPAND)
+        gbs.Add(panel, (1, 0), flag=wx.EXPAND)
+        gbs.Layout()
+        self.Fit()
+        size = panel.GetSize()
+
+        gbs.Remove(1)
+        gbs.Remove(0)
+        gbs.RemoveGrowableRow(1)
+
+        panel.Reparent(parent)
+        panel.SetInitialSize(size)
+        self.SetInitialSize(self.GetSize())
 
     def __bind_events(self):
         Publisher.subscribe(self.OnEnableState, "Enable state project")
@@ -178,19 +216,19 @@ class LowerTaskPanel(wx.Panel):
         for item in self.enable_items:
             item.Enable()
 
+    def ResizeFPB(self):
+        sizeNeeded = self.fold_panel.GetPanelsLength(0, 0)[2]
+        self.fold_panel.SetMinSize((self.fold_panel.GetSize()[0], sizeNeeded ))
+        self.fold_panel.SetSize((self.fold_panel.GetSize()[0], sizeNeeded))
+
 
 # Upper fold panel
 class UpperTaskPanel(wx.Panel):
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, pos=wx.Point(5, 5),
-                          size=wx.Size(280, 656))
-
+        wx.Panel.__init__(self, parent)
         fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
-                                      self.GetSize(),FPB_DEFAULT_STYLE,
+                                      wx.DefaultSize,FPB_DEFAULT_STYLE,
                                       fpb.FPB_SINGLE_FOLD)
-
-        #self.SetBackgroundColour((0,255,0))
-
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(fold_panel, 1, wx.GROW|wx.EXPAND)
@@ -210,7 +248,8 @@ class UpperTaskPanel(wx.Panel):
             tasks = [(_("Load data"), importer.TaskPanel),
                      (_("Select region of interest"), slice_.TaskPanel),
                      (_("Configure 3D surface"), surface.TaskPanel),
-                     (_("Export data"), exporter.TaskPanel)]
+                     (_("Export data"), exporter.TaskPanel)
+                    ]
         elif int(session.mode) == const.MODE_NAVIGATOR:
             tasks = [(_("Load data"), importer.TaskPanel),
                      (_("Select region of interest"), slice_.TaskPanel),
@@ -300,3 +339,9 @@ class UpperTaskPanel(wx.Panel):
 
 
         evt.Skip()
+        wx.CallAfter(self.ResizeFPB)
+
+    def ResizeFPB(self):
+        sizeNeeded = self.fold_panel.GetPanelsLength(0, 0)[2]
+        self.fold_panel.SetMinSize((self.fold_panel.GetSize()[0], sizeNeeded ))
+        self.fold_panel.SetSize((self.fold_panel.GetSize()[0], sizeNeeded))

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -330,7 +330,7 @@ class VolumeViewerCover(wx.Panel):
 
 class VolumeToolPanel(wx.Panel):
     def __init__(self, parent):
-        wx.Panel.__init__(self, parent, size = (10,100))
+        wx.Panel.__init__(self, parent)
 
         # VOLUME RAYCASTING BUTTON
         BMP_RAYCASTING = wx.Bitmap("../icons/volume_raycasting.png",
@@ -346,15 +346,15 @@ class VolumeToolPanel(wx.Panel):
 
         button_raycasting = pbtn.PlateButton(self, BUTTON_RAYCASTING,"",
                 BMP_RAYCASTING, style=pbtn.PB_STYLE_SQUARE,
-                size=(24,24))
+                size=(32,32))
 
         button_stereo = pbtn.PlateButton(self, BUTTON_3D_STEREO,"",
                 BMP_3D_STEREO, style=pbtn.PB_STYLE_SQUARE,
-                    size=(24,24))
+                    size=(32,32))
 
         button_slice_plane = self.button_slice_plane = pbtn.PlateButton(self, BUTTON_SLICE_PLANE,"",
         BMP_SLICE_PLANE, style=pbtn.PB_STYLE_SQUARE,
-        size=(24,24))
+        size=(32,32))
 
         self.button_raycasting = button_raycasting
         self.button_stereo = button_stereo
@@ -363,13 +363,13 @@ class VolumeToolPanel(wx.Panel):
         BMP_FRONT = wx.Bitmap(ID_TO_BMP[const.VOL_FRONT][1],
                               wx.BITMAP_TYPE_PNG)
         button_view = pbtn.PlateButton(self, BUTTON_VIEW, "",
-                                        BMP_FRONT, size=(24,24),
+                                        BMP_FRONT, size=(32,32),
                                         style=pbtn.PB_STYLE_SQUARE)
         self.button_view = button_view
 
         # VOLUME COLOUR BUTTON
         if sys.platform == 'linux2':
-            size = (28,28)
+            size = (32,32)
             sp = 2
         else:
             size = (24,24)

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -215,7 +215,7 @@ def ShowOpenProjectDialog():
     dlg = wx.FileDialog(None, message=_("Open InVesalius 3 project..."),
                         defaultDir="",
                         defaultFile="", wildcard=WILDCARD_OPEN,
-                        style=wx.OPEN|wx.CHANGE_DIR)
+                        style=wx.FD_OPEN|wx.FD_CHANGE_DIR)
 
     # inv3 filter is default
     dlg.SetFilterIndex(0)
@@ -243,7 +243,7 @@ def ShowOpenAnalyzeDialog():
     dlg = wx.FileDialog(None, message=_("Open Analyze file"),
                         defaultDir="",
                         defaultFile="", wildcard=WILDCARD_ANALYZE,
-                        style=wx.OPEN|wx.CHANGE_DIR)
+                        style=wx.FD_OPEN|wx.FD_CHANGE_DIR)
 
     # inv3 filter is default
     dlg.SetFilterIndex(0)
@@ -313,7 +313,7 @@ def ShowSaveAsProjectDialog(default_filename=None):
                         "", # last used directory
                         default_filename,
                         _("InVesalius project (*.inv3)|*.inv3"),
-                        wx.SAVE|wx.OVERWRITE_PROMPT)
+                        wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
     #dlg.SetFilterIndex(0) # default is VTI
 
     filename = None
@@ -780,7 +780,8 @@ def ShowAboutDialog(parent):
                        "Tatiana Al-Chueyr (former)",
                        "Guilherme Cesar Soares Ruppert (former)",
                        "Fabio de Souza Azevedo (former)",
-                       "Bruno Lara Bottazzini (contributor)"]
+                       "Bruno Lara Bottazzini (contributor)",
+                       "Olly Betts (patches to support wxPython3)"]
 
     info.Translators = ["Alex P. Natsios",
                         "Andreas Loupasakis",
@@ -973,7 +974,7 @@ def ExportPicture(type_=""):
                         "", # last used directory
                         project_name, # filename
                         WILDCARD_SAVE_PICTURE,
-                        wx.SAVE|wx.OVERWRITE_PROMPT)
+                        wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
     dlg.SetFilterIndex(1) # default is VTI
 
     if dlg.ShowModal() == wx.ID_OK:

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -85,6 +85,7 @@ class Frame(wx.Frame):
         if sys.platform != 'darwin':
             self.Maximize()
         
+        self.sizeChanged = True
         #Necessary update AUI (statusBar in special)
         #when maximized in the Win 7 and XP
         self.SetSize(self.GetSize())
@@ -132,6 +133,7 @@ class Frame(wx.Frame):
         Bind normal events from wx (except pubsub related).
         """
         self.Bind(wx.EVT_SIZE, self.OnSize)
+        self.Bind(wx.EVT_IDLE, self.OnIdle)
         self.Bind(wx.EVT_MENU, self.OnMenuClick)
         self.Bind(wx.EVT_CLOSE, self.OnClose)
         #self.Bind(wx.EVT_MOVE, self.OnMove)
@@ -404,8 +406,17 @@ class Frame(wx.Frame):
         """
         Refresh GUI when frame is resized.
         """
-        Publisher.sendMessage(('ProgressBar Reposition'))
         evt.Skip()
+        self.Reposition()
+        self.sizeChanged = True
+
+    def OnIdle(self, evt):
+        if self.sizeChanged:
+            self.Reposition()
+
+    def Reposition(self):
+        Publisher.sendMessage(('ProgressBar Reposition'))
+        self.sizeChanged = False
 
 
     def OnMove(self, evt):
@@ -596,13 +607,13 @@ class MenuBar(wx.MenuBar):
 
             file_edit_item_undo = wx.MenuItem(file_edit, wx.ID_UNDO,  _("Undo\tCtrl+Z"))
             file_edit_item_undo.SetBitmap(self.BMP_UNDO)
-            file_edit_item_undo.Enable(False)
             file_edit.AppendItem(file_edit_item_undo)
+            file_edit_item_undo.Enable(False)
 
             file_edit_item_redo = wx.MenuItem(file_edit, wx.ID_REDO,  _("Redo\tCtrl+Y"))
             file_edit_item_redo.SetBitmap(self.BMP_REDO)
-            file_edit_item_redo.Enable(False)
             file_edit.AppendItem(file_edit_item_redo)
+            file_edit_item_redo.Enable(False)
         else:
             file_edit.Append(wx.ID_UNDO, _("Undo\tCtrl+Z")).Enable(False)
             file_edit.Append(wx.ID_REDO, _("Redo\tCtrl+Y")).Enable(False)
@@ -732,9 +743,10 @@ class ProgressBar(wx.Gauge):
         """
         Compute new size and position, according to parent resize
         """
-        rect = self.parent.GetFieldRect(2)
+        rect = self.Parent.GetFieldRect(2)
         self.SetPosition((rect.x + 2, rect.y + 2))
         self.SetSize((rect.width - 4, rect.height - 4))
+        self.Show()
 
     def SetPercentage(self, value):
         """

--- a/invesalius/gui/import_panel.py
+++ b/invesalius/gui/import_panel.py
@@ -110,16 +110,16 @@ class InnerPanel(wx.Panel):
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(splitter, 20, wx.EXPAND)
-        sizer.Add(panel, 1, wx.EXPAND|wx.LEFT, 90)
-
-        self.SetSizer(sizer)
-        sizer.Fit(self)
+        sizer.Add(panel, 0, wx.EXPAND|wx.LEFT, 90)
 
         self.text_panel = TextPanel(splitter)
         splitter.AppendWindow(self.text_panel, 250)
 
         self.image_panel = ImagePanel(splitter)
         splitter.AppendWindow(self.image_panel, 250)
+        
+        self.SetSizer(sizer)
+        sizer.Fit(self)
 
         self.Layout()
         self.Update()

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -44,7 +44,7 @@ WILDCARD_SAVE_3D = "Inventor (*.iv)|*.iv|"\
                    "VTK PolyData (*.vtp)|*.vtp|"\
                    "Wavefront (*.obj)|*.obj|"\
                    "X3D (*.x3d)|*.x3d"
-                     
+
 INDEX_TO_TYPE_3D = {0: const.FILETYPE_IV,
                     1: const.FILETYPE_PLY,
                     2: const.FILETYPE_RIB,
@@ -86,7 +86,7 @@ class TaskPanel(wx.Panel):
 
         inner_panel = InnerTaskPanel(self)
 
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
+        sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(inner_panel, 1, wx.EXPAND | wx.GROW | wx.BOTTOM | wx.RIGHT |
                   wx.LEFT, 7)
         sizer.Fit(self)
@@ -99,7 +99,8 @@ class InnerTaskPanel(wx.Panel):
 
     def __init__(self, parent):
         wx.Panel.__init__(self, parent)
-        self.SetBackgroundColour(wx.Colour(255,255,255))
+        backgroud_colour = wx.Colour(255,255,255)
+        self.SetBackgroundColour(backgroud_colour)
         self.SetAutoLayout(1)
 
         # Counter for projects loaded in current GUI
@@ -109,7 +110,9 @@ class InnerTaskPanel(wx.Panel):
         link_export_picture = hl.HyperLinkCtrl(self, -1,
                                             _("Export picture..."))
         link_export_picture.SetUnderlines(False, False, False)
+        link_export_picture.SetBold(True)
         link_export_picture.SetColours("BLACK", "BLACK", "BLACK")
+        link_export_picture.SetBackgroundColour(self.GetBackgroundColour())
         link_export_picture.SetToolTip(tooltip)
         link_export_picture.AutoBrowse(False)
         link_export_picture.UpdateLink()
@@ -119,7 +122,9 @@ class InnerTaskPanel(wx.Panel):
         tooltip = wx.ToolTip(_("Export 3D surface"))
         link_export_surface = hl.HyperLinkCtrl(self, -1,_("Export 3D surface..."))
         link_export_surface.SetUnderlines(False, False, False)
+        link_export_surface.SetBold(True)
         link_export_surface.SetColours("BLACK", "BLACK", "BLACK")
+        link_export_surface.SetBackgroundColour(self.GetBackgroundColour())
         link_export_surface.SetToolTip(tooltip)
         link_export_surface.AutoBrowse(False)
         link_export_surface.UpdateLink()
@@ -160,26 +165,28 @@ class InnerTaskPanel(wx.Panel):
         if sys.platform == 'darwin':
             BMP_EXPORT_SURFACE = wx.Bitmap(\
                                   "../icons/surface_export_original.png",
-                                  wx.BITMAP_TYPE_PNG)
+                                  wx.BITMAP_TYPE_PNG).ConvertToImage()\
+                                          .Rescale(25, 25).ConvertToBitmap()
             BMP_TAKE_PICTURE = wx.Bitmap(\
                                  "../icons/tool_photo_original.png",
-                                 wx.BITMAP_TYPE_PNG)
+                                 wx.BITMAP_TYPE_PNG).ConvertToImage()\
+                                          .Rescale(25, 25).ConvertToBitmap()
+
             #BMP_EXPORT_MASK = wx.Bitmap("../icons/mask.png",
             #                            wx.BITMAP_TYPE_PNG)
         else:
             BMP_EXPORT_SURFACE = wx.Bitmap("../icons/surface_export.png",
-                                        wx.BITMAP_TYPE_PNG)
+                                        wx.BITMAP_TYPE_PNG).ConvertToImage()\
+                                          .Rescale(25, 25).ConvertToBitmap()
+
             BMP_TAKE_PICTURE = wx.Bitmap("../icons/tool_photo.png",
-                                     wx.BITMAP_TYPE_PNG)
+                                     wx.BITMAP_TYPE_PNG).ConvertToImage()\
+                                          .Rescale(25, 25).ConvertToBitmap()
+
             #BMP_EXPORT_MASK = wx.Bitmap("../icons/mask_small.png",
             #                            wx.BITMAP_TYPE_PNG)
 
 
-        bmp_list = [BMP_TAKE_PICTURE, BMP_EXPORT_SURFACE]#,
-        #            BMP_EXPORT_MASK]
-        for bmp in bmp_list:
-            bmp.SetWidth(25)
-            bmp.SetHeight(25)
 
         # Buttons related to hyperlinks
         button_style = pbtn.PB_STYLE_SQUARE | pbtn.PB_STYLE_DEFAULT
@@ -187,11 +194,13 @@ class InnerTaskPanel(wx.Panel):
         button_picture = pbtn.PlateButton(self, BTN_PICTURE, "",
                                                BMP_TAKE_PICTURE,
                                                style=button_style)
+        button_picture.SetBackgroundColour(self.GetBackgroundColour())
         self.button_picture = button_picture
 
         button_surface = pbtn.PlateButton(self, BTN_SURFACE, "",
                                                 BMP_EXPORT_SURFACE,
                                               style=button_style)
+        button_surface.SetBackgroundColour(self.GetBackgroundColour())
         #button_mask = pbtn.PlateButton(self, BTN_MASK, "",
         #                                BMP_EXPORT_MASK,
         #                                style=button_style)
@@ -232,7 +241,7 @@ class InnerTaskPanel(wx.Panel):
         self.__init_menu()
 
     def __init_menu(self):
-        
+
 
         menu = wx.Menu()
         self.id_to_name = {const.AXIAL:_("Axial slice"),
@@ -244,23 +253,23 @@ class InnerTaskPanel(wx.Panel):
             item = wx.MenuItem(menu, id, self.id_to_name[id])
             menu.AppendItem(item)
 
-        self.menu_picture = menu 
+        self.menu_picture = menu
         menu.Bind(wx.EVT_MENU, self.OnMenuPicture)
 
     def OnMenuPicture(self, evt):
-        print "OnMenuPicture" 
+        print "OnMenuPicture"
         id = evt.GetId()
         value = dlg.ExportPicture(self.id_to_name[id])
         if value:
-            filename, filetype = value 
+            filename, filetype = value
             Publisher.sendMessage('Export picture to file',
                                        (id, filename, filetype))
- 
+
 
 
     def OnLinkExportPicture(self, evt=None):
         self.button_picture.PopupMenu(self.menu_picture)
-        
+
 
     def OnLinkExportMask(self, evt=None):
         project = proj.Project()
@@ -276,9 +285,9 @@ class InnerTaskPanel(wx.Panel):
                             "", # last used directory
                             project_name, # filename
                             WILDCARD_SAVE_MASK,
-                            wx.SAVE|wx.OVERWRITE_PROMPT)
+                            wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
         dlg.SetFilterIndex(0) # default is VTI
-                                
+
         if dlg.ShowModal() == wx.ID_OK:
             filename = dlg.GetPath()
             print "filename", filename
@@ -312,9 +321,9 @@ class InnerTaskPanel(wx.Panel):
                                 "", # last used directory
                                 project_name, # filename
                                 WILDCARD_SAVE_3D,
-                                wx.SAVE|wx.OVERWRITE_PROMPT)
+                                wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
             dlg.SetFilterIndex(3) # default is STL
-                                
+
             if dlg.ShowModal() == wx.ID_OK:
                 filetype_index = dlg.GetFilterIndex()
                 filetype = INDEX_TO_TYPE_3D[filetype_index]

--- a/invesalius/gui/task_importer.py
+++ b/invesalius/gui/task_importer.py
@@ -51,7 +51,10 @@ class TaskPanel(wx.Panel):
 class InnerTaskPanel(wx.Panel):
     def __init__(self, parent):
         wx.Panel.__init__(self, parent)
-        self.SetBackgroundColour(wx.Colour(255,255,255))
+
+        backgroud_colour = wx.Colour(255,255,255)
+
+        self.SetBackgroundColour(backgroud_colour)
         self.SetAutoLayout(1)
 
         # Counter for projects loaded in current GUI
@@ -64,7 +67,9 @@ class InnerTaskPanel(wx.Panel):
         tooltip = wx.ToolTip(_("Select DICOM or Analyze files to be reconstructed"))
         link_import_local = hl.HyperLinkCtrl(self, -1, _("Import medical images..."))
         link_import_local.SetUnderlines(False, False, False)
+        link_import_local.SetBold(True)
         link_import_local.SetColours("BLACK", "BLACK", "BLACK")
+        link_import_local.SetBackgroundColour(backgroud_colour)
         link_import_local.SetToolTip(tooltip)
         link_import_local.AutoBrowse(False)
         link_import_local.UpdateLink()
@@ -82,7 +87,9 @@ class InnerTaskPanel(wx.Panel):
         tooltip = wx.ToolTip(_("Open an existing InVesalius project..."))
         link_open_proj = hl.HyperLinkCtrl(self,-1,_("Open an existing project..."))
         link_open_proj.SetUnderlines(False, False, False)
+        link_open_proj.SetBold(True)
         link_open_proj.SetColours("BLACK", "BLACK", "BLACK")
+        link_open_proj.SetBackgroundColour(backgroud_colour)
         link_open_proj.SetToolTip(tooltip)
         link_open_proj.AutoBrowse(False)
         link_open_proj.UpdateLink()
@@ -94,9 +101,9 @@ class InnerTaskPanel(wx.Panel):
         BMP_OPEN_PROJECT = wx.Bitmap("../icons/file_open.png", wx.BITMAP_TYPE_PNG)
 
         bmp_list = [BMP_IMPORT, BMP_NET, BMP_OPEN_PROJECT]
-        for bmp in bmp_list:
-            bmp.SetWidth(25)
-            bmp.SetHeight(25)
+        #for bmp in bmp_list:
+            #bmp.SetWidth(25)
+            #bmp.SetHeight(25)
 
         # Buttons related to hyperlinks
         button_style = pbtn.PB_STYLE_SQUARE | pbtn.PB_STYLE_DEFAULT
@@ -105,8 +112,10 @@ class InnerTaskPanel(wx.Panel):
         #                                      style=button_style)
         button_import_local = pbtn.PlateButton(self, BTN_IMPORT_LOCAL, "",
                                                BMP_IMPORT, style=button_style)
+        button_import_local.SetBackgroundColour(self.GetBackgroundColour())
         button_open_proj = pbtn.PlateButton(self, BTN_OPEN_PROJECT, "",
                                             BMP_OPEN_PROJECT, style=button_style)
+        button_open_proj.SetBackgroundColour(self.GetBackgroundColour())
 
         # When using PlaneButton, it is necessary to bind events from parent win
         self.Bind(wx.EVT_BUTTON, self.OnButton)
@@ -185,6 +194,7 @@ class InnerTaskPanel(wx.Panel):
             proj_link = hl.HyperLinkCtrl(self, -1, label)
             proj_link.SetUnderlines(False, False, False)
             proj_link.SetColours("BLACK", "BLACK", "BLACK")
+            proj_link.SetBackgroundColour(self.GetBackgroundColour())
             proj_link.AutoBrowse(False)
             proj_link.UpdateLink()
             proj_link.Bind(hl.EVT_HYPERLINK_LEFT,
@@ -201,7 +211,7 @@ class InnerTaskPanel(wx.Panel):
     def OnLinkImport(self, event):
         self.ImportDicom()
         event.Skip()
-    
+
     def OnLinkImportPACS(self, event):
         self.ImportPACS()
         event.Skip()
@@ -210,7 +220,7 @@ class InnerTaskPanel(wx.Panel):
         self.OpenProject()
         event.Skip()
 
- 
+
     def ImportPACS(self):
         print "TODO: Send Signal - Import DICOM files from PACS"
 

--- a/invesalius/invesalius.py
+++ b/invesalius/invesalius.py
@@ -30,8 +30,9 @@ if sys.platform == 'win32':
 else:
     if sys.platform != 'darwin':
         import wxversion
-        wxversion.ensureMinimal('2.8-unicode', optionsRequired=True)
-        wxversion.select('2.8-unicode', optionsRequired=True)
+        #wxversion.ensureMinimal('2.8-unicode', optionsRequired=True)
+        #wxversion.select('2.8-unicode', optionsRequired=True)
+        wxversion.ensureMinimal('3.0')
         
 import wx
 #from wx.lib.pubsub import setupv1 #new wx


### PR DESCRIPTION
Fixed problems with sizers, colors ans panel sizes.

Created functions to calculate panel sizes inside foldpanelbar

Showing the left-down panel where masks and surfaces info are showed

applyied the patches from Olly Betts to run in wxpython3

The gradient widget is working

The comboboxes from mask properties are working now.

The problem was that combobox must not empty.

Surface task is working again

Putting combobox thresholds presets in a new line

putting the import pil inside a try except

expanding the label 'set predefined or manual threshold'

showing the buttons when importing a dicom

better layout to task_slice

the size of the data_notebook

the size of the buttons inside of data_notebook

the size of the volume viewer icons

solved the problem with position of statusbar using idle event

Solved the problem with left icons

Added Olly Betts as contributor

Added Olly Betts as contributor

Calculating best size to data notebook

Removed the background colors

Better sizing, but not completed.

Tests

data notebook with better size

Better sizings

Removed some unused codes

Fixed the problems with backgroundcolour from statictext in the taskbar

better spacings

Align button "Create surface" to the right