### PR TITLE
Drag and drop support to measures in slices

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -10,6 +10,7 @@ import vtk
 import constants as const
 import project as prj
 import session as ses
+import utils
 
 TYPE = {const.LINEAR: _(u"Linear"),
         const.ANGULAR: _(u"Angular"),
@@ -26,6 +27,7 @@ class MeasureData:
     """
     Responsible to keep measures data.
     """
+    __metaclass__= utils.Singleton
     def __init__(self):
         self.measures = {const.SURFACE: {},
                          const.AXIAL:   {},
@@ -34,7 +36,6 @@ class MeasureData:
         self._list_measures = []
 
     def append(self, m):
-        print m[0].location, m[0].slice_number
         try:
             self.measures[m[0].location][m[0].slice_number].append(m)
         except KeyError:

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -657,20 +657,59 @@ class AngularMeasure(object):
             return (self.point_actor3, self.line_actor, self.text_actor)
 
     def SetPoint1(self, x, y, z):
-        self.points[0] = (x, y, z)
-        self.number_of_points = 1
-        self.point_actor1 = self.representation.GetRepresentation(x, y, z)
+        if self.number_of_points == 0:
+            self.points[0] = (x, y, z)
+            self.number_of_points = 1
+            self.point_actor1 = self.representation.GetRepresentation(x, y, z)
+        else:
+            self.points[0] = (x, y, z)
+            if len(self.points) == 3:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
+                self.point_actor3 = self.representation.GetRepresentation(*self.points[2])
+                self.CreateMeasure()
+            else:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
 
     def SetPoint2(self, x, y, z):
-        self.number_of_points = 2
-        self.points[1] = (x, y, z)
-        self.point_actor2 = self.representation.GetRepresentation(x, y, z)
+        if self.number_of_points == 1:
+            self.number_of_points = 2
+            self.points[1] = (x, y, z)
+            self.point_actor2 = self.representation.GetRepresentation(x, y, z)
+        else:
+            self.points[1] = (x, y, z)
+            if len(self.points) == 3:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
+                self.point_actor3 = self.representation.GetRepresentation(*self.points[2])
+                self.CreateMeasure()
+            else:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
 
     def SetPoint3(self, x, y, z):
-        self.number_of_points = 3
-        self.points[2] = (x, y, z)
-        self.point_actor3 = self.representation.GetRepresentation(x, y, z)
-        self.CreateMeasure()
+        if self.number_of_points == 2:
+            self.number_of_points = 3
+            self.points[2] = (x, y, z)
+            self.point_actor3 = self.representation.GetRepresentation(x, y, z)
+            self.CreateMeasure()
+        else:
+            self.points[2] = (x, y, z)
+            if len(self.points) == 3:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
+                self.point_actor3 = self.representation.GetRepresentation(*self.points[2])
+                self.CreateMeasure()
+            else:
+                self.Remove()
+                self.point_actor1 = self.representation.GetRepresentation(*self.points[0])
+                self.point_actor2 = self.representation.GetRepresentation(*self.points[1])
 
     def CreateMeasure(self):
         self._draw_line()

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -22,6 +22,35 @@ LOCATION = {const.SURFACE: _(u"3D"),
         }
 
 
+class MeasureData:
+    """
+    Responsible to keep measures data.
+    """
+    def __init__(self):
+        self.measures = {const.SURFACE: {},
+                         const.AXIAL:   {},
+                         const.CORONAL: {},
+                         const.SAGITAL: {}}
+        self._list_measures = []
+
+    def append(self, m):
+        print m[0].location, m[0].slice_number
+        try:
+            self.measures[m[0].location][m[0].slice_number].append(m)
+        except KeyError:
+            self.measures[m[0].location][m[0].slice_number] = [m, ]
+
+        self._list_measures.append(m)
+
+    def pop(self, idx):
+        m = self._list_measures.pop(idx)
+        self.measures[m[0].location][m[0].slice_number].remove(m)
+        return m
+
+    def __len__(self):
+        return len(self._list_measures)
+
+
 class MeasurementManager(object):
     """
     A class to manage the use (Addition, remotion and visibility) from
@@ -29,7 +58,7 @@ class MeasurementManager(object):
     """
     def __init__(self):
         self.current = None
-        self.measures = []
+        self.measures = MeasureData()
         self._bind_events()
 
     def _bind_events(self):

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -490,6 +490,7 @@ class LinearMeasure(object):
         a.GetPositionCoordinate().SetCoordinateSystemToWorld()
         a.GetPositionCoordinate().SetValue(x,y,z)
         a.GetProperty().SetColor((0, 1, 0))
+        a.GetProperty().SetOpacity(0.75)
         self.text_actor = a
 
     def GetNumberOfPoints(self):

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -394,36 +394,19 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
 
     def OnReleaseMeasurePoint(self, obj, evt):
         if self.selected:
-            print "Changing Position"
             n, m, mr = self.selected
             x, y, z = self._get_pos_clicked()
-            ren = self.slice_data.renderer
-            mr.renderer = ren
-            if n == 0:
-                mr.SetPoint1(x, y, z)
-                m.points[0] = x, y, z
-            elif n == 1:
-                mr.SetPoint2(x, y, z)
-                m.points[1] = x, y, z
-
-            m.value = mr.GetValue()
-
+            idx = self.measures._list_measures.index((m, mr))
+            Publisher.sendMessage('Change measurement point position', (idx, n, (x, y, z)))
             Publisher.sendMessage('Reload actual slice %s' % self.orientation)
             self.selected = None
 
     def OnMoveMeasurePoint(self, obj, evt):
         if self.selected:
-            print "Changing Position"
             n, m, mr = self.selected
             x, y, z = self._get_pos_clicked()
-            ren = self.slice_data.renderer
-            mr.renderer = ren
-            if n == 0:
-                mr.SetPoint1(x, y, z)
-                m.points[0] = x, y, z
-            elif n == 1:
-                mr.SetPoint2(x, y, z)
-                m.points[1] = x, y, z
+            idx = self.measures._list_measures.index((m, mr))
+            Publisher.sendMessage('Change measurement point position', (idx, n, (x, y, z)))
 
             Publisher.sendMessage('Reload actual slice %s' % self.orientation)
 
@@ -452,11 +435,12 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
 
         if slice_number in self.measures.measures[self._ori]:
             for m, mr in self.measures.measures[self._ori][slice_number]:
-                for n, p in enumerate(m.points):
-                    px, py, pz = p
-                    dist = ((px-x)**2 + (py-y)**2 + (pz-z)**2)**0.5
-                    if dist < max_dist:
-                        return (n, m, mr)
+                if mr.IsComplete():
+                    for n, p in enumerate(m.points):
+                        px, py, pz = p
+                        dist = ((px-x)**2 + (py-y)**2 + (pz-z)**2)**0.5
+                        if dist < max_dist:
+                            return (n, m, mr)
         return None
 
 class AngularMeasureInteractorStyle(DefaultInteractorStyle):

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -389,7 +389,7 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
                 Publisher.sendMessage("Add measurement point",
                                       ((x, y,z), const.LINEAR,
                                        ORIENTATIONS[self.orientation],
-                                       slice_number, self.radius, renderer))
+                                       slice_number, self.radius))
                 Publisher.sendMessage('Reload actual slice %s' % self.orientation)
 
     def OnReleaseMeasurePoint(self, obj, evt):

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -385,10 +385,11 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
             self.selected = selected
         else:
             if self.picker.GetViewProp():
+                renderer = self.viewer.slice_data.renderer
                 Publisher.sendMessage("Add measurement point",
                                       ((x, y,z), const.LINEAR,
                                        ORIENTATIONS[self.orientation],
-                                       slice_number, self.radius))
+                                       slice_number, self.radius, renderer))
                 Publisher.sendMessage('Reload actual slice %s' % self.orientation)
 
     def OnReleaseMeasurePoint(self, obj, evt):

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -389,7 +389,7 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
                                       ((x, y,z), const.LINEAR,
                                        ORIENTATIONS[self.orientation],
                                        slice_number, self.radius))
-                self.viewer.interactor.Render()
+                Publisher.sendMessage('Reload actual slice %s' % self.orientation)
 
     def OnReleaseMeasurePoint(self, obj, evt):
         if self.selected:
@@ -405,7 +405,8 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
                 mr.SetPoint2(x, y, z)
                 m.points[1] = x, y, z
 
-            self.viewer.interactor.Render()
+            m.value = mr.GetValue()
+
             Publisher.sendMessage('Reload actual slice %s' % self.orientation)
             self.selected = None
 
@@ -423,7 +424,6 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
                 mr.SetPoint2(x, y, z)
                 m.points[1] = x, y, z
 
-            self.viewer.interactor.Render()
             Publisher.sendMessage('Reload actual slice %s' % self.orientation)
 
     def CleanUp(self):
@@ -441,12 +441,20 @@ class LinearMeasureInteractorStyle(DefaultInteractorStyle):
 
     def _verify_clicked(self, x, y, z):
         slice_number = self.slice_data.number
+        sx, sy, sz = self.viewer.slice_.spacing
+        if self.orientation == "AXIAL":
+            max_dist = 2 * max(sx, sy)
+        elif self.orientation == "CORONAL":
+            max_dist = 2 * max(sx, sz)
+        elif self.orientation == "SAGITAL":
+            max_dist = 2 * max(sy, sz)
+
         if slice_number in self.measures.measures[self._ori]:
             for m, mr in self.measures.measures[self._ori][slice_number]:
                 for n, p in enumerate(m.points):
                     px, py, pz = p
                     dist = ((px-x)**2 + (py-y)**2 + (pz-z)**2)**0.5
-                    if dist < 2:
+                    if dist < max_dist:
                         return (n, m, mr)
         return None
 

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1189,6 +1189,7 @@ class Viewer(wx.Panel):
                 self.slice_data.renderer.RemoveActor(actor)
 
         for (m, mr) in self.measures.get(self.orientation, index):
+            mr.renderer = self.slice_data.renderer
             for actor in mr.GetActors():
                 self.slice_data.renderer.AddActor(actor)
 

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1184,11 +1184,11 @@ class Viewer(wx.Panel):
         for actor in self.actors_by_slice_number[index]:
             self.slice_data.renderer.AddActor(actor)
 
-        for (m, mr) in self.measures[self.orientation].get(self.slice_data.number, []):
+        for (m, mr) in self.measures.get(self.orientation, self.slice_data.number):
             for actor in mr.GetActors():
                 self.slice_data.renderer.RemoveActor(actor)
 
-        for (m, mr) in self.measures[self.orientation].get(index, []):
+        for (m, mr) in self.measures.get(self.orientation, index):
             for actor in mr.GetActors():
                 self.slice_data.renderer.AddActor(actor)
 

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -19,6 +19,7 @@
 #    detalhes.
 #--------------------------------------------------------------------------
 
+import collections
 import itertools
 import tempfile
 
@@ -172,7 +173,7 @@ class Viewer(wx.Panel):
         self.orientation_texts = []
 
         self.measures = measures.MeasureData()
-        self.actors_by_slice_number = {}
+        self.actors_by_slice_number = collections.defaultdict(list)
         self.renderers_by_slice_number = {}
 
         self.orientation = orientation
@@ -1178,9 +1179,9 @@ class Viewer(wx.Panel):
         image = self.slice_.GetSlices(self.orientation, index,
                                       self.number_slices, inverted, border_size)
         self.slice_data.actor.SetInputData(image)
-        for actor in self.actors_by_slice_number.get(self.slice_data.number, []):
+        for actor in self.actors_by_slice_number[self.slice_data.number]:
             self.slice_data.renderer.RemoveActor(actor)
-        for actor in self.actors_by_slice_number.get(index, []):
+        for actor in self.actors_by_slice_number[index]:
             self.slice_data.renderer.AddActor(actor)
 
         for (m, mr) in self.measures[self.orientation].get(self.slice_data.number, []):
@@ -1247,10 +1248,7 @@ class Viewer(wx.Panel):
             for actor in actors:
                 self.slice_data.renderer.AddActor(actor)
 
-        try:
-            self.actors_by_slice_number[n].extend(actors)
-        except KeyError:
-            self.actors_by_slice_number[n] = list(actors)
+        self.actors_by_slice_number[n].extend(actors)
 
     def RemoveActors(self, pubsub_evt):
         "Remove a list of actors"

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -171,7 +171,7 @@ class Viewer(wx.Panel):
         self.layout = (1, 1)
         self.orientation_texts = []
 
-        self.measures = []
+        self.measures = measures.MeasureData()
         self.actors_by_slice_number = {}
         self.renderers_by_slice_number = {}
 
@@ -1182,6 +1182,14 @@ class Viewer(wx.Panel):
             self.slice_data.renderer.RemoveActor(actor)
         for actor in self.actors_by_slice_number.get(index, []):
             self.slice_data.renderer.AddActor(actor)
+
+        for (m, mr) in self.measures[self.orientation].get(self.slice_data.number, []):
+            for actor in mr.GetActors():
+                self.slice_data.renderer.RemoveActor(actor)
+
+        for (m, mr) in self.measures[self.orientation].get(index, []):
+            for actor in mr.GetActors():
+                self.slice_data.renderer.AddActor(actor)
 
         if self.slice_._type_projection == const.PROJECTION_NORMAL:
             self.slice_data.SetNumber(index)

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1127,6 +1127,8 @@ class MeasuresListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin):
                 self.UpdateItemInfo(index, name, colour, location, type_, value)
             else:
                 self.InsertNewItem(index, name, colour, location, type_, value)
+        else:
+            self.UpdateItemInfo(index, name, colour, location, type_, value)
 
 
 

--- a/invesalius/utils.py
+++ b/invesalius/utils.py
@@ -23,6 +23,8 @@ import re
 import locale
 import math
 
+import numpy as np
+
 def format_time(value):
     sp1 = value.split(".")
     sp2 = value.split(":")
@@ -418,3 +420,11 @@ def UpdateCheck():
         if (last!=const.INVESALIUS_VERSION):
             print "  ...New update found!!! -> version:", last #, ", url=",url
             wx.CallAfter(wx.CallLater, 1000, _show_update_info)
+
+
+def vtkarray_to_numpy(m):
+    nm = np.zeros((4, 4))
+    for i in xrange(4):
+        for j in xrange(4):
+            nm[i, j] = m.GetElement(i, j)
+    return nm


### PR DESCRIPTION
Support to Drag and drop to measures. It only works inside the slice viewer. The support to 3D viewer is more complicated, because the code to interact with this viewer is not well separated like in the slice viewer. In Slice viewer we have the concept of Styles class. Each Style class is responsible to one type of interaction. For instance, LinearMeasureInteractorStyle is responsible to linear measure interaction.

The measures are stored inside the class MeasureData. This class is a Singleton. This was needed because LinearMeasureInteractorStyle needs to access each measurement directly to know if an existing measure was clicked. It was not possible before, because the list of measures was not directly accessible from this class.

The idea of Adding and removing the actors is not more used by the measures. Now Slice viewer has access to the MeasureData and knows what actors to add or remove.