### PR TITLE
Markers manipulation improvement

### DIFF
--- a/invesalius/data/trigger.py
+++ b/invesalius/data/trigger.py
@@ -32,6 +32,8 @@ class Trigger(threading.Thread):
     def __init__(self, nav_id):
         threading.Thread.__init__(self)
         self.trigger_init = None
+        self.stylusplh = False
+        self.__bind_events()
         try:
             import serial
 
@@ -46,6 +48,12 @@ class Trigger(threading.Thread):
         except serial.serialutil.SerialException:
             print 'Connection with port COM1 failed.'
 
+    def __bind_events(self):
+        Publisher.subscribe(self.OnStylusPLH, 'PLH Stylus Button On')
+
+    def OnStylusPLH(self, pubsuv_evt):
+        self.stylusplh = True
+
     def stop(self):
         self._pause_ = True
 
@@ -59,6 +67,13 @@ class Trigger(threading.Thread):
             # lines = True
             if lines:
                 wx.CallAfter(Publisher.sendMessage, 'Create marker')
+                sleep(0.5)
+
+            if self.stylusplh:
+                wx.CallAfter(Publisher.sendMessage, 'Create marker')
+                sleep(0.5)
+                self.stylusplh = False
+
             sleep(0.175)
             if self._pause_:
                 if self.trigger_init:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -483,9 +483,10 @@ class Viewer(wx.Panel):
 
     def RemoveMarker(self, pubsub_evt):
         index = pubsub_evt.data
-        self.ren.RemoveActor(self.staticballs[index])
-        del self.staticballs[index]
-        self.ball_id = self.ball_id - 1
+        for i in reversed(index):
+            self.ren.RemoveActor(self.staticballs[i])
+            del self.staticballs[i]
+            self.ball_id = self.ball_id - 1
         self.UpdateRender()
 
     def BlinkMarker(self, pubsub_evt):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -123,7 +123,8 @@ class Viewer(wx.Panel):
         self.sen1 = False
         self.sen2 = False
 
-        self.blink = False
+        self.timer = False
+        self.index = False
 
     def __bind_events(self):
         Publisher.subscribe(self.LoadActor,
@@ -205,7 +206,8 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.ShowAllMarkers, 'Show all markers')
         Publisher.subscribe(self.RemoveAllMarkers, 'Remove all markers')
         Publisher.subscribe(self.RemoveMarker, 'Remove marker')
-        Publisher.subscribe(self.BlinkMarker, 'Blink marker')
+        Publisher.subscribe(self.BlinkMarker, 'Blink Marker')
+        Publisher.subscribe(self.StopBlinkMarker, 'Stop Blink Marker')
 
     def SetStereoMode(self, pubsub_evt):
         mode = pubsub_evt.data
@@ -487,15 +489,27 @@ class Viewer(wx.Panel):
         self.UpdateRender()
 
     def BlinkMarker(self, pubsub_evt):
-        index = pubsub_evt.data
-        cb = vtkTimerCallback()
-        if self.blink:
-            self.interactor.DestroyTimer('TimerEvent', cb.execute)
-        else:
+        if self.timer:
+            self.timer.Stop()
+            self.staticballs[self.index].SetVisibility(1)
+        self.index = pubsub_evt.data
+        self.timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.blink, self.timer)
+        self.timer.Start(500)
+        self.timer_count = 0
 
-            cb.actor = self.staticballs[index]
-            self.interactor.AddObserver('TimerEvent', cb.execute)
-            self.blink = self.interactor.CreateRepeatingTimer(500)
+    def blink(self, evt):
+        self.staticballs[self.index].SetVisibility(int(self.timer_count % 2))
+        self.Refresh()
+        self.timer_count += 1
+
+    def StopBlinkMarker(self, pubsub_evt):
+        if self.timer:
+            self.timer.Stop()
+            if pubsub_evt.data == None:
+                self.staticballs[self.index].SetVisibility(1)
+                self.Refresh()
+            self.index = False
 
     def CreateBallReference(self):
         """
@@ -1041,17 +1055,6 @@ class Viewer(wx.Panel):
             elif not self._to_show_ball and self._ball_ref_visibility:
                 self.RemoveBallReference()
                 self.interactor.Render()
-
-
-class vtkTimerCallback():
-    def __init__(self):
-        self.timer_count = 0
-
-    def execute(self, obj, event):
-        self.actor.SetVisibility(int(self.timer_count % 2))
-        iren = obj
-        iren.GetRenderWindow().Render()
-        self.timer_count += 1
 
 class SlicePlane:
     def __init__(self):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -676,22 +676,23 @@ class MarkersPanel(wx.Panel):
                         for i in const.BTNS_IMG_MKS:
                             if marker_id in const.BTNS_IMG_MKS[i].values()[0]:
                                 self.lc.Focus(item.GetId())
-                self.DeleteMarker()
+                index = [self.lc.GetFocusedItem()]
         else:
             if self.lc.GetFocusedItem() is not -1:
-                self.DeleteMarker()
+                index = self.GetSelectedItems()
             elif not self.lc.GetItemCount():
                 pass
             else:
                 dlg.NoMarkerSelected()
+        self.DeleteMarker(index)
 
-    def DeleteMarker(self):
-        index = self.lc.GetFocusedItem()
-        del self.list_coord[index]
-        self.lc.DeleteItem(index)
-        for n in range(0, self.lc.GetItemCount()):
-            self.lc.SetStringItem(n, 0, str(n+1))
-        self.marker_ind -= 1
+    def DeleteMarker(self, index):
+        for i in reversed(index):
+            del self.list_coord[i]
+            self.lc.DeleteItem(i)
+            for n in range(0, self.lc.GetItemCount()):
+                self.lc.SetStringItem(n, 0, str(n+1))
+            self.marker_ind -= 1
         Publisher.sendMessage('Remove marker', index)
 
     def OnCreateMarker(self, evt):
@@ -786,3 +787,15 @@ class MarkersPanel(wx.Panel):
         self.lc.SetStringItem(num_items, 3, str(round(coord[2], 2)))
         self.lc.SetStringItem(num_items, 4, str(marker_id))
         self.lc.EnsureVisible(num_items)
+
+    def GetSelectedItems(self):
+        """    
+        Returns a list of the selected items in the list control.
+        """
+        selection = []
+        index = self.lc.GetFirstSelected()
+        selection.append(index)
+        while len(selection) != self.lc.GetSelectedItemCount():
+            index = self.lc.GetNextSelected(index)
+            selection.append(index)
+        return selection

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -325,7 +325,6 @@ class NeuronavigationPanel(wx.Panel):
         Publisher.subscribe(self.UpdateTriggerState, 'Update trigger state')
         Publisher.subscribe(self.UpdateImageCoordinates, 'Set ball reference position')
         Publisher.subscribe(self.OnDisconnectTracker, 'Disconnect tracker')
-        Publisher.subscribe(self.OnStylusButton, 'PLH Stylus Button On')
 
     def LoadImageFiducials(self, pubsub_evt):
         marker_id = pubsub_evt.data[0]
@@ -358,10 +357,6 @@ class NeuronavigationPanel(wx.Panel):
     def OnDisconnectTracker(self, pubsub_evt):
         if self.tracker_id:
             dt.TrackerConnection(self.tracker_id, 'disconnect')
-
-    def OnStylusButton(self, pubsub_evt):
-        if self.trigger_state:
-            Publisher.sendMessage('Create marker')
 
     def OnChoiceTracker(self, evt, ctrl):
         Publisher.sendMessage('Update status text in GUI', _("Configuring tracker ..."))

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -612,7 +612,8 @@ class MarkersPanel(wx.Panel):
         self.lc.SetColumnWidth(3, 50)
         self.lc.SetColumnWidth(4, 50)
         self.lc.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnListEditMarkerId)
-        self.lc.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.OnItemBlink)
+        self.lc.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemBlink)
+        self.lc.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnStopItemBlink)
 
         # Add all lines into main sizer
         group_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -641,7 +642,10 @@ class MarkersPanel(wx.Panel):
         menu_id.Destroy()
 
     def OnItemBlink(self, evt):
-        Publisher.sendMessage('Blink marker', self.lc.GetFocusedItem())
+        Publisher.sendMessage('Blink Marker', self.lc.GetFocusedItem())
+
+    def OnStopItemBlink(self, evt):
+        Publisher.sendMessage('Stop Blink Marker')
 
     def OnMenuEditMarkerId(self, evt):
         id_label = dlg.EnterMarkerID(self.lc.GetItemText(self.lc.GetFocusedItem(), 4))
@@ -657,6 +661,7 @@ class MarkersPanel(wx.Panel):
             self.marker_ind = 0
             Publisher.sendMessage('Remove all markers', self.lc.GetItemCount())
             self.lc.DeleteAllItems()
+            Publisher.sendMessage('Stop Blink Marker', 'DeleteAll')
 
     def OnDeleteSingleMarker(self, evt):
         # OnDeleteSingleMarker is used for both pubsub and button click events

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -612,6 +612,7 @@ class MarkersPanel(wx.Panel):
         self.lc.SetColumnWidth(3, 50)
         self.lc.SetColumnWidth(4, 50)
         self.lc.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnListEditMarkerId)
+        self.lc.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.OnItemBlink)
 
         # Add all lines into main sizer
         group_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -638,6 +639,9 @@ class MarkersPanel(wx.Panel):
         menu_id.Bind(wx.EVT_MENU, self.OnMenuEditMarkerId)
         self.PopupMenu(menu_id)
         menu_id.Destroy()
+
+    def OnItemBlink(self, evt):
+        Publisher.sendMessage('Blink marker', self.lc.GetFocusedItem())
 
     def OnMenuEditMarkerId(self, evt):
         id_label = dlg.EnterMarkerID(self.lc.GetItemText(self.lc.GetFocusedItem(), 4))

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -114,10 +114,13 @@ class InnerFoldPanel(wx.Panel):
         # is not working properly in this panel. It might be on some child or
         # parent panel. Perhaps we need to insert the item into the sizer also...
         # Study this.
-
-        fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
-                                      (10, 293), 0, fpb.FPB_SINGLE_FOLD)
-
+        displaySize = wx.DisplaySize()
+        if displaySize[1] > 768:
+            fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
+                                          (10, 350), 0, fpb.FPB_SINGLE_FOLD)
+        else:
+            fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
+                                          (10, 293), 0, fpb.FPB_SINGLE_FOLD)
         # Fold panel style
         style = fpb.CaptionBarStyle()
         style.SetCaptionStyle(fpb.CAPTIONBAR_GRADIENT_V)
@@ -243,7 +246,7 @@ class NeuronavigationPanel(wx.Panel):
         for k in btns_img:
             n = btns_img[k].keys()[0]
             lab = btns_img[k].values()[0]
-            self.btns_coord[n] = wx.ToggleButton(self, k, label=lab, size=wx.Size(30, 23))
+            self.btns_coord[n] = wx.ToggleButton(self, k, label=lab, size=wx.Size(45, 23))
             self.btns_coord[n].SetToolTip(tips_img[n])
             self.btns_coord[n].Bind(wx.EVT_TOGGLEBUTTON, self.OnImageFiducials)
 
@@ -254,7 +257,7 @@ class NeuronavigationPanel(wx.Panel):
         for k in btns_trk:
             n = btns_trk[k].keys()[0]
             lab = btns_trk[k].values()[0]
-            self.btns_coord[n] = wx.Button(self, k, label=lab, size=wx.Size(30, 23))
+            self.btns_coord[n] = wx.Button(self, k, label=lab, size=wx.Size(45, 23))
             self.btns_coord[n].SetToolTip(tips_trk[n-3])
             # Excepetion for event of button that set image coordinates
             if n == 6:
@@ -587,7 +590,7 @@ class MarkersPanel(wx.Panel):
         btn_delete_single = wx.Button(self, -1, label=_('Remove'), size=wx.Size(65, 23))
         btn_delete_single.Bind(wx.EVT_BUTTON, self.OnDeleteSingleMarker)
 
-        btn_delete_all = wx.Button(self, -1, label=_('Delete all markers'), size=wx.Size(135, 23))
+        btn_delete_all = wx.Button(self, -1, label=_('Delete all'), size=wx.Size(135, 23))
         btn_delete_all.Bind(wx.EVT_BUTTON, self.OnDeleteAllMarkers)
 
         sizer_delete = wx.FlexGridSizer(rows=1, cols=2, hgap=5, vgap=5)


### PR DESCRIPTION
When a markers is double-clicked in the list ctrl the marker in the volume starts to blink.
- To stops blink just press once at any place in the list ctrl 

It is possible now to select multiple markers in the list ctrl and remove all selected markers.

Trigger improvements
- Now Polhemus Stylus button creates markers inside the trigger thread. Avoiding navigation freezing. 