### PR TITLE
Transform surface physical into inv coord system

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -859,6 +859,13 @@ class Controller():
         self.matrix, scalar_range, self.filename = image_utils.img2memmap(group)
 
         hdr = group.header
+        if group.affine.any():
+            from numpy import hstack
+            from numpy.linalg import inv
+            affine = inv(group.affine)
+            affine[1, 3] = -affine[1, 3]
+            Publisher.sendMessage('Update affine matrix',
+                                  affine=hstack(affine))
         hdr.set_data_dtype('int16')
         dims = hdr.get_zooms()
         dimsf = tuple([float(s) for s in dims])

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -657,6 +657,7 @@ class Controller():
         proj.level = self.Slice.window_level
         proj.threshold_range = int(matrix.min()), int(matrix.max())
         proj.spacing = self.Slice.spacing
+        proj.affine = self.affine.tolist()
 
         ######
         session = ses.Session()
@@ -865,8 +866,9 @@ class Controller():
             from numpy.linalg import inv
             affine = inv(group.affine)
             affine[1, 3] = -affine[1, 3]
+            self.affine = hstack(affine)
             Publisher.sendMessage('Update affine matrix',
-                                  affine=hstack(affine))
+                                  affine=self.affine)
         hdr.set_data_dtype('int16')
         dims = hdr.get_zooms()
         dimsf = tuple([float(s) for s in dims])

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -868,7 +868,7 @@ class Controller():
             affine[1, 3] = -affine[1, 3]
             self.affine = hstack(affine)
             Publisher.sendMessage('Update affine matrix',
-                                  affine=self.affine)
+                                  affine=self.affine, status=True)
         hdr.set_data_dtype('int16')
         dims = hdr.get_zooms()
         dimsf = tuple([float(s) for s in dims])

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -336,7 +336,7 @@ class SurfaceManager():
             name = os.path.splitext(os.path.split(filename)[-1])[0]
             self.CreateSurfaceFromPolydata(polydata, name=name, scalar=scalar)
 
-    def UpdateAffineMatrix(self, affine):
+    def UpdateAffineMatrix(self, affine, status):
         self.affine = affine
 
     def UpdateconverttoInVflag(self, converttoInV):
@@ -442,6 +442,9 @@ class SurfaceManager():
 
         # restarting the surface index
         Surface.general_index = -1
+
+        Publisher.sendMessage('Update affine matrix',
+                              affine=None, status=False)
 
     def OnSelectSurface(self, surface_index):
         #self.last_surface_index = surface_index

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -350,6 +350,7 @@ class SurfaceManager():
         transformFilter.SetTransform(transform)
         transformFilter.SetInputData(polydata)
         transformFilter.Update()
+        polydata = transformFilter.GetOutput()
 
         normals = vtk.vtkPolyDataNormals()
         normals.SetInputData(transformFilter.GetOutput())

--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -146,7 +146,7 @@ def PlhWrapperConnection(tracker_id):
 def PlhSerialConnection(tracker_id):
     import serial
 
-    trck_init = serial.Serial('COM1', baudrate=115200, timeout=0.03)
+    trck_init = serial.Serial('COM3', baudrate=115200, timeout=0.03)
 
     if tracker_id == 2:
         # Polhemus FASTRAK needs configurations first

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -604,8 +604,13 @@ class SurfaceButtonControlPanel(wx.Panel):
         wx.Panel.__init__(self, parent, pos=wx.Point(0, 50),
                             size=wx.Size(256, 22))
         self.parent = parent
+        self.affinestatus = False
+        self.__init_evt()
         self.__init_gui()
 
+    def __init_evt(self):
+        Publisher.subscribe(self.AffineStatus,
+                                'Update affine matrix')
     def __init_gui(self):
 
         # Bitmaps to be used in plate buttons
@@ -701,10 +706,13 @@ class SurfaceButtonControlPanel(wx.Panel):
     def OnOpenMesh(self):
         filename = dlg.ShowImportMeshFilesDialog()
         if filename:
-            converttoInV = dlg.ImportMeshCoordSystem()
-            Publisher.sendMessage('Update converttoInV flag', converttoInV=converttoInV)
+            if self.affinestatus:
+                converttoInV = dlg.ImportMeshCoordSystem()
+                Publisher.sendMessage('Update converttoInV flag', converttoInV=converttoInV)
             Publisher.sendMessage('Import surface file', filename=filename)
 
+    def AffineStatus(self, affine, status):
+        self.affinestatus = status
 
 class SurfacesListCtrlPanel(wx.ListCtrl, listmix.TextEditMixin, listmix.CheckListCtrlMixin):
 

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -692,6 +692,8 @@ class SurfaceButtonControlPanel(wx.Panel):
     def OnOpenMesh(self):
         filename = dlg.ShowImportMeshFilesDialog()
         if filename:
+            converttoInV = dlg.ImportMeshCoordSystem()
+            Publisher.sendMessage('Update converttoInV flag', converttoInV=converttoInV)
             Publisher.sendMessage('Import surface file', filename=filename)
 
 

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -998,7 +998,7 @@ def EnterMarkerID(default):
     if sys.platform == 'darwin':
         dlg = wx.TextEntryDialog(None, "", msg, defaultValue=default)
     else:
-        dlg = wx.TextEntryDialog(None, msg, "InVesalius 3", defaultValue=default)
+        dlg = wx.TextEntryDialog(None, msg, "InVesalius 3", value=default)
     dlg.ShowModal()
     result = dlg.GetValue()
     dlg.Destroy()

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -441,6 +441,22 @@ def ShowImportMeshFilesDialog():
     os.chdir(current_dir)
     return filename
 
+def ImportMeshCoordSystem():
+    msg = _("Is the imported mesh on InVesalius coordinate system?")
+    if sys.platform == 'darwin':
+        dlg = wx.MessageDialog(None, "", msg,
+                               wx.YES_NO)
+    else:
+        dlg = wx.MessageDialog(None, msg, "InVesalius 3",
+                               wx.YES_NO)
+
+    if dlg.ShowModal() == wx.ID_YES:
+        flag = False
+    else:
+        flag = True
+
+    dlg.Destroy()
+    return flag
 
 def ShowSaveAsProjectDialog(default_filename=None):
     current_dir = os.path.abspath(".")

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -464,7 +464,7 @@ def ShowImportMeshFilesDialog():
     return filename
 
 def ImportMeshCoordSystem():
-    msg = _("Is the imported mesh on InVesalius coordinate system?")
+    msg = _("Was the imported mesh created in InVesalius?")
     if sys.platform == 'darwin':
         dlg = wx.MessageDialog(None, "", msg,
                                wx.YES_NO)

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -464,7 +464,7 @@ def ShowImportMeshFilesDialog():
     return filename
 
 def ImportMeshCoordSystem():
-    msg = _("Was the imported mesh created in InVesalius?")
+    msg = _("Was the imported mesh created by InVesalius?")
     if sys.platform == 'darwin':
         dlg = wx.MessageDialog(None, "", msg,
                                wx.YES_NO)

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -57,6 +57,7 @@ class Project(with_metaclass(Singleton, object)):
         self.original_orientation = ''
         self.window = ''
         self.level = ''
+        self.affine = ''
 
         # Masks (vtkImageData)
         self.mask_dict = {}
@@ -227,6 +228,7 @@ class Project(with_metaclass(Singleton, object)):
                    "window_level": self.level,
                    "scalar_range": self.threshold_range,
                    "spacing": self.spacing,
+                   "affine": self.affine,
                   }
 
         # Saving the matrix containing the slices
@@ -313,6 +315,10 @@ class Project(with_metaclass(Singleton, object)):
         self.level = project["window_level"]
         self.threshold_range = project["scalar_range"]
         self.spacing = project["spacing"]
+        if project.get("affine"):
+            self.affine = project["affine"]
+            Publisher.sendMessage('Update affine matrix',
+                                  affine=self.affine)
 
         self.compress = project.get("compress", True)
 

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -318,7 +318,7 @@ class Project(with_metaclass(Singleton, object)):
         if project.get("affine"):
             self.affine = project["affine"]
             Publisher.sendMessage('Update affine matrix',
-                                  affine=self.affine)
+                                  affine=self.affine, status=True)
 
         self.compress = project.get("compress", True)
 


### PR DESCRIPTION
Tool to transform an imported object to InVesalius coordinate system. 

-works only with nifiti, rec/par and analyze images
-affine matrix is saved at main.plist of inv project
-scalarvisibility set as on for vtp files (feature for DTI import)

TODO: 
-choose the coord system of the export surface
-Set scalarvisibilityon when an inv project is opened