### PR TITLE
Fixing the cross focal point update in Go To Slice tool

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -874,6 +874,9 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.SetInterpolatedSlices, "Set interpolated slices")
         Publisher.subscribe(self.UpdateInterpolatedSlice, "Update Slice Interpolation")
 
+        Publisher.subscribe(self.GetCrossPos, "Set Update cross pos")
+        Publisher.subscribe(self.UpdateCross, "Update cross pos")
+
 
     def RefreshViewer(self):
         self.Refresh()
@@ -1487,6 +1490,17 @@ class Viewer(wx.Panel):
             cursor.SetSpacing((spacing[0], spacing[2], spacing[1]))
 
         self.slice_data.renderer.ResetCamera()
+
+    def GetCrossPos(self):
+        spacing = self.slice_data.actor.GetInput().GetSpacing()
+        Publisher.sendMessage("Cross focal point", coord = self.cross.GetFocalPoint(), spacing = spacing)
+
+    def UpdateCross(self, coord):
+        self.cross.SetFocalPoint(coord)
+        Publisher.sendMessage('Set ball reference position', position=self.cross.GetFocalPoint())
+        Publisher.sendMessage('Co-registered points',  arg=None, position=(coord[0], coord[1], coord[2], 0., 0., 0.))
+        self.OnScrollBar()
+        self.interactor.Render()
 
     def AddActors(self, actors, slice_number):
         "Inserting actors"


### PR DESCRIPTION
While using the tool Go To Slice with the slices' cross navigation activated, neither the focal point of the cross, or the neuronavigation coords, or  the 3D viewer were being updated. This changes have fixed that.