### PR TITLE
ADD: Remote communication via Socket.IO

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ import optparse as op
 import os
 import sys
 import shutil
+import time
 import traceback
 
 import re
@@ -51,7 +52,7 @@ try:
 except ImportError:
     from wx import SplashScreen
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 #import wx.lib.agw.advancedsplash as agw
 #if sys.platform.startswith('linux'):
@@ -322,6 +323,10 @@ def parse_comand_line():
 
     parser.add_option("--import-folder", action="store", dest="import_folder")
 
+    parser.add_option("--remote-host",
+                      action="store",
+                      dest="remote_host")
+
     parser.add_option("-s", "--save",
                       help="Save the project after an import.")
 
@@ -487,11 +492,61 @@ def print_events(topic=Publisher.AUTO_TOPIC, **msg_data):
     """
     utils.debug("%s\n\tParameters: %s" % (topic, msg_data))
 
+def setup_remote_host(remote_host):
+    import socketio
+    sio = socketio.Client()
+
+    connected = False
+
+    @sio.on('connect')
+    def on_connect():
+        print("Connected to {}".format(remote_host))
+
+        nonlocal connected
+        connected = True
+
+    @sio.on('disconnect')
+    def on_disconnect():
+        print("Disconnected")
+
+    sio.connect(remote_host)
+
+    while not connected:
+        print("Connecting...")
+        time.sleep(1.0)
+
+    def emit(topic, data):
+        print("Emitting data {} to topic {}".format(data, topic))
+        try:
+            if isinstance(topic, str):
+                sio.emit("from_neuronavigation", {
+                    "topic": topic,
+                    "data": data,
+                })
+        except TypeError:
+            pass
+
+    @sio.on("to_neuronavigation")
+    def handler(msg):
+        topic = msg["topic"]
+        data = msg["data"]
+
+        print("Received an event into topic '{}' with data {}".format(topic, str(data)))
+        Publisher.sendMessage_no_hook(
+            topicName=topic,
+            **data
+        )
+
+    Publisher.add_sendMessage_hook(emit)
+
 def main():
     """
     Initialize InVesalius GUI
     """
     options, args = parse_comand_line()
+
+    if options.remote_host is not None:
+        setup_remote_host(options.remote_host)
 
     if options.no_gui:
         non_gui_startup(options, args)

--- a/docs/devel/example_pubsub.py
+++ b/docs/devel/example_pubsub.py
@@ -3,7 +3,7 @@
 # More information about this design pattern can be found at:
 # http://wiki.wxpython.org/ModelViewController
 # http://wiki.wxpython.org/PubSub
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 # The maintainer of Pubsub module is Oliver Schoenborn.
 # Since the end of 2006 Pubsub is now maintained separately on SourceForge at:

--- a/docs/devel/example_singleton_pubsub.py
+++ b/docs/devel/example_singleton_pubsub.py
@@ -1,6 +1,6 @@
 # Singleton and Publisher-Subscriber design patterns example.
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 class Singleton(type):
     # This is a Gary Robinson implementation:

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -24,7 +24,7 @@ import textwrap
 import wx
 import numpy as np
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.imagedata_utils as image_utils

--- a/invesalius/data/coordinates.py
+++ b/invesalius/data/coordinates.py
@@ -26,7 +26,7 @@ import invesalius.constants as const
 
 from time import sleep
 from random import uniform
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 def GetCoordinates(trck_init, trck_id, ref_mode):

--- a/invesalius/data/editor.py
+++ b/invesalius/data/editor.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 
 import math
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import vtk
 
 AXIAL = 2

--- a/invesalius/data/geometry.py
+++ b/invesalius/data/geometry.py
@@ -22,7 +22,7 @@ import math
 
 import numpy as np
 import vtk
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.utils as utils

--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -27,7 +27,8 @@ import imageio
 import numpy
 import numpy as np
 import vtk
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
+
 from scipy.ndimage import shift, zoom
 from vtk.util import numpy_support
 

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -33,7 +33,7 @@ from invesalius.data.volume import VolumeMask
 import numpy as np
 import vtk
 from invesalius_cy import floodfill
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from scipy import ndimage
 from vtk.util import numpy_support
 

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -4,7 +4,7 @@ import math
 import random
 import sys
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import numpy as np
 import vtk

--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -21,7 +21,7 @@ import sys
 
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.vtk_utils as vu

--- a/invesalius/data/record_coords.py
+++ b/invesalius/data/record_coords.py
@@ -23,7 +23,7 @@ import time
 import wx
 from numpy import array, savetxt, hstack,vstack, asarray
 import invesalius.gui.dialogs as dlg
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Record(threading.Thread):

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -22,7 +22,7 @@ import tempfile
 import numpy as np
 import vtk
 from scipy import ndimage
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.converters as converters

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -31,7 +31,7 @@ from scipy import ndimage
 from imageio import imsave
 from scipy.ndimage import generate_binary_structure, watershed_ift
 from skimage.morphology import watershed
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.converters as converters

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -23,7 +23,7 @@ import wx
 import invesalius.constants as const
 import invesalius.project as prj
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 PROP_MEASURE = 0.8

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -38,7 +38,7 @@ import vtk
 import wx
 import wx.lib.agw.genericmessagedialog as GMD
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 if sys.platform == 'win32':
     try:

--- a/invesalius/data/tractography.py
+++ b/invesalius/data/tractography.py
@@ -28,7 +28,7 @@ import time
 
 import numpy as np
 import queue
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from scipy.stats import norm
 import vtk
 

--- a/invesalius/data/trigger.py
+++ b/invesalius/data/trigger.py
@@ -21,7 +21,7 @@ import threading
 from time import sleep
 
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Trigger(threading.Thread):

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -31,7 +31,7 @@ from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 import invesalius.data.styles as styles
 import wx
 import sys
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from agw import floatspin as FS

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -29,7 +29,7 @@ from numpy.core.umath_tests import inner1d
 import wx
 import vtk
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import random
 from scipy.spatial import distance
 
@@ -589,6 +589,7 @@ class Viewer(wx.Panel):
 
         self.ren.AddActor(self.staticballs[self.ball_id])
         self.ball_id = self.ball_id + 1
+
         #self.UpdateRender()
         self.Refresh()
 

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -24,7 +24,7 @@ from distutils.version import LooseVersion
 import numpy
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.project as prj

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -20,7 +20,7 @@ import sys
 
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import invesalius.constants as const
 from invesalius.gui.dialogs import ProgressDialog
 

--- a/invesalius/gui/bitmap_preview_panel.py
+++ b/invesalius/gui/bitmap_preview_panel.py
@@ -5,7 +5,7 @@ import numpy
 
 from vtk.util import  numpy_support
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.vtk_utils as vtku

--- a/invesalius/gui/brain_seg_dialog.py
+++ b/invesalius/gui/brain_seg_dialog.py
@@ -12,7 +12,7 @@ import time
 
 import numpy as np
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.slice_ as slc
 from invesalius.segmentation.brain import segment, utils

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -34,7 +34,7 @@ except ImportError:
     import wx.lib.flatnotebook as fnb
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slice_

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -22,7 +22,7 @@ try:
     import wx.lib.agw.foldpanelbar as fpb
 except ModuleNotFoundError:
     import wx.lib.foldpanelbar as fpb
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.data_notebook as nb

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -21,7 +21,7 @@ import os
 
 import wx
 import wx.lib.agw.fourwaysplitter as fws
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.viewer_slice as slice_viewer
 import invesalius.data.viewer_volume as volume_viewer
@@ -316,7 +316,7 @@ class VolumeInteraction(wx.Panel):
 
 import wx.lib.platebtn as pbtn
 import wx.lib.buttons as btn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.colourselect as csel
 
 RAYCASTING_TOOLS = wx.NewId()

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -47,7 +47,7 @@ from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 from wx.lib import masked
 from wx.lib.agw import floatspin
 from wx.lib.wordwrap import wordwrap
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from wx.adv import AboutDialogInfo, AboutBox

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -29,7 +29,7 @@ import vtk
 
 from vtk.util import  numpy_support
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.reader.dicom_reader as dicom_reader

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -43,7 +43,7 @@ import wx.lib.popupctl as pc
 from invesalius import inv_paths
 from invesalius.gui import project_properties
 from wx.lib.agw.aui.auibar import AUI_TB_PLAIN_BACKGROUND, AuiToolBar
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from wx.adv import TaskBarIcon as wx_TaskBarIcon

--- a/invesalius/gui/import_bitmap_panel.py
+++ b/invesalius/gui/import_bitmap_panel.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 import wx
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/import_network_panel.py
+++ b/invesalius/gui/import_network_panel.py
@@ -19,7 +19,7 @@
 import wx
 import sys
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/import_panel.py
+++ b/invesalius/gui/import_panel.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 import wx
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -4,7 +4,7 @@ import invesalius.constants as const
 import invesalius.session as ses
 import wx
 from invesalius.gui.language_dialog import ComboBoxLanguage
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Preferences(wx.Dialog):

--- a/invesalius/gui/project_properties.py
+++ b/invesalius/gui/project_properties.py
@@ -19,7 +19,7 @@
 
 import wx
 import invesalius.project as prj
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from invesalius.gui import utils
 from invesalius import constants as const
 

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -29,7 +29,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.dialogs as dlg

--- a/invesalius/gui/task_importer.py
+++ b/invesalius/gui/task_importer.py
@@ -26,7 +26,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 import wx.lib.platebtn as pbtn
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.dialogs as dlg

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -42,7 +42,7 @@ except ImportError:
 
 import wx.lib.colourselect as csel
 import wx.lib.masked.numctrl
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from time import sleep
 
 import invesalius.constants as const

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -31,7 +31,7 @@ except ImportError:
 
 import wx.lib.platebtn as pbtn
 import wx.lib.colourselect as csel
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.mask as mask
 import invesalius.data.slice_ as slice_

--- a/invesalius/gui/task_surface.py
+++ b/invesalius/gui/task_surface.py
@@ -28,7 +28,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
     import wx.lib.foldpanelbar as fpb
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.colourselect as csel
 import wx.lib.scrolledpanel as scrolled
 

--- a/invesalius/gui/task_tools.py
+++ b/invesalius/gui/task_tools.py
@@ -27,7 +27,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as constants
 import invesalius.constants as const

--- a/invesalius/gui/widgets/canvas_renderer.py
+++ b/invesalius/gui/widgets/canvas_renderer.py
@@ -30,7 +30,7 @@ except ImportError:
     from weakrefmethod import WeakMethod
 
 from invesalius.data import converters
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class CanvasEvent:

--- a/invesalius/gui/widgets/clut_raycasting.py
+++ b/invesalius/gui/widgets/clut_raycasting.py
@@ -24,7 +24,7 @@ import sys
 
 import numpy
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.gui.dialogs as dialog
 import invesalius.constants as const

--- a/invesalius/gui/widgets/slice_menu.py
+++ b/invesalius/gui/widgets/slice_menu.py
@@ -26,7 +26,7 @@ except(ImportError):
     from ordereddict import OrderedDict
 
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.slice_ as sl

--- a/invesalius/plugins.py
+++ b/invesalius/plugins.py
@@ -24,7 +24,7 @@ import pathlib
 import sys
 from itertools import chain
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as consts
 from invesalius import inv_paths

--- a/invesalius/presets.py
+++ b/invesalius/presets.py
@@ -22,7 +22,7 @@ import plistlib
 
 import invesalius.constants as const
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 from invesalius import inv_paths
 from invesalius.utils import TwoWaysDictionary

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -30,7 +30,7 @@ import numpy as np
 import vtk
 import wx
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.polydata_utils as pu

--- a/invesalius/reader/bitmap_reader.py
+++ b/invesalius/reader/bitmap_reader.py
@@ -28,7 +28,7 @@ import numpy
 import vtk
 import wx
 from imageio import imread
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from vtk.util import numpy_support
 
 import invesalius.constants as const

--- a/invesalius/reader/dicom_reader.py
+++ b/invesalius/reader/dicom_reader.py
@@ -28,7 +28,7 @@ import gdcm
 # Not showing GDCM warning and debug messages
 gdcm.Trace_DebugOff()
 gdcm.Trace_WarningOff()
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.reader.dicom as dicom

--- a/invesalius/session.py
+++ b/invesalius/session.py
@@ -31,7 +31,7 @@ import codecs
 import collections
 import json
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx
 
 from invesalius.utils import Singleton, debug, decode, deep_merge_dict

--- a/invesalius/style.py
+++ b/invesalius/style.py
@@ -17,7 +17,7 @@
 #    detalhes.
 #--------------------------------------------------------------------------
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 # mode.py

--- a/invesalius_pubsub/pub.py
+++ b/invesalius_pubsub/pub.py
@@ -1,0 +1,86 @@
+#--------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+#--------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+#--------------------------------------------------------------------------
+
+from typing import Callable
+
+from pubsub import pub as Publisher
+from pubsub.core.listener import UserListener
+
+__all__ = [
+    # subscribing
+    'subscribe',
+    'unsubscribe',
+
+    # publishing
+    'sendMessage',
+    'sendMessage_no_hook',
+
+    # adding hooks
+    'add_sendMessage_hook'
+]
+
+Hook = Callable[[str, dict], None]
+
+sendMessage_hook: Hook = None
+
+def add_sendMessage_hook(hook: Hook):
+    """Add a hook for sending messages. The hook is a function that takes the topic
+    name as the first parameter and the message dict as the second parameter, and
+    returns None.
+
+    :param hook:
+    """
+    global sendMessage_hook
+    sendMessage_hook = hook
+
+def subscribe(listener: UserListener, topicName: str, **curriedArgs):
+    """Subscribe to a topic.
+
+    :param listener:
+    :param topicName:
+    :param curriedArgs:
+    """
+    subscribedListener, success = Publisher.subscribe(listener, topicName, **curriedArgs)
+    return subscribedListener, success
+
+def unsubscribe(*args, **kwargs):
+    """Unsubscribe from a topic.
+
+    """
+    Publisher.unsubscribe(*args, **kwargs)
+
+def sendMessage(topicName: str, **msgdata):
+    """Send a message in a given topic.
+
+    :param topicName:
+    :param msgdata:
+    """
+    Publisher.sendMessage(topicName, **msgdata)
+    if sendMessage_hook is not None:
+        sendMessage_hook(topicName, msgdata)
+
+def sendMessage_no_hook(topicName: str, **msgdata):
+    """Send a message in a given topic, but do not call the hook.
+
+    :param topicName:
+    :param msgdata:
+    """
+    Publisher.sendMessage(topicName, **msgdata)
+
+AUTO_TOPIC = Publisher.AUTO_TOPIC

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ class build_ext_subclass(build_ext):
 
 setup(
     cmdclass={"build_ext": build_ext_subclass},
+    packages=['invesalius_pubsub'],
     ext_modules=cythonize(
         [
             Extension(


### PR DESCRIPTION
- Add a command line option (--remote-host) to connect to a remote server via Socket.IO.

- Add a hook to send all internal events to the remote server using `from_neuronavigation` event.

- Add a Socket.IO event listener for `to_neuronavigation` events, send those events internally.