### PR TITLE
ADD: Send 'Coil at target' message

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -911,8 +911,10 @@ class Viewer(wx.Panel):
 
             if thrdist and thrcoordx and thrcoordy and thrcoordz:
                 self.dummy_coil_actor.GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('Green'))
+                Publisher.sendMessage('Coil at target', state=True)
             else:
                 self.dummy_coil_actor.GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('DarkOrange'))
+                Publisher.sendMessage('Coil at target', state=False)
 
             self.arrow_actor_list = arrow_roll_x1, arrow_roll_x2, arrow_yaw_z1, arrow_yaw_z2, \
                                     arrow_pitch_y1, arrow_pitch_y2


### PR DESCRIPTION
Not used by InVesalius, but useful when wanting to have the
information about coil being at the target or not outside
InVesalius.