### PR TITLE
Allow setting markers remotely by using 'Set markers' event

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -575,14 +575,19 @@ class Viewer(wx.Panel):
             ball_id = marker["ball_id"]
             size = marker["size"]
             colour = marker["colour"]
-            coord = marker["coord"]
+            position = marker["position"]
+            direction = marker["direction"]
+            target = marker["target"]
 
             self.AddMarker(
                 ball_id=ball_id,
                 size=size,
                 colour=colour,
-                coord=coord,
+                coord=position,
             )
+
+            if target:
+                Publisher.sendMessage('Update target', coord=position + direction)
 
         self.UpdateRender()
 
@@ -949,6 +954,7 @@ class Viewer(wx.Panel):
         self.target_coord = coord
         self.target_coord[1] = -self.target_coord[1]
         self.CreateTargetAim()
+        print("Target updated to coordinates {}".format(coord))
 
     def OnRemoveTarget(self, status):
         if not status:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -959,12 +959,14 @@ class Viewer(wx.Panel):
         self.target_coord = coord
         self.target_coord[1] = -self.target_coord[1]
         self.CreateTargetAim()
+        Publisher.sendMessage('Target selected', status=True)
         print("Target updated to coordinates {}".format(coord))
 
     def RemoveTarget(self):
         self.target_mode = None
         self.target_coord = None
         self.RemoveTargetAim()
+        Publisher.sendMessage('Target selected', status=False)
 
     def OnDisableOrEnableCoilTracker(self, status):
         if not status:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -288,6 +288,7 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.BlinkMarker, 'Blink Marker')
         Publisher.subscribe(self.StopBlinkMarker, 'Stop Blink Marker')
         Publisher.subscribe(self.SetNewColor, 'Set new color')
+        Publisher.subscribe(self.SetMarkers, 'Set markers')
 
         # Related to object tracking during neuronavigation
         Publisher.subscribe(self.OnNavigationStatus, 'Navigation status')
@@ -562,6 +563,28 @@ class Viewer(wx.Panel):
         """
         actor = self.points_reference.pop(point)
         self.ren.RemoveActor(actor)
+
+    def SetMarkers(self, markers):
+        """
+        Set all markers, overwriting the previous markers.
+        """
+        self.RemoveAllMarkers(len(self.staticballs))
+
+        for marker in markers:
+
+            ball_id = marker["ball_id"]
+            size = marker["size"]
+            colour = marker["colour"]
+            coord = marker["coord"]
+
+            self.AddMarker(
+                ball_id=ball_id,
+                size=size,
+                colour=colour,
+                coord=coord,
+            )
+
+        self.UpdateRender()
 
     def AddMarker(self, ball_id, size, colour, coord):
         """

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -299,7 +299,7 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.ActivateTargetMode, 'Target navigation mode')
         Publisher.subscribe(self.OnUpdateObjectTargetGuide, 'Update object matrix')
         Publisher.subscribe(self.OnUpdateTargetCoordinates, 'Update target')
-        Publisher.subscribe(self.OnRemoveTarget, 'Disable or enable coil tracker')
+        Publisher.subscribe(self.OnDisableOrEnableCoilTracker, 'Disable or enable coil tracker')
         Publisher.subscribe(self.OnTargetMarkerTransparency, 'Set target transparency')
         Publisher.subscribe(self.OnUpdateAngleThreshold, 'Update angle threshold')
         Publisher.subscribe(self.OnUpdateDistThreshold, 'Update dist threshold')
@@ -570,6 +570,7 @@ class Viewer(wx.Panel):
         """
         self.RemoveAllMarkers(len(self.staticballs))
 
+        target_selected = False
         for marker in markers:
 
             ball_id = marker["ball_id"]
@@ -588,6 +589,10 @@ class Viewer(wx.Panel):
 
             if target:
                 Publisher.sendMessage('Update target', coord=position + direction)
+                target_selected = True
+
+        if not target_selected:
+            self.RemoveTarget()
 
         self.UpdateRender()
 
@@ -956,11 +961,14 @@ class Viewer(wx.Panel):
         self.CreateTargetAim()
         print("Target updated to coordinates {}".format(coord))
 
-    def OnRemoveTarget(self, status):
+    def RemoveTarget(self):
+        self.target_mode = None
+        self.target_coord = None
+        self.RemoveTargetAim()
+
+    def OnDisableOrEnableCoilTracker(self, status):
         if not status:
-            self.target_mode = None
-            self.target_coord = None
-            self.RemoveTargetAim()
+            self.RemoveTarget()
             self.DisableCoilTracker()
 
     def CreateTargetAim(self):

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -388,7 +388,7 @@ class VolumeToolPanel(wx.Panel):
         #  sizer.Add(self.button_3d_mask, 0, wx.TOP | wx.BOTTOM, 1)
 
         self.navigation_status = False
-        self.status_target_select = False
+        self.status_target_selected = False
         self.status_obj_tracker = False
 
         sizer.Fit(self)
@@ -408,7 +408,7 @@ class VolumeToolPanel(wx.Panel):
         Publisher.subscribe(self.DisablePreset, 'Close project data')
         Publisher.subscribe(self.Uncheck, 'Uncheck image plane menu')
         Publisher.subscribe(self.DisableVolumeCutMenu, 'Disable volume cut menu')
-        Publisher.subscribe(self.StatusTargetSelect, 'Disable or enable coil tracker')
+        Publisher.subscribe(self.StatusTargetSelected, 'Target selected')
         Publisher.subscribe(self.StatusObjTracker, 'Status target button')
         Publisher.subscribe(self.ActiveTarget, 'Active target button')
         Publisher.subscribe(self.DeactiveTarget, 'Deactive target button')
@@ -442,8 +442,8 @@ class VolumeToolPanel(wx.Panel):
         self.status_obj_tracker = status
         self.StatusNavigation()
 
-    def StatusTargetSelect(self, status):
-        self.status_target_select = status
+    def StatusTargetSelected(self, status):
+        self.status_target_selected = status
         self.StatusNavigation()
 
     def ActiveTarget(self):
@@ -453,7 +453,7 @@ class VolumeToolPanel(wx.Panel):
         self.button_target.Hide()
 
     def StatusNavigation(self):
-        if self.status_target_select and self.status_obj_tracker:
+        if self.status_target_selected and self.status_obj_tracker:
             self.button_target.Enable(1)
         else:
             self.OnButtonTarget(False)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1384,7 +1384,6 @@ class MarkersPanel(wx.Panel):
 
         Publisher.sendMessage('Update target', coord=self.list_coord[self.tgt_index][:6])
         Publisher.sendMessage('Set target transparency', status=True, index=self.tgt_index)
-        Publisher.sendMessage('Disable or enable coil tracker', status=True)
         self.OnMenuEditMarkerId('TARGET')
         self.tgt_flag = True
         wx.MessageBox(_("New target selected."), _("InVesalius 3"))


### PR DESCRIPTION
Most of these changes refactor and rearrange the internal events so that when setting markers
using 'Set markers' event, one of the markers can be set as the target, and InVesalius then
correctly updates all the internal variables needed when a target is set.