### PR TITLE
Revert "FIX: Locale problem crashing with Windows 10 and certain locales (#283)"

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,7 +106,6 @@ class InVesalius(wx.App):
         from multiprocessing import freeze_support
         freeze_support()
 
-        self.ResetLocale()
         self.SetAppName("InVesalius 3")
         self.splash = Inv3SplashScreen()
         self.splash.Show()


### PR DESCRIPTION
This reverts commit 30ae50b1b29bb0d9c331971f0190fe7b5332e12b.

See #247 for more information: apparently this is not the correct fix, but it still causes InVesalius to not work with wxPython 4.0.6, as that version does not have the ResetLocale function. (I'm not sure if 4.0.6 should be supported in the first place, but it's probably better to stay conservative until the correct fix is found.)