### PR TITLE
MOD: Remove 'Disconnect tracker' option from tracker dropdown menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,7 +136,7 @@ class Inv3SplashScreen(SplashScreen):
     def __init__(self):
         # Splash screen image will depend on currently language
         lang = LANG
-        self.locale = wx.Locale(wx.LANGUAGE_DEFAULT)
+        self.locale = wx.Locale(wx.LANGUAGE_ENGLISH)
 
         # Language information is available in session configuration
         # file. First we need to check if this file exist, if now, it

--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -670,7 +670,6 @@ POLARISP4 = 7
 OPTITRACK = 8
 DEBUGTRACKRANDOM = 9
 DEBUGTRACKAPPROACH = 10
-DISCTRACK = 11
 DEFAULT_TRACKER = SELECT
 
 NDICOMPORT = b'COM1'
@@ -680,7 +679,7 @@ TRACKERS = [_("Claron MicronTracker"),
             _("Polhemus PATRIOT"), _("Camera tracker"),
             _("NDI Polaris"), _("NDI Polaris P4"),
             _("Optitrack"), _("Debug tracker (random)"),
-            _("Debug tracker (approach)"), _("Disconnect tracker")]
+            _("Debug tracker (approach)")]
 
 STATIC_REF = 0
 DYNAMIC_REF = 1


### PR DESCRIPTION
Tested a couple of functions after this change, and they seemed to work without error messages or warnings in the console:

- Opening a project and selecting a tracker
- Selecting another tracker when one tracker is already selected
- Selecting a non-working tracker
- Opening another project when one project is already opened (closing the connection to the tracker)
- Closing InVesalius

I also tentatively fixed my GitHub email address so the merge commit shouldn't show two separate authors for the change anymore -- let's see if it works.