### PR TITLE
FIX: Bug in StopNavigation, causing error if serial port not enabled

### DIFF
--- a/invesalius/data/serial_port_connection.py
+++ b/invesalius/data/serial_port_connection.py
@@ -40,9 +40,6 @@ class SerialPortConnection(threading.Thread):
         self.event = event
         self.sleep_nav = sleep_nav
 
-    def Enabled(self):
-        return self.port is not None
-
     def Connect(self):
         if self.port is None:
             print("Serial port init error: COM port is unset.")

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -485,7 +485,7 @@ class Navigation():
             self.tracts_queue.clear()
             self.tracts_queue.join()
 
-        vis_components = [self.serial_port_connection.Enabled(), self.view_tracts,  self.peel_loaded]
+        vis_components = [self.SerialPortEnabled(), self.view_tracts,  self.peel_loaded]
         Publisher.sendMessage("Navigation status", nav_status=False, vis_status=vis_components)
 
 


### PR DESCRIPTION
- The correct way to ask if serial port is enabled is to use
  SerialPortEnabled function in Navigation class.

- While at it, remove the unused Enabled function from
  SerialPortConnection class.