### PR TITLE
Remove ball when coil is projected

### DIFF
--- a/invesalius/data/coordinates.py
+++ b/invesalius/data/coordinates.py
@@ -93,7 +93,6 @@ def OptitrackCoord(trck_init, trck_id, ref_mode):
     coord3 = np.array([float(trck.PositionCoilZ1) * scale[0], float(trck.PositionCoilX1) * scale[1],
                        float(trck.PositionCoilY1) * scale[2]])
     coord3 = np.hstack((coord3, angles_coil))
-
     coord = np.vstack([coord1, coord2, coord3])
     return coord
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -345,16 +345,18 @@ class Viewer(wx.Panel):
             # self._check_and_set_ball_visibility()
             self._ball_ref_visibility = True
             # if self._to_show_ball:
-            if not self.ball_actor:
+            if not self.ball_actor and not self.actor_peel:
                 self.CreateBallReference()
-
+                self.ball_actor.SetVisibility(1)
+            else:
+                self.ball_actor.SetVisibility(0)
             self.interactor.Render()
 
     def _uncheck_ball_reference(self, style):
         if style == const.SLICE_STATE_CROSS:
             self._mode_cross = False
             # self.RemoveBallReference()
-            self._ball_ref_visibility = False
+            self._ball_ref_visibility = True
             if self.ball_actor:
                 self.ren.RemoveActor(self.ball_actor)
                 self.ball_actor = None
@@ -1236,10 +1238,11 @@ class Viewer(wx.Panel):
     #     self.UpdateCameraBallPosition(None, position)
 
     def UpdateCameraBallPosition(self, position):
-        coord_flip = list(position[:3])
-        coord_flip[1] = -coord_flip[1]
-        self.ball_actor.SetPosition(coord_flip)
-        self.SetVolumeCamera(coord_flip)
+        if not self.actor_peel:
+            coord_flip = list(position[:3])
+            coord_flip[1] = -coord_flip[1]
+            self.ball_actor.SetPosition(coord_flip)
+            self.SetVolumeCamera(coord_flip)
 
     def CreateObjectPolyData(self, filename):
         """

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1332,6 +1332,9 @@ class Viewer(wx.Panel):
         self.ren.AddActor(self.x_actor)
         self.ren.AddActor(self.y_actor)
         self.ren.AddActor(self.z_actor)
+        self.x_actor.SetVisibility(0)
+        self.y_actor.SetVisibility(0)
+        self.z_actor.SetVisibility(0)
         #self.ren.AddActor(self.obj_projection_arrow_actor)
         #self.ren.AddActor(self.object_orientation_torus_actor)
         # self.obj_axes = vtk.vtkAxesActor()
@@ -1539,11 +1542,10 @@ class Viewer(wx.Panel):
             self.pTarget = self.CenterOfMass()
             if self.obj_actor:
                 self.obj_actor.SetVisibility(self.obj_state)
-                self.x_actor.SetVisibility(self.obj_state)
-                self.y_actor.SetVisibility(self.obj_state)
-                self.z_actor.SetVisibility(self.obj_state)
-                #self.object_orientation_torus_actor.SetVisibility(self.obj_state)
-                #self.obj_projection_arrow_actor.SetVisibility(self.obj_state)
+                #self.x_actor.SetVisibility(self.obj_state)
+                #self.y_actor.SetVisibility(self.obj_state)
+                #self.z_actor.SetVisibility(self.obj_state)
+
         self.Refresh()
 
     def UpdateSeedOffset(self, data):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -343,13 +343,16 @@ class Viewer(wx.Panel):
         if style == const.SLICE_STATE_CROSS:
             self._mode_cross = True
             # self._check_and_set_ball_visibility()
+            #if not self.actor_peel:
             self._ball_ref_visibility = True
+            #else:
+            #    self._ball_ref_visibility = False
             # if self._to_show_ball:
-            if not self.ball_actor and not self.actor_peel:
+            if not self.ball_actor: #and not self.actor_peel:
                 self.CreateBallReference()
-                self.ball_actor.SetVisibility(1)
-            else:
-                self.ball_actor.SetVisibility(0)
+                #self.ball_actor.SetVisibility(1)
+            #else:
+             #   self.ball_actor.SetVisibility(0)
             self.interactor.Render()
 
     def _uncheck_ball_reference(self, style):
@@ -1238,11 +1241,11 @@ class Viewer(wx.Panel):
     #     self.UpdateCameraBallPosition(None, position)
 
     def UpdateCameraBallPosition(self, position):
-        if not self.actor_peel:
-            coord_flip = list(position[:3])
-            coord_flip[1] = -coord_flip[1]
-            self.ball_actor.SetPosition(coord_flip)
-            self.SetVolumeCamera(coord_flip)
+        #if not self.actor_peel:
+        coord_flip = list(position[:3])
+        coord_flip[1] = -coord_flip[1]
+        self.ball_actor.SetPosition(coord_flip)
+        self.SetVolumeCamera(coord_flip)
 
     def CreateObjectPolyData(self, filename):
         """
@@ -1443,6 +1446,8 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.object_orientation_torus_actor)
             self.ren.RemoveActor(self.obj_projection_arrow_actor)
             self.actor_peel = None
+            self.ball_actor.SetVisibility(1)
+
         if flag and actor:
             self.ren.AddActor(actor)
             self.actor_peel = actor
@@ -1500,7 +1505,7 @@ class Viewer(wx.Panel):
 
                     self.ren.AddActor(self.obj_projection_arrow_actor)
                     self.ren.AddActor(self.object_orientation_torus_actor)
-
+                    self.ball_actor.SetVisibility(0)
                     self.obj_projection_arrow_actor.SetPosition(closestPoint)
                     self.obj_projection_arrow_actor.SetOrientation(coil_dir)
 
@@ -1521,6 +1526,8 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.obj_projection_arrow_actor)
             self.ren.RemoveActor(self.object_orientation_torus_actor)
             self.ren.RemoveActor(self.x_actor)
+            self.ball_actor.SetVisibility(1)
+
             #self.ren.RemoveActor(self.y_actor)
         self.Refresh()
 
@@ -1631,7 +1638,10 @@ class Viewer(wx.Panel):
             self.x_actor.SetVisibility(self.obj_state)
             self.y_actor.SetVisibility(self.obj_state)
             self.z_actor.SetVisibility(self.obj_state)
-
+            #if self.actor_peel:
+            #    self.ball_actor.SetVisibility(0)
+            #else:
+            #    self.ball_actor.SetVisibility(1)
         self.Refresh()
 
     def OnUpdateTracts(self, root=None, affine_vtk=None, coord_offset=None):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1545,7 +1545,8 @@ class Viewer(wx.Panel):
                 #self.x_actor.SetVisibility(self.obj_state)
                 #self.y_actor.SetVisibility(self.obj_state)
                 #self.z_actor.SetVisibility(self.obj_state)
-
+                #self.object_orientation_torus_actor.SetVisibility(self.obj_state)
+                #self.obj_projection_arrow_actor.SetVisibility(self.obj_state)
         self.Refresh()
 
     def UpdateSeedOffset(self, data):


### PR DESCRIPTION
-Modify visibility of red ball when peel is loaded. Ball is not visible when the coil projections hits the peel. 
-Modify visibility of x, y, z line actors to not be visible
-Modify visibility of torus and arrow actors when adding the object (coil) to not be visible.  