### PR TITLE
MOD: Change logic for when to use coil without handle to mark the target

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -192,6 +192,7 @@ class Viewer(wx.Panel):
         self.dummy_coil_actor = None
         self.target_mode = False
         self.polydata = None
+        self.use_default_object = True
         self.anglethreshold = const.COIL_ANGLES_THRESHOLD
         self.distthreshold = const.COIL_COORD_THRESHOLD
         self.angle_arrow_projection_threshold = const.COIL_ANGLE_ARROW_PROJECTION_THRESHOLD
@@ -1017,10 +1018,10 @@ class Viewer(wx.Panel):
         self.aim_actor = aim_actor
         self.ren.AddActor(aim_actor)
 
-        if self.polydata:
-            obj_polydata = self.polydata
-        else:
+        if self.use_default_object:
             obj_polydata = self.CreateObjectPolyData(os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil_no_handle.stl"))
+        else:
+            obj_polydata = self.polydata
 
         transform = vtk.vtkTransform()
         transform.RotateZ(90)
@@ -1597,10 +1598,11 @@ class Viewer(wx.Panel):
             self.GetCellIntersection(p1, norm, coil_norm, coil_dir)
         self.Refresh()
 
-    def UpdateTrackObjectState(self, evt=None, flag=None, obj_name=None, polydata=None):
+    def UpdateTrackObjectState(self, evt=None, flag=None, obj_name=None, polydata=None, use_default_object=True):
         if flag:
             self.obj_name = obj_name
             self.polydata = polydata
+            self.use_default_object = use_default_object
             if not self.obj_actor:
                 self.AddObjectActor(self.obj_name)
         else:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -3267,6 +3267,7 @@ class ObjectCalibrationDialog(wx.Dialog):
         self.obj_ref_id = 2
         self.obj_name = None
         self.polydata = None
+        self.use_default_object = False
 
         self.obj_fiducials = np.full([5, 3], np.nan)
         self.obj_orients = np.full([5, 3], np.nan)
@@ -3379,8 +3380,9 @@ class ObjectCalibrationDialog(wx.Dialog):
             return 0
 
     def LoadObject(self):
-        default = self.ObjectImportDialog()
-        if not default:
+        self.use_default_object = self.ObjectImportDialog()
+
+        if not self.use_default_object:
             filename = ShowImportMeshFilesDialog()
 
             if filename:
@@ -3398,6 +3400,12 @@ class ObjectCalibrationDialog(wx.Dialog):
             else:
                 filename = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl")
                 reader = vtk.vtkSTLReader()
+
+                # XXX: If the user cancels the dialog for importing the coil mesh file, the current behavior is to
+                #      use the default object after all. A more logical behavior in that case would be to cancel the
+                #      whole object calibration, but implementing that would need larger refactoring.
+                #
+                self.use_default_object = True
         else:
             filename = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl")
             reader = vtk.vtkSTLReader()
@@ -3531,7 +3539,7 @@ class ObjectCalibrationDialog(wx.Dialog):
             self.obj_ref_id = 0
 
     def GetValue(self):
-        return self.obj_fiducials, self.obj_orients, self.obj_ref_id, self.obj_name, self.polydata
+        return self.obj_fiducials, self.obj_orients, self.obj_ref_id, self.obj_name, self.polydata, self.use_default_object
 
 class ICPCorregistrationDialog(wx.Dialog):
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -287,7 +287,7 @@ class InnerFoldPanel(wx.Panel):
 
         Publisher.sendMessage('Update serial port', serial_port=com_port)
 
-    def OnShowObject(self, evt=None, flag=None, obj_name=None, polydata=None):
+    def OnShowObject(self, evt=None, flag=None, obj_name=None, polydata=None, use_default_object=True):
         if not evt:
             if flag:
                 self.checkobj.Enable(True)
@@ -966,7 +966,7 @@ class NeuronavigationPanel(wx.Panel):
     def UpdateObjectRegistration(self, data=None):
         self.navigation.obj_reg = data
 
-    def UpdateTrackObjectState(self, evt=None, flag=None, obj_name=None, polydata=None):
+    def UpdateTrackObjectState(self, evt=None, flag=None, obj_name=None, polydata=None, use_default_object=True):
         self.navigation.track_obj = flag
 
     def UpdateSerialPort(self, serial_port):
@@ -1320,7 +1320,7 @@ class ObjectRegistrationPanel(wx.Panel):
             dialog = dlg.ObjectCalibrationDialog(self.nav_prop)
             try:
                 if dialog.ShowModal() == wx.ID_OK:
-                    self.obj_fiducials, self.obj_orients, self.obj_ref_mode, self.obj_name, polydata = dialog.GetValue()
+                    self.obj_fiducials, self.obj_orients, self.obj_ref_mode, self.obj_name, polydata, use_default_object = dialog.GetValue()
                     if np.isfinite(self.obj_fiducials).all() and np.isfinite(self.obj_orients).all():
                         self.checktrack.Enable(1)
                         Publisher.sendMessage('Update object registration',
@@ -1329,7 +1329,13 @@ class ObjectRegistrationPanel(wx.Panel):
                                               label=_("Ready"))
                         # Enable automatically Track object, Show coil and disable Vol. Camera
                         self.checktrack.SetValue(True)
-                        Publisher.sendMessage('Update track object state', flag=True, obj_name=self.obj_name, polydata=polydata)
+                        Publisher.sendMessage(
+                            'Update track object state',
+                            flag=True,
+                            obj_name=self.obj_name,
+                            polydata=polydata,
+                            use_default_object=use_default_object,
+                        )
                         Publisher.sendMessage('Change camera checkbox', status=False)
 
             except wx._core.PyAssertionError:  # TODO FIX: win64


### PR DESCRIPTION
- Previously, coil without handle was used to mark the target only if
  object calibration had not been done yet. After object calibration
  was done, the variable polydata stored the coil mesh that was selected
  by the user when doing the calibration, and hence that coil mesh
  (typically containing the handle) was used to mark the target.

- Change the logic to follow these rules:

  * When the default coil is selected in object calibration, use the
    default coil with a handle to mark the coil location, and default
	coil without a handle to mark the target.

  * When object calibration is not yet done, use default coil without
    a handle to mark the target.

  * When a custom coil is selected in object calibration, use the custom
    coil to mark both the coil location and the target, regardless of if
    the mesh contains handle or not. This is done because otherwise the user
    would need to select two custom meshes, one that is used to mark the coil
    location and another for the target.