### PR TITLE
FIX: Bug in task navigator: unselecting image fiducial does not work

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -320,7 +320,6 @@ class Navigation():
 
         self.image_fiducials = np.full([3, 3], np.nan)
         self.correg = None
-        self.current_coord = 0, 0, 0
         self.target = None
         self.obj_reg = None
         self.track_obj = False
@@ -719,6 +718,7 @@ class NeuronavigationPanel(wx.Panel):
 
         self.nav_status = False
         self.tracker_fiducial_being_set = None
+        self.current_coord = 0, 0, 0
 
         # Initialize list of buttons and numctrls for wx objects
         self.btns_set_fiducial = [None, None, None, None, None, None]
@@ -981,7 +981,7 @@ class NeuronavigationPanel(wx.Panel):
 
     def UpdateImageCoordinates(self, position):
         # TODO: Change from world coordinates to matrix coordinates. They are better for multi software communication.
-        self.navigation.current_coord = position
+        self.current_coord = position
 
         for m in [0, 1, 2]:
             if not self.btns_set_fiducial[m].GetValue():


### PR DESCRIPTION
* current_coord is not actually used by Navigator class, in which
  it resided previously. Instead, it is used by NeuroNavigationPanel
  when an image fiducial is unselected (the button for selecting
  the image fiducial is pressed twice). Previously, unselecting
  an image fiducial caused a crash due to not having current_coord
  variable in NeuroNavigationPanel. This patch moves it there to
  fix the bug.