### PR TITLE
MOD: Allow setting object fiducials using pedal

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -761,17 +761,38 @@ OBJA = wx.NewId()
 OBJC = wx.NewId()
 OBJF = wx.NewId()
 
-BTNS_OBJ = {OBJL: {0: _('Left')},
-            OBJR: {1: _('Right')},
-            OBJA: {2: _('Anterior')},
-            OBJC: {3: _('Center')},
-            OBJF: {4: _('Fixed')}}
-
-TIPS_OBJ = [_("Select left object fiducial"),
-            _("Select right object fiducial"),
-            _("Select anterior object fiducial"),
-            _("Select object center"),
-            _("Attach sensor to object")]
+OBJECT_FIDUCIALS = [
+    {
+        'fiducial_index': 0,
+        'button_id': OBJL,
+        'label': _('Left'),
+        'tip': _("Select left object fiducial"),
+    },
+    {
+        'fiducial_index': 1,
+        'button_id': OBJR,
+        'label': _('Right'),
+        'tip': _("Select right object fiducial"),
+    },
+    {
+        'fiducial_index': 2,
+        'button_id': OBJA,
+        'label': _('Anterior'),
+        'tip': _("Select anterior object fiducial"),
+    },
+    {
+        'fiducial_index': 3,
+        'button_id': OBJC,
+        'label': _('Center'),
+        'tip': _("Select object center"),
+    },
+    {
+        'fiducial_index': 4,
+        'button_id': OBJF,
+        'label': _('Fixed'),
+        'tip': _("Attach sensor to object"),
+    },
+]
 
 MTC_PROBE_NAME = "1Probe"
 MTC_REF_NAME = "2Ref"

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -161,9 +161,10 @@ class InnerFoldPanel(wx.Panel):
         fold_panel = fpb.FoldPanelBar(self, -1, wx.DefaultPosition,
                                       (10, 310), 0, fpb.FPB_SINGLE_FOLD)
 
-        # Initialize Tracker object here so that it is available to several panels.
+        # Initialize Tracker and PedalConnection objects here so that they are available to several panels.
         #
         tracker = Tracker()
+        pedal_connection = PedalConnection() if HAS_PEDAL_CONNECTION else None
 
         # Fold panel style
         style = fpb.CaptionBarStyle()
@@ -173,7 +174,7 @@ class InnerFoldPanel(wx.Panel):
 
         # Fold 1 - Navigation panel
         item = fold_panel.AddFoldPanel(_("Neuronavigation"), collapsed=True)
-        ntw = NeuronavigationPanel(item, tracker)
+        ntw = NeuronavigationPanel(item, tracker, pedal_connection)
 
         fold_panel.ApplyCaptionStyle(item, style)
         fold_panel.AddFoldPanelWindow(item, ntw, spacing=0,
@@ -182,7 +183,7 @@ class InnerFoldPanel(wx.Panel):
 
         # Fold 2 - Object registration panel
         item = fold_panel.AddFoldPanel(_("Object registration"), collapsed=True)
-        otw = ObjectRegistrationPanel(item, tracker)
+        otw = ObjectRegistrationPanel(item, tracker, pedal_connection)
 
         fold_panel.ApplyCaptionStyle(item, style)
         fold_panel.AddFoldPanelWindow(item, otw, spacing=0,
@@ -487,7 +488,7 @@ class ICP():
         self.icp_fre = None
 
 class NeuronavigationPanel(wx.Panel):
-    def __init__(self, parent, tracker):
+    def __init__(self, parent, tracker, pedal_connection):
         wx.Panel.__init__(self, parent)
         try:
             default_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
@@ -500,9 +501,9 @@ class NeuronavigationPanel(wx.Panel):
         self.__bind_events()
 
         # Initialize global variables
-        self.pedal_connection = PedalConnection() if HAS_PEDAL_CONNECTION else None
+        self.pedal_connection = pedal_connection
         self.navigation = Navigation(
-            pedal_connection=self.pedal_connection,
+            pedal_connection=pedal_connection,
         )
         self.icp = ICP()
         self.tracker = tracker
@@ -566,7 +567,7 @@ class NeuronavigationPanel(wx.Panel):
         txt_fre = wx.StaticText(self, -1, _('FRE:'))
         txt_icp = wx.StaticText(self, -1, _('Refine:'))
 
-        if self.pedal_connection is not None and self.pedal_connection.in_use:
+        if pedal_connection is not None and pedal_connection.in_use:
             txt_pedal_pressed = wx.StaticText(self, -1, _('Pedal pressed:'))
         else:
             txt_pedal_pressed = None
@@ -595,14 +596,14 @@ class NeuronavigationPanel(wx.Panel):
         self.checkbox_icp = checkbox_icp
 
         # An indicator for pedal trigger
-        if self.pedal_connection is not None and self.pedal_connection.in_use:
+        if pedal_connection is not None and pedal_connection.in_use:
             tooltip = wx.ToolTip(_(u"Is the pedal pressed"))
             checkbox_pedal_pressed = wx.CheckBox(self, -1, _(' '))
             checkbox_pedal_pressed.SetValue(False)
             checkbox_pedal_pressed.Enable(False)
             checkbox_pedal_pressed.SetToolTip(tooltip)
 
-            self.pedal_connection.add_callback('gui', checkbox_pedal_pressed.SetValue)
+            pedal_connection.add_callback('gui', checkbox_pedal_pressed.SetValue)
 
             self.checkbox_pedal_pressed = checkbox_pedal_pressed
         else:
@@ -636,7 +637,7 @@ class NeuronavigationPanel(wx.Panel):
                            (checkbox_icp, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL)])
 
         pedal_sizer = wx.FlexGridSizer(rows=1, cols=2, hgap=5, vgap=5)
-        if HAS_PEDAL_CONNECTION and self.pedal_connection.in_use:
+        if HAS_PEDAL_CONNECTION and pedal_connection.in_use:
             pedal_sizer.AddMany([(txt_pedal_pressed, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL),
                                 (checkbox_pedal_pressed, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL)])
 
@@ -985,7 +986,7 @@ class NeuronavigationPanel(wx.Panel):
 
 
 class ObjectRegistrationPanel(wx.Panel):
-    def __init__(self, parent, tracker):
+    def __init__(self, parent, tracker, pedal_connection):
         wx.Panel.__init__(self, parent)
         try:
             default_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
@@ -996,6 +997,7 @@ class ObjectRegistrationPanel(wx.Panel):
         self.coil_list = const.COIL
 
         self.tracker = tracker
+        self.pedal_connection = pedal_connection
 
         self.nav_prop = None
         self.obj_fiducials = None
@@ -1158,7 +1160,7 @@ class ObjectRegistrationPanel(wx.Panel):
     def OnLinkCreate(self, event=None):
 
         if self.tracker.IsTrackerInitialized():
-            dialog = dlg.ObjectCalibrationDialog(self.tracker)
+            dialog = dlg.ObjectCalibrationDialog(self.tracker, self.pedal_connection)
             try:
                 if dialog.ShowModal() == wx.ID_OK:
                     self.obj_fiducials, self.obj_orients, self.obj_ref_mode, self.obj_name, polydata, use_default_object = dialog.GetValue()


### PR DESCRIPTION
* Add OBJECT_FIDUCIALS dict to constants.py, replacing BTNS_OBJ
  and TIPS_OBJ, and facilitating cleaning up the code.

* Pass PedalConnection object to ObjectCalibrationDialog so that
  the pedal can be used for object calibration.

* Copy and slightly adapt the code that was used to set tracker
  fiducials using pedal (in OnTrackerFiducials in NeuronavigationPanel
  class) to do the same for object fiducials. Mark code duplication with
  TODO comment for later clean-up.

* Rename a function (OnGetObjectFiducials -> OnObjectFiducialButton),
  and rename a few variables (e.g., btn_id -> fiducial_index).