### PR TITLE
FIX: StopNavigation function when serial port connection has not been formed

### DIFF
--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -324,9 +324,10 @@ class Navigation():
         self.coord_queue.clear()
         self.coord_queue.join()
 
-        if self.SerialPortEnabled():
+        if self.serial_port_connection is not None:
             self.serial_port_connection.join()
 
+        if self.SerialPortEnabled():
             self.serial_port_queue.clear()
             self.serial_port_queue.join()
 


### PR DESCRIPTION
StopNavigation function is called, e.g., when InVesalius is quitted. If the
serial port was enabled in the UI but navigation had not been started, it
previously caused an error because serial_port_connection variable was None.