### PR TITLE
MOD: Allow selecting baud rate for serial port communication

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -830,3 +830,7 @@ TREKKER_CONFIG = {'seed_max': 1, 'step_size': 0.1, 'min_fod': 0.1, 'probe_qualit
 MARKER_FILE_MAGICK_STRING = "INVESALIUS3_MARKER_FILE_"
 CURRENT_MARKER_FILE_VERSION = 0
 WILDCARD_MARKER_FILES = _("Marker scanner coord files (*.mkss)|*.mkss") 
+
+# Serial port
+BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]
+BAUD_RATE_DEFAULT_SELECTION = 4

--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -266,7 +266,7 @@ def PlhSerialConnection(tracker_id):
     import serial
     from wx import ID_OK
     trck_init = None
-    dlg_port = dlg.SetCOMport()
+    dlg_port = dlg.SetCOMPort(select_baud_rate=False)
     if dlg_port.ShowModal() == ID_OK:
         com_port = dlg_port.GetValue()
         try:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -4322,7 +4322,8 @@ class SetNDIconfigs(wx.Dialog):
         self._init_gui()
 
     def serial_ports(self):
-        """ Lists serial port names and pre-select the description containing NDI
+        """
+        Lists serial port names and pre-select the description containing NDI
         """
         import serial.tools.list_ports
 
@@ -4430,13 +4431,16 @@ class SetNDIconfigs(wx.Dialog):
         return self.com_ports.GetString(self.com_ports.GetSelection()).encode(const.FS_ENCODE), fn_probe, fn_ref, fn_obj
 
 
-class SetCOMport(wx.Dialog):
-    def __init__(self, title=_("Select COM port")):
-        wx.Dialog.__init__(self, wx.GetApp().GetTopWindow(), -1, title, style=wx.DEFAULT_DIALOG_STYLE|wx.FRAME_FLOAT_ON_PARENT|wx.STAY_ON_TOP)
+class SetCOMPort(wx.Dialog):
+    def __init__(self, select_baud_rate, title=_("Select COM port")):
+        wx.Dialog.__init__(self, wx.GetApp().GetTopWindow(), -1, title, style=wx.DEFAULT_DIALOG_STYLE | wx.FRAME_FLOAT_ON_PARENT | wx.STAY_ON_TOP)
+
+        self.select_baud_rate = select_baud_rate
         self._init_gui()
 
     def serial_ports(self):
-        """ Lists serial port names
+        """
+        Lists serial port names
         """
         import serial.tools.list_ports
         if sys.platform.startswith('win'):
@@ -4446,12 +4450,26 @@ class SetCOMport(wx.Dialog):
         return ports
 
     def _init_gui(self):
-        self.com_ports = wx.ComboBox(self, -1, style=wx.CB_DROPDOWN|wx.CB_READONLY)
+        # COM port selection
         ports = self.serial_ports()
-        self.com_ports.Append(ports)
+        self.com_port_dropdown = wx.ComboBox(self, -1, choices=ports, style=wx.CB_DROPDOWN | wx.CB_READONLY)
+        self.com_port_dropdown.SetSelection(0)
 
-       # self.goto_orientation.SetSelection(cb_init)
+        com_port_text_and_dropdown = wx.BoxSizer(wx.VERTICAL)
+        com_port_text_and_dropdown.Add(wx.StaticText(self, wx.ID_ANY, "COM port"), 0, wx.TOP | wx.RIGHT,5)
+        com_port_text_and_dropdown.Add(self.com_port_dropdown, 0, wx.EXPAND)
 
+        # Baud rate selection
+        if self.select_baud_rate:
+            baud_rates_as_strings = [str(baud_rate) for baud_rate in const.BAUD_RATES]
+            self.baud_rate_dropdown = wx.ComboBox(self, -1, choices=baud_rates_as_strings, style=wx.CB_DROPDOWN | wx.CB_READONLY)
+            self.baud_rate_dropdown.SetSelection(const.BAUD_RATE_DEFAULT_SELECTION)
+
+            baud_rate_text_and_dropdown = wx.BoxSizer(wx.VERTICAL)
+            baud_rate_text_and_dropdown.Add(wx.StaticText(self, wx.ID_ANY, "Baud rate"), 0, wx.TOP | wx.RIGHT,5)
+            baud_rate_text_and_dropdown.Add(self.baud_rate_dropdown, 0, wx.EXPAND)
+
+        # OK and Cancel buttons
         btn_ok = wx.Button(self, wx.ID_OK)
         btn_ok.SetHelpText("")
         btn_ok.SetDefault()
@@ -4464,10 +4482,16 @@ class SetCOMport(wx.Dialog):
         btnsizer.AddButton(btn_cancel)
         btnsizer.Realize()
 
+        # Set up the main sizer
         main_sizer = wx.BoxSizer(wx.VERTICAL)
 
         main_sizer.Add((5, 5))
-        main_sizer.Add(self.com_ports, 1, wx.EXPAND|wx.LEFT|wx.RIGHT, 5)
+        main_sizer.Add(com_port_text_and_dropdown, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
+
+        if self.select_baud_rate:
+            main_sizer.Add((5, 5))
+            main_sizer.Add(baud_rate_text_and_dropdown, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
+
         main_sizer.Add((5, 5))
         main_sizer.Add(btnsizer, 0, wx.EXPAND)
         main_sizer.Add((5, 5))
@@ -4478,7 +4502,14 @@ class SetCOMport(wx.Dialog):
         self.CenterOnParent()
 
     def GetValue(self):
-        return self.com_ports.GetString(self.com_ports.GetSelection())
+        com_port = self.com_port_dropdown.GetString(self.com_port_dropdown.GetSelection())
+
+        if self.select_baud_rate:
+            baud_rate = self.baud_rate_dropdown.GetString(self.baud_rate_dropdown.GetSelection())
+        else:
+            baud_rate = None
+
+        return com_port, baud_rate
 
 
 class ManualWWWLDialog(wx.Dialog):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -287,12 +287,15 @@ class InnerFoldPanel(wx.Panel):
     def OnEnableSerialPort(self, evt, ctrl):
         if ctrl.GetValue():
             from wx import ID_OK
-            dlg_port = dlg.SetCOMPort(select_baud_rate=True)
+            dlg_port = dlg.SetCOMPort(select_baud_rate=False)
+
             if dlg_port.ShowModal() != ID_OK:
                 ctrl.SetValue(False)
                 return
 
-            com_port, baud_rate = dlg_port.GetValue()
+            com_port = dlg_port.GetValue()
+            baud_rate = 115200
+
             Publisher.sendMessage('Update serial port', serial_port_in_use=True, com_port=com_port, baud_rate=baud_rate)
         else:
             Publisher.sendMessage('Update serial port', serial_port_in_use=False)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -222,8 +222,8 @@ class InnerFoldPanel(wx.Panel):
         checkcamera.Bind(wx.EVT_CHECKBOX, self.OnVolumeCamera)
         self.checkcamera = checkcamera
 
-        # Check box to create markers from serial port
-        tooltip = wx.ToolTip(_("Enable serial port communication for creating markers"))
+        # Check box to use serial port to trigger pulse signal and create markers
+        tooltip = wx.ToolTip(_("Enable serial port communication to trigger pulse and create markers"))
         checkbox_serial_port = wx.CheckBox(self, -1, _('Serial port'))
         checkbox_serial_port.SetToolTip(tooltip)
         checkbox_serial_port.SetValue(False)
@@ -285,14 +285,17 @@ class InnerFoldPanel(wx.Panel):
                 self.checkobj.Enable(True)
 
     def OnEnableSerialPort(self, evt, ctrl):
-        com_port = None
         if ctrl.GetValue():
             from wx import ID_OK
-            dlg_port = dlg.SetCOMport()
-            if dlg_port.ShowModal() == ID_OK:
-                com_port = dlg_port.GetValue()
+            dlg_port = dlg.SetCOMPort(select_baud_rate=True)
+            if dlg_port.ShowModal() != ID_OK:
+                ctrl.SetValue(False)
+                return
 
-        Publisher.sendMessage('Update serial port', serial_port=com_port)
+            com_port, baud_rate = dlg_port.GetValue()
+            Publisher.sendMessage('Update serial port', serial_port_in_use=True, com_port=com_port, baud_rate=baud_rate)
+        else:
+            Publisher.sendMessage('Update serial port', serial_port_in_use=False)
 
     def OnShowObject(self, evt=None, flag=None, obj_name=None, polydata=None, use_default_object=True):
         if not evt:
@@ -490,7 +493,6 @@ class NeuronavigationPanel(wx.Panel):
         Publisher.subscribe(self.LoadImageFiducials, 'Load image fiducials')
         Publisher.subscribe(self.SetImageFiducial, 'Set image fiducial')
         Publisher.subscribe(self.SetTrackerFiducial, 'Set tracker fiducial')
-        Publisher.subscribe(self.UpdateSerialPort, 'Update serial port')
         Publisher.subscribe(self.UpdateTrackObjectState, 'Update track object state')
         Publisher.subscribe(self.UpdateImageCoordinates, 'Set cross focal point')
         Publisher.subscribe(self.OnDisconnectTracker, 'Disconnect tracker')
@@ -613,9 +615,6 @@ class NeuronavigationPanel(wx.Panel):
 
     def UpdateTrackObjectState(self, evt=None, flag=None, obj_name=None, polydata=None, use_default_object=True):
         self.navigation.track_obj = flag
-
-    def UpdateSerialPort(self, serial_port):
-        self.navigation.serial_port = serial_port
 
     def ResetICP(self):
         self.icp.ResetICP()

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -168,7 +168,9 @@ class Navigation():
         self.sleep_nav = const.SLEEP_NAVIGATION
 
         # Serial port
-        self.serial_port = None
+        self.serial_port_in_use = False
+        self.com_port = None
+        self.baud_rate = None
         self.serial_port_connection = None
 
         # During navigation
@@ -178,6 +180,7 @@ class Navigation():
 
     def __bind_events(self):
         Publisher.subscribe(self.CoilAtTarget, 'Coil at target')
+        Publisher.subscribe(self.UpdateSerialPort, 'Update serial port')
 
     def CoilAtTarget(self, state):
         self.coil_at_target = state
@@ -186,8 +189,10 @@ class Navigation():
         self.sleep_nav = sleep
         self.serial_port_connection.sleep_nav = sleep
 
-    def SerialPortEnabled(self):
-        return self.serial_port is not None
+    def UpdateSerialPort(self, serial_port_in_use, com_port=None, baud_rate=None):
+        self.serial_port_in_use = serial_port_in_use
+        self.com_port = com_port
+        self.baud_rate = baud_rate
 
     def SetReferenceMode(self, value):
         self.ref_mode_id = value
@@ -215,7 +220,7 @@ class Navigation():
         return fre, fre <= const.FIDUCIAL_REGISTRATION_ERROR_THRESHOLD
 
     def PedalStateChanged(self, state):
-        if state is True and self.coil_at_target and self.SerialPortEnabled():
+        if state is True and self.coil_at_target and self.serial_port_in_use:
             self.serial_port_connection.SendPulse()
 
     def StartNavigation(self, tracker):
@@ -227,7 +232,7 @@ class Navigation():
         if self.event.is_set():
             self.event.clear()
 
-        vis_components = [self.SerialPortEnabled(), self.view_tracts, self.peel_loaded]
+        vis_components = [self.serial_port_in_use, self.view_tracts, self.peel_loaded]
         vis_queues = [self.coord_queue, self.serial_port_queue, self.tracts_queue, self.icp_queue]
 
         Publisher.sendMessage("Navigation status", nav_status=True, vis_status=vis_components)
@@ -276,12 +281,13 @@ class Navigation():
 
         if not errors:
             #TODO: Test the serial port thread
-            if self.SerialPortEnabled():
+            if self.serial_port_in_use:
                 self.serial_port_connection = spc.SerialPortConnection(
-                    self.serial_port,
-                    self.serial_port_queue,
-                    self.event,
-                    self.sleep_nav,
+                    com_port=self.com_port,
+                    baud_rate=self.baud_rate,
+                    serial_port_queue=self.serial_port_queue,
+                    event=self.event,
+                    sleep_nav=self.sleep_nav,
                 )
                 self.serial_port_connection.Connect()
                 jobs_list.append(self.serial_port_connection)
@@ -327,7 +333,7 @@ class Navigation():
         if self.serial_port_connection is not None:
             self.serial_port_connection.join()
 
-        if self.SerialPortEnabled():
+        if self.serial_port_in_use:
             self.serial_port_queue.clear()
             self.serial_port_queue.join()
 
@@ -338,5 +344,5 @@ class Navigation():
             self.tracts_queue.clear()
             self.tracts_queue.join()
 
-        vis_components = [self.SerialPortEnabled(), self.view_tracts,  self.peel_loaded]
+        vis_components = [self.serial_port_in_use, self.view_tracts,  self.peel_loaded]
         Publisher.sendMessage("Navigation status", nav_status=False, vis_status=vis_components)


### PR DESCRIPTION
Other changes:

- Disallow not selecting COM port in COM port selection dialog by
  defaulting to the first COM port in the list. Previously, it was
  possible to pass an empty string as the COM port by not making
  the selection.

- When the "Serial port" checkbox is pressed and the user presses
  "Cancel" in the dialog that is opened, uncheck the "Serial port" checkbox
  instead of keeping it checked.

- Be explicit about if the serial port is in use or not, instead of inferring
  it from the COM port variable being set or not.

- Pass the serial port parameters (COM port, baud rate) directly to the
  Navigation class, instead of passing them through NeuronavigationPanel.

- Minor improvements to style and naming of the variables.