### PR TITLE
ADD: Script for sending events to InVesalius via Socket.IO

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,3 +1,7 @@
+aioconsole==0.3.2
 mido==1.2.10
+nest-asyncio==1.5.1
 python-rtmidi==1.4.9
 python-socketio[client]==5.3.0
+requests==2.26.0
+uvicorn[standard]==0.15.0

--- a/scripts/invesalius_server.py
+++ b/scripts/invesalius_server.py
@@ -4,10 +4,6 @@
 # This scripts allows sending events to InVesalius via Socket.IO, mimicking InVesalius's
 # internal communication. It can be useful for developing and debugging InVesalius.
 #
-# Install the requirements by running:
-#
-#     pip install aioconsole nest-asyncio python-socketio[client] requests uvicorn[standard]
-#
 # Example usage:
 #
 #     - (In console window 1) Run the script by: python scripts/invesalius_server.py 5000


### PR DESCRIPTION
The scripts allows sending events to InVesalius via Socket.IO, mimicking InVesalius's internal communication.
It can be useful for developing and debugging InVesalius.