### PR TITLE
Markers file magic string is now prepended with two hashtags.

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -827,7 +827,7 @@ TREKKER_CONFIG = {'seed_max': 1, 'step_size': 0.1, 'min_fod': 0.1, 'probe_qualit
                   'write_interval': 50, 'numb_threads': '', 'max_lenth': 200,
                   'min_lenth': 20, 'max_sampling_step': 100}
 
-MARKER_FILE_MAGICK_STRING = "INVESALIUS3_MARKER_FILE_"
+MARKER_FILE_MAGICK_STRING = "##INVESALIUS3_MARKER_FILE_"
 CURRENT_MARKER_FILE_VERSION = 0
 WILDCARD_MARKER_FILES = _("Marker scanner coord files (*.mkss)|*.mkss") 
 


### PR DESCRIPTION
Markers file magic string is now prepended with two hashtags. Thus it will be treated as a comment by parsers that use hashtags for comments.