### PR TITLE
FIX: Add pixel spacing in inv to voxel coordinate transformation

### DIFF
--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -595,7 +595,7 @@ def convert_invesalius_to_voxel(position):
     :return: a vector of 3 coordinates in the voxel space
     """
     slice = sl.Slice()
-    return np.array((position[0], (slice.spacing[1]*slice.matrix.shape[1] - 1) - position[1], position[2]))
+    return np.array((position[0], slice.spacing[1]*(slice.matrix.shape[1] - 1) - position[1], position[2]))
 
 
 def convert_invesalius_to_world(position, orientation):


### PR DESCRIPTION
When converting from invesalius to voxel coordinate systems, a shift in Y coordinate is required. This shift depends on the pixel spacing and on a single voxel translation to keep the range of both coordinate systems from 0 to maximum.

The transformation is:
voxel_y = SPACING*(SHAPE - 1) - invesalius_y
the -1 is to ensure that both spaces voxel and invesalius start from 0.. 

example: consider an image with Y voxel spacing of 0.488 mm and 512 voxels. In invesalius space the coordinates will range from 0 to 249.5 mm [0.488*(512-1)]. To keep the same range and convert to the voxel space, we:

voxel_y = SPACING*(SHAPE - 1) - invesalius_y
voxel_y = 249.5 - invesalius_y

max_voxel_y = 249.5 - 0 = 249.5
min_voxel_y = 249.5 - 249.5 = 0