### PR TITLE
FIX: Save affine in project and refactor instances of affine creation

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -4200,37 +4200,23 @@ class GoToDialogScannerCoord(wx.Dialog):
         self.__bind_events()
 
         btn_ok.Bind(wx.EVT_BUTTON, self.OnOk)
-        Publisher.sendMessage('Get affine matrix')
 
     def __bind_events(self):
         Publisher.subscribe(self.SetNewFocalPoint, 'Cross focal point')
-        Publisher.subscribe(self.UpdateAffineMatrix, 'Update affine matrix')
-
-    def UpdateAffineMatrix(self, affine):
-        self.affine = affine
 
     def SetNewFocalPoint(self, coord, spacing):
         Publisher.sendMessage('Update cross pos', coord=self.result*spacing)
 
     def OnOk(self, evt):
-        from numpy.linalg import inv
         import invesalius.data.slice_ as slc
         try:
-            #get affine from image import
-            if self.affine is not None:
-                affine = self.affine
-            #get affine from project
-            else:
-                from invesalius.project import Project
-                affine = Project().affine
-
             point = [float(self.goto_sagital.GetValue()),
                      float(self.goto_coronal.GetValue()),
                      float(self.goto_axial.GetValue())]
 
             # transformation from scanner coordinates to inv coord system
-            affine = inv(affine)
-            self.result = np.dot(affine[:3, :3], np.transpose(point[0:3])) + affine[:3, 3]
+            affine_inverse = np.linalg.inv(slc.Slice().affine)
+            self.result = np.dot(affine_inverse[:3, :3], np.transpose(point[0:3])) + affine_inverse[:3, 3]
             self.result[1] = slc.Slice().GetMaxSliceNumber(const.CORONAL_STR) - self.result[1]
 
             Publisher.sendMessage('Update status text in GUI', label=_("Calculating the transformation ..."))

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -892,7 +892,7 @@ class MenuBar(wx.MenuBar):
         sub(self.OnEnableState, "Enable state project")
         sub(self.OnEnableUndo, "Enable undo")
         sub(self.OnEnableRedo, "Enable redo")
-        sub(self.OnEnableGotoCoord, "Update affine matrix")
+        sub(self.OnEnableGotoCoord, "Enable Go-to-Coord")
         sub(self.OnEnableNavigation, "Navigation status")
 
         sub(self.OnAddMask, "Add mask")
@@ -1242,15 +1242,13 @@ class MenuBar(wx.MenuBar):
         else:
             self.FindItemById(wx.ID_REDO).Enable(False)
 
-    def OnEnableGotoCoord(self, affine):
+    def OnEnableGotoCoord(self, status=True):
         """
-        Disable goto coord either if there is no affine matrix or affine is wrongly imported.
-        :param status: Affine matrix status
+        Enable or disable goto coord depending on the imported affine matrix.
+        :param status: True for enabling and False for disabling the Go-To-Coord
         """
-        if affine is not None:
-            self.FindItemById(const.ID_GOTO_COORD).Enable(True)
-        else:
-            self.FindItemById(const.ID_GOTO_COORD).Enable(False)
+
+        self.FindItemById(const.ID_GOTO_COORD).Enable(status)
 
     def OnEnableNavigation(self, nav_status, vis_status):
         """

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -329,8 +329,6 @@ class Project(metaclass=Singleton):
 
         if project.get("affine", ""):
             self.affine = project["affine"]
-            Publisher.sendMessage('Update affine matrix',
-                                  affine=np.asarray(self.affine).reshape(4, 4))
 
         # Opening the masks
         self.mask_dict = TwoWaysDictionary()


### PR DESCRIPTION
Fixed the issue that affine was not being saved with the project. Also simplified instances of affine creation in OtherProjects.

This causes the Go-To-Scanner-Coord not to work anymore. This is a minor issue and will be solved later. But this PR needs to be applied urgently due to its criticality.