### PR TITLE
FIX: Error raised if 3D not created before when adding a peeling surface

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1455,7 +1455,8 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.object_orientation_torus_actor)
             self.ren.RemoveActor(self.obj_projection_arrow_actor)
             self.actor_peel = None
-            self.ball_actor.SetVisibility(1)
+            if self.ball_actor:
+                self.ball_actor.SetVisibility(1)
 
         if flag and actor:
             self.ren.AddActor(actor)


### PR DESCRIPTION
The ball actor visibility was being set when adding a peeled surface even after the ball_actor was created, which raised an error. This pull request fix this issue.