### PR TITLE
ADD: Selection of navigation mode, affecting triggering of stimulation pulse

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -663,6 +663,9 @@ MARKER_SIZE = 2
 CALIBRATION_TRACKER_SAMPLES = 10
 FIDUCIAL_REGISTRATION_ERROR_THRESHOLD = 3.0
 
+NAVIGATION_MODES = [_("Target-based navigation"),
+                    _("Free navigation")]
+
 SELECT = 0
 MTC = 1
 FASTRAK = 2


### PR DESCRIPTION
Two navigation modes are available, "Target-based navigation", which
only allows triggering stimulation pulse if the coil is at the target,
and "Free navigation", which allows triggering the pulse regardless
of the coil location.

Note that in "Free navigation" mode, a target can still be set and used
for navigating. For added safety, the target feature could be disabled
completely in that mode to prevent the user from getting confused about
which mode they are in. However, that is not done by this patch.