### PR TITLE
FIX: Selecting COM port in UI

### DIFF
--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -268,9 +268,11 @@ def PlhSerialConnection(tracker_id):
     trck_init = None
     dlg_port = dlg.SetCOMPort(select_baud_rate=False)
     if dlg_port.ShowModal() == ID_OK:
-        com_port = dlg_port.GetValue()
+        com_port = dlg_port.GetCOMPort()
+        baud_rate = 115200
+
         try:
-            trck_init = serial.Serial(com_port, baudrate=115200, timeout=0.03)
+            trck_init = serial.Serial(com_port, baudrate=baud_rate, timeout=0.03)
 
             if tracker_id == 2:
                 # Polhemus FASTRAK needs configurations first

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -4487,15 +4487,16 @@ class SetCOMPort(wx.Dialog):
 
         self.CenterOnParent()
 
-    def GetValue(self):
+    def GetCOMPort(self):
         com_port = self.com_port_dropdown.GetString(self.com_port_dropdown.GetSelection())
+        return com_port
 
-        if self.select_baud_rate:
-            baud_rate = self.baud_rate_dropdown.GetString(self.baud_rate_dropdown.GetSelection())
-        else:
-            baud_rate = None
+    def GetBaudRate(self):
+        if not self.select_baud_rate:
+            return None
 
-        return com_port, baud_rate
+        baud_rate = self.baud_rate_dropdown.GetString(self.baud_rate_dropdown.GetSelection())
+        return baud_rate
 
 
 class ManualWWWLDialog(wx.Dialog):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -293,7 +293,7 @@ class InnerFoldPanel(wx.Panel):
                 ctrl.SetValue(False)
                 return
 
-            com_port = dlg_port.GetValue()
+            com_port = dlg_port.GetCOMPort()
             baud_rate = 115200
 
             Publisher.sendMessage('Update serial port', serial_port_in_use=True, com_port=com_port, baud_rate=baud_rate)


### PR DESCRIPTION
Previously, SetCOMPort.GetValue returned a pair (com_port, baud_rate),
which needed to be unpacked into two variables, but the unpacking was
not done.

Change the API so that the dialog object has separate functions GetCOMPort
and GetBaudRate, thus removing the need to unpack the return value.