### PR TITLE
FIX: Coil registration had wrong minus in Z coord

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -3604,7 +3604,6 @@ class ObjectCalibrationDialog(wx.Dialog):
                 coord = coord_raw[self.obj_ref_id, :]
         else:
             coord = coord_raw[0, :]
-        coord[2] = -coord[2]
 
         if fiducial_index == 3:
             coord = np.zeros([6,])


### PR DESCRIPTION
Removes a minus multiplication in the dialog for object registration that was causing all object registrations to be wrong.

The fix was tested with Polaris and Optitrack cameras.