### PR TITLE
FIX: updates render with refresh only in win

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1845,8 +1845,10 @@ class Viewer(wx.Panel):
         # Need to be outside condition for sphere marker position update
         # self.ren.ResetCameraClippingRange()
         # self.ren.ResetCamera()
-        #self.interactor.Render()
-        self.Refresh()
+        if sys.platform == 'win32':
+            self.Refresh()
+        else:
+            self.interactor.Render()
 
     def OnExportSurface(self, filename, filetype):
         if filetype not in (const.FILETYPE_STL,


### PR DESCRIPTION
self.Refresh() is not updating the 3D view in unix. 
self.interactor.Render() is slower than Refresh() thats why I created the condition.