### PR TITLE
FIX: transforms the polydata of imported surface to invesalius space

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -361,6 +361,7 @@ class SurfaceManager():
             transformFilter.SetInputData(polydata)
             transformFilter.Update()
             polydata = transformFilter.GetOutput()
+            self.ConvertToInV = False
 
         normals = vtk.vtkPolyDataNormals()
         normals.SetInputData(polydata)

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -160,7 +160,7 @@ class SurfaceManager():
     def __init__(self):
         self.actors_dict = {}
         self.last_surface_index = 0
-        self.convert2inv = None
+        self.ConvertToInV = None
         self.__bind_events()
 
         self._default_parameters = {
@@ -207,7 +207,7 @@ class SurfaceManager():
 
         Publisher.subscribe(self.OnImportSurfaceFile, 'Import surface file')
 
-        Publisher.subscribe(self.UpdateConvert2InvFlag, 'Update convert2inv flag')
+        Publisher.subscribe(self.UpdateConvertToInvFlag, 'Update ConvertToInV flag')
 
         Publisher.subscribe(self.CreateSurfaceFromPolydata, 'Create surface from polydata')
 
@@ -337,12 +337,30 @@ class SurfaceManager():
             name = os.path.splitext(os.path.split(filename)[-1])[0]
             self.CreateSurfaceFromPolydata(polydata, name=name, scalar=scalar)
 
-    def UpdateConvert2InvFlag(self, convert2inv=False):
-        self.convert2inv = convert2inv
+    def UpdateConvertToInvFlag(self, ConvertToInV=False):
+        self.ConvertToInV = ConvertToInV
 
     def CreateSurfaceFromPolydata(self, polydata, overwrite=False, index=None,
                                   name=None, colour=None, transparency=None,
                                   volume=None, area=None, scalar=False):
+        if self.ConvertToInV:
+            # convert between invesalius and world space with shift in the Y coordinate
+            matrix_shape = sl.Slice().matrix.shape
+            spacing = sl.Slice().spacing
+            img_shift = spacing[1] * (matrix_shape[1] - 1)
+            affine = sl.Slice().affine.copy()
+            affine[1, -1] -= img_shift
+            affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(affine)
+
+            polydata_transform = vtk.vtkTransform()
+            polydata_transform.PostMultiply()
+            polydata_transform.Concatenate(affine_vtk)
+
+            transformFilter = vtk.vtkTransformPolyDataFilter()
+            transformFilter.SetTransform(polydata_transform)
+            transformFilter.SetInputData(polydata)
+            transformFilter.Update()
+            polydata = transformFilter.GetOutput()
 
         normals = vtk.vtkPolyDataNormals()
         normals.SetInputData(polydata)
@@ -361,21 +379,6 @@ class SurfaceManager():
         actor = vtk.vtkActor()
         actor.SetMapper(mapper)
         actor.GetProperty().SetBackfaceCulling(1)
-
-        if self.convert2inv:
-            # convert between invesalius and world space with shift in the Y coordinate
-            affine = sl.Slice().affine
-            # TODO: Check that this is needed with the new way of using affine
-            #  now the affine should be at least the identity(4) and never None
-            if affine is not None:
-                matrix_shape = sl.Slice().matrix.shape
-                spacing = sl.Slice().spacing
-                img_shift = spacing[1] * (matrix_shape[1] - 1)
-                affine = sl.Slice().affine.copy()
-                affine[1, -1] -= img_shift
-                affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(affine)
-
-                actor.SetUserMatrix(affine_vtk)
 
         if overwrite:
             if index is None:
@@ -458,7 +461,7 @@ class SurfaceManager():
         Surface.general_index = -1
 
         self.affine_vtk = None
-        self.convert2inv = False
+        self.ConvertToInV = False
 
 
     def OnSelectSurface(self, surface_index):

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -28,6 +28,7 @@ except ImportError:
 
 import wx
 import wx.grid
+import numpy as np
 try:
     import wx.lib.agw.flatnotebook as fnb
 except ImportError:
@@ -740,8 +741,9 @@ class SurfaceButtonControlPanel(wx.Panel):
     def OnOpenMesh(self):
         filename = dlg.ShowImportMeshFilesDialog()
         if filename:
-            convert2inv = dlg.ImportMeshCoordSystem()
-            Publisher.sendMessage('Update convert2inv flag', convert2inv=convert2inv)
+            if not np.allclose(slice_.Slice().affine, np.eye(4)):
+                ConvertToInV = dlg.ImportMeshCoordSystem()
+                Publisher.sendMessage('Update ConvertToInV flag', ConvertToInV=ConvertToInV)
             Publisher.sendMessage('Import surface file', filename=filename)
 
 


### PR DESCRIPTION
- applies the affine transformation to polydata instead of the actor
- Shows ImportMeshCoordSystem dialog only if affine is not identity