### PR TITLE
Integrate orientation

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -678,7 +678,7 @@ class Viewer(wx.Panel):
                 marker_id=ball_id,
                 size=size,
                 colour=colour,
-                coord=position,
+                coord=position + direction,
                 arrow_flag=arrow_flag,
             )
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -670,7 +670,7 @@ class Viewer(wx.Panel):
             size = marker["size"]
             colour = marker["colour"]
             position = marker["position"]
-            direction = marker["direction"]
+            orientation = marker["orientation"]
             target = marker["target"]
             arrow_flag = marker["arrow_flag"]
 
@@ -678,12 +678,12 @@ class Viewer(wx.Panel):
                 marker_id=ball_id,
                 size=size,
                 colour=colour,
-                coord=position + direction,
+                coord=position + orientation,
                 arrow_flag=arrow_flag,
             )
 
             if target:
-                Publisher.sendMessage('Update target', coord=position + direction)
+                Publisher.sendMessage('Update target', coord=position + orientation)
                 target_selected = True
 
         if not target_selected:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -678,7 +678,8 @@ class Viewer(wx.Panel):
                 marker_id=ball_id,
                 size=size,
                 colour=colour,
-                coord=position + orientation,
+                position=position,
+                orientation=orientation,
                 arrow_flag=arrow_flag,
             )
 
@@ -691,21 +692,21 @@ class Viewer(wx.Panel):
 
         self.UpdateRender()
 
-    def AddMarker(self, marker_id, size, colour, coord, arrow_flag):
+    def AddMarker(self, marker_id, size, colour, position, orientation, arrow_flag):
         """
         Markers created by navigation tools and rendered in volume viewer.
         """
         self.marker_id = marker_id
-        coord_flip = list(coord)
-        coord_flip[1] = -coord_flip[1]
+        position_flip = list(position)
+        position_flip[1] = -position_flip[1]
 
         if arrow_flag:
             """
             Markers arrow with orientation created by navigation tools and rendered in volume viewer.
             """
-            marker_actor = self.CreateActorArrow(coord_flip[:3], coord_flip[3:6], colour, const.ARROW_MARKER_SIZE)
+            marker_actor = self.CreateActorArrow(position_flip, orientation, colour, const.ARROW_MARKER_SIZE)
         else:
-            marker_actor = self.CreateActorBall(coord_flip[:3], colour, size)
+            marker_actor = self.CreateActorBall(position_flip, colour, size)
 
         # adding a new actor for the marker
         self.static_markers.append(marker_actor)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1766,13 +1766,14 @@ class MarkersPanel(wx.Panel):
 
     def UpdateMarkerOrientation(self, marker_id=None):
         list_index = marker_id if marker_id else 0
-        marker = self.markers[list_index].coord
-        dialog = dlg.SetCoilOrientationDialog(marker=marker)
+        position = self.markers[list_index].position
+        orientation = self.markers[list_index].orientation
+        dialog = dlg.SetCoilOrientationDialog(marker=position+orientation)
 
         if dialog.ShowModal() == wx.ID_OK:
-            marker[3], marker[4], marker[5] = dialog.GetValue()
+            orientation = dialog.GetValue()
             Publisher.sendMessage('Update target orientation',
-                                  target_id=marker_id, orientation=[marker[3], marker[4], marker[5]])
+                                  target_id=marker_id, orientation=list(orientation))
         dialog.Destroy()
 
     def SetMarkers(self, markers):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1773,12 +1773,12 @@ class MarkersPanel(wx.Panel):
             size = marker["size"]
             colour = marker["colour"]
             position = marker["position"]
-            direction = marker["direction"]
+            orientation = marker["orientation"]
 
             self.CreateMarker(
                 size=size,
                 colour=colour,
-                coord=position + direction,
+                coord=position + orientation,
             )
 
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1621,7 +1621,7 @@ class MarkersPanel(wx.Panel):
         Publisher.sendMessage('Update tracker fiducials matrix',
                               matrix_tracker_fiducials=matrix_tracker_fiducials)
 
-        target_coord = self.markers[index].coord[:3]
+        target_coord = self.markers[index].position
         target = dcr.image_to_tracker(self.navigation.m_change, target_coord, self.icp)
 
         Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=target.tolist())

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1385,6 +1385,7 @@ class MarkersPanel(wx.Panel):
         Publisher.subscribe(self.UpdateNavigationStatus, 'Navigation status')
         Publisher.subscribe(self.UpdateSeedCoordinates, 'Update tracts')
         Publisher.subscribe(self.OnChangeCurrentSession, 'Current session changed')
+        Publisher.subscribe(self.UpdateMarkerOrientation, 'Open marker orientation dialog')
 
     def __find_target_marker(self):
         """
@@ -1740,6 +1741,17 @@ class MarkersPanel(wx.Panel):
 
     def OnChangeCurrentSession(self, new_session_id):
         self.current_session = new_session_id
+
+    def UpdateMarkerOrientation(self, marker_id=None):
+        # self.lc.GetFocusedItem()
+        list_index = marker_id if marker_id else 0
+        marker = self.markers[list_index].coord
+        dialog = dlg.SetCoilOrientationDialog(marker=marker)
+
+        if dialog.ShowModal() == wx.ID_OK:
+            marker[3], marker[4], marker[5] = dialog.GetValue()
+            self.CreateMarker(marker)
+        dialog.Destroy()
 
     def CreateMarker(self, coord=None, colour=None, size=None, label='*', is_target=False, seed=None, session_id=None):
         new_marker = self.Marker()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -21,7 +21,6 @@ import dataclasses
 from functools import partial
 import itertools
 import time
-import threading
 
 import nibabel as nb
 import numpy as np

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1407,12 +1407,20 @@ class MarkersPanel(wx.Panel):
         selection = []
 
         next = self.lc.GetFirstSelected()
-               
+
         while next != -1:
             selection.append(next)
             next = self.lc.GetNextSelected(next)
 
         return selection
+
+    def __delete_all_markers(self):
+        """
+        Delete all markers
+        """
+        for i in reversed(range(len(self.markers))):
+            del self.markers[i]
+            self.lc.DeleteItem(i)
 
     def __delete_multiple_markers(self, index):
         """
@@ -1751,7 +1759,6 @@ class MarkersPanel(wx.Panel):
 
         if dialog.ShowModal() == wx.ID_OK:
             marker[3], marker[4], marker[5] = dialog.GetValue()
-            self.CreateMarker(marker)
             Publisher.sendMessage('Update target orientation',
                                   target_id=marker_id, orientation=[marker[3], marker[4], marker[5]])
         dialog.Destroy()
@@ -1761,16 +1768,13 @@ class MarkersPanel(wx.Panel):
         Set all markers, overwriting the previous markers.
         """
 
-        index = range(len(self.markers))
-        self.__delete_multiple_markers(index)
+        self.__delete_all_markers()
+
         for marker in markers:
-            ball_id = marker["ball_id"]
             size = marker["size"]
             colour = marker["colour"]
             position = marker["position"]
             direction = marker["direction"]
-            target = marker["target"]
-            arrow_flag = marker["arrow_flag"]
 
             self.CreateMarker(
                 size=size,

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -215,10 +215,10 @@ class Navigation(metaclass=Singleton):
     def GetReferenceMode(self):
         return self.ref_mode_id
 
-    def SetImageFiducial(self, fiducial_index, coord):
-        self.image_fiducials[fiducial_index, :] = coord
+    def SetImageFiducial(self, fiducial_index, position):
+        self.image_fiducials[fiducial_index, :] = position
 
-        print("Set image fiducial {} to coordinates {}".format(fiducial_index, coord))
+        print("Set image fiducial {} to coordinates {}".format(fiducial_index, position))
 
     def AreImageFiducialsSet(self):
         return not np.isnan(self.image_fiducials).any()

--- a/invesalius/net/neuronavigation_api.py
+++ b/invesalius/net/neuronavigation_api.py
@@ -122,6 +122,10 @@ class NeuronavigationApi(metaclass=Singleton):
 
     def __set_callbacks(self, connection):
         connection.set_callback__set_markers(self.set_markers)
+        connection.set_callback__open_orientation_dialog(self.open_orienation_dialog)
+
+    def open_orienation_dialog(self, target_id):
+        Publisher.sendMessage('Open marker orientation dialog', marker_id=target_id)
 
     def set_markers(self, markers):
         Publisher.sendMessage('Set markers', markers=markers)

--- a/invesalius/net/neuronavigation_api.py
+++ b/invesalius/net/neuronavigation_api.py
@@ -18,7 +18,9 @@
 # --------------------------------------------------------------------------
 
 from invesalius.pubsub import pub as Publisher
-from invesalius.utils import Singleton
+from invesalius.utils import Singleton, debug
+
+import wx
 
 import numpy as np
 from vtkmodules.numpy_interface import dataset_adapter
@@ -134,7 +136,7 @@ class NeuronavigationApi(metaclass=Singleton):
         connection.set_callback__open_orientation_dialog(self.open_orientation_dialog)
 
     def open_orientation_dialog(self, target_id):
-        Publisher.sendMessage('Open marker orientation dialog', marker_id=target_id)
+        wx.CallAfter(Publisher.sendMessage, 'Open marker orientation dialog', marker_id=target_id)
 
     def set_markers(self, markers):
-        Publisher.sendMessage('Set markers', markers=markers)
+        wx.CallAfter(Publisher.sendMessage, 'Set markers', markers=markers)

--- a/invesalius/net/neuronavigation_api.py
+++ b/invesalius/net/neuronavigation_api.py
@@ -1,10 +1,10 @@
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
 # Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
 # Homepage:     http://www.softwarepublico.gov.br
 # Contact:      invesalius@cti.gov.br
 # License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 #    Este programa e software livre; voce pode redistribui-lo e/ou
 #    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
 #    publicada pela Free Software Foundation; de acordo com a versao 2
@@ -15,13 +15,14 @@
 #    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton
 
 import numpy as np
 from vtkmodules.numpy_interface import dataset_adapter
+
 
 class NeuronavigationApi(metaclass=Singleton):
     """
@@ -64,8 +65,16 @@ class NeuronavigationApi(metaclass=Singleton):
     def __bind_events(self):
         Publisher.subscribe(self.update_coil_at_target, 'Coil at target')
         Publisher.subscribe(self.update_focus, 'Set cross focal point')
+        Publisher.subscribe(self.update_target_orientation, 'Update target orientation')
 
     # Functions for InVesalius to send updates.
+
+    def update_target_orientation(self, target_id, orientation):
+        if self.connection is not None:
+            self.connection.update_target_orientation(
+                target_id=target_id,
+                orientation=orientation
+            )
 
     # TODO: Not the cleanest API; for an example of a better API, see update_coil_pose
     #   below, for which position and orientation are sent separately. Changing this
@@ -122,9 +131,9 @@ class NeuronavigationApi(metaclass=Singleton):
 
     def __set_callbacks(self, connection):
         connection.set_callback__set_markers(self.set_markers)
-        connection.set_callback__open_orientation_dialog(self.open_orienation_dialog)
+        connection.set_callback__open_orientation_dialog(self.open_orientation_dialog)
 
-    def open_orienation_dialog(self, target_id):
+    def open_orientation_dialog(self, target_id):
         Publisher.sendMessage('Open marker orientation dialog', marker_id=target_id)
 
     def set_markers(self, markers):


### PR DESCRIPTION
Adds neuronavigation_api integration with setting marker orientation. task_navigator also now subscribes to set markers so its marker state stays in sync with viewer_volume marker state. In addition, now viewer_volume correctly sets orientation when creating markers that already have an orientation set. 