### PR TITLE
FIX: Import MRI with float64 by rescaling pixel values

### DIFF
--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -522,8 +522,13 @@ def img2memmap(group):
     temp_file = tempfile.mktemp()
 
     data = group.get_data()
-    # Normalize image pixel values and convert to int16
-    #  data = imgnormalize(data)
+
+    # if scalar range is larger than uint16 maximum number, the image needs
+    # to be rescalaed so that no negative values are created when converting to int16
+    # maximum of 10000 was selected arbitrarily by testing with one MRI example
+    # alternatively could test if "data.dtype == 'float64'" but maybe it is too specific
+    if numpy.ptp(data) > (2**16/2-1):
+        data = image_normalize(data, min_=0, max_=10000, output_dtype=np.int16)
 
     # Convert RAS+ to default InVesalius orientation ZYX
     data = numpy.swapaxes(data, 0, 2)


### PR DESCRIPTION
Fix the import of MRI images with float64 (possibly any other float). Now, when importing a NIFTI file, we check if the range of pixel values exceed the limit of uint16 precision. If it exceeds, we rescale the pixel range to allow proper conversion to int16. Tested with a three different MRIs from different scanners.