### PR TITLE
ADD: Targeting robot with neuronavigation

### DIFF
--- a/invesalius/data/coregistration.py
+++ b/invesalius/data/coregistration.py
@@ -107,20 +107,25 @@ def tracker_to_image(m_change, m_probe_ref, r_obj_img, m_obj_raw, s0_dyn):
 
 
 def image_to_tracker(m_change, coord_raw, target, icp, obj_data):
-    """Compute the transformation matrix to the tracker coordinate system
+    """Compute the transformation matrix to the tracker coordinate system.
+    The transformation matrix is splitted in two steps, one for rotation and one for translation
 
-    :param m_change: Corregistration transformation obtained from fiducials
+    :param m_change: Coregistration transformation obtained from fiducials.
+                        Transforms from tracker coordinate system in head base to img coordinate system
     :type m_change: numpy.ndarray
+    :param coord_raw: Probe, head and coil in tracker coordinate system
+    :type target: numpy.ndarray
     :param target: Target in invesalius coordinate system
     :type target: numpy.ndarray
     :param icp: ICP transformation matrix
     :type icp: numpy.ndarray
+    :param obj_data: Transformations matrices for coil
+    :type obj_data: list of numpy.ndarray
 
-    :return: 4 x 4 numpy double array
+    :return: The transformation matrices from invesalius coordinate system to tracker coordinate system
     :rtype: numpy.ndarray
     """
     t_obj_raw, s0_raw, r_s0_raw, s0_dyn, m_obj_raw, r_obj_img = obj_data
-    #position
     m_target_in_image = dco.coordinates_to_transformation_matrix(
         position=target[:3],
         orientation=target[3:],
@@ -128,12 +133,14 @@ def image_to_tracker(m_change, coord_raw, target, icp, obj_data):
     )
     if icp.use_icp:
         m_target_in_image = bases.inverse_transform_icp(m_target_in_image, icp.m_icp)
+
+    # transform from invesalius coordinate system to tracker coordinate system. This transformation works from for translation
     m_trk = np.linalg.inv(m_change) @ m_target_in_image
 
     # invert y coordinate
     m_trk_flip = m_trk.copy()
     m_trk_flip[2, -1] = -m_trk_flip[2, -1]
-    #rotation
+    # finds the inverse rotation matrix from invesalius coordinate system to head base in tracker coordinate system
     m_probe_ref = s0_dyn @ m_obj_raw @ np.linalg.inv(r_obj_img) @ m_target_in_image @ np.linalg.inv(m_obj_raw)
     m_trk_flip[:3, :3] = m_probe_ref[:3, :3]
 
@@ -142,17 +149,18 @@ def image_to_tracker(m_change, coord_raw, target, icp, obj_data):
         orientation=coord_raw[1, 3:],
         axes='rzyx',
     )
-    # transform from head space to tracker space
+    # transform from head base to raw tracker coordinate system
     m_probe = m_ref @ m_trk_flip
     t_probe = np.identity(4)
     t_probe[:, -1] = m_probe[:, -1]
     r_probe = np.identity(4)
     r_probe[:, :3] = m_probe[:, :3]
-    # transform object center to raw marker coordinate
+    # translate object center to raw tracker coordinate system
     t_offset_aux = np.linalg.inv(r_s0_raw) @ r_probe @ t_obj_raw
     t_offset = np.identity(4)
     t_offset[:, -1] = t_offset_aux[:, -1]
     t_probe_raw = s0_raw @ np.linalg.inv(t_offset) @ np.linalg.inv(s0_raw) @ t_probe
+
     m_target_in_tracker = np.identity(4)
     m_target_in_tracker[:, -1] = t_probe_raw[:, -1]
     m_target_in_tracker[:3, :3] = r_probe[:3, :3]
@@ -236,6 +244,24 @@ def apply_icp(m_img, icp):
         m_img = bases.transform_icp(m_img, m_icp)
 
     return m_img
+
+def ComputeRelativeDistanceToTarget(target_coord, m_img):
+    m_target = dco.coordinates_to_transformation_matrix(
+        position=target_coord[:3],
+        orientation=target_coord[3:],
+        axes='sxyz',
+    )
+    m_img[1, -1] = -m_img[1, -1]
+    m_relative_target = np.linalg.inv(m_target) @ m_img
+
+    # compute rotation angles
+    angles = tr.euler_from_matrix(m_relative_target, axes='sxyz')
+
+    # create output coordinate list
+    distance = [m_relative_target[0, -1], m_relative_target[1, -1], m_relative_target[2, -1], \
+            np.degrees(angles[0]), np.degrees(angles[1]), np.degrees(angles[2])]
+
+    return distance
 
 
 class CoordinateCorregistrate(threading.Thread):

--- a/invesalius/data/coregistration.py
+++ b/invesalius/data/coregistration.py
@@ -102,7 +102,7 @@ def tracker_to_image(m_change, m_probe_ref, r_obj_img, m_obj_raw, s0_dyn):
     return m_img
 
 
-def image_to_tracker(m_change, target, icp):
+def image_to_tracker(m_change, target, icp, obj_data):
     """Compute the transformation matrix to the tracker coordinate system
 
     :param m_change: Corregistration transformation obtained from fiducials
@@ -115,6 +115,8 @@ def image_to_tracker(m_change, target, icp):
     :return: 4 x 4 numpy double array
     :rtype: numpy.ndarray
     """
+    t_obj_raw, s0_raw, r_s0_raw, s0_dyn, m_obj_raw, r_obj_img = obj_data
+    #position
     m_target_in_image = dco.coordinates_to_transformation_matrix(
         position=target[:3],
         orientation=[0, 0, 0],
@@ -126,6 +128,21 @@ def image_to_tracker(m_change, target, icp):
 
     # invert y coordinate
     m_target_in_tracker[2, -1] = -m_target_in_tracker[2, -1]
+    #rotation
+
+    r_obj = dco.coordinates_to_transformation_matrix(
+        position=target[:3],
+        orientation=target[3:],
+        axes='sxyz',
+    )
+    m_probe_ref = s0_dyn @ m_obj_raw @ np.linalg.inv(r_obj_img) @ r_obj @ np.linalg.inv(m_obj_raw)
+
+    # invert y coordinate
+    m_probe_ref[2, -1] = -m_probe_ref[2, -1]
+
+    # transform object center to reference marker if specified as dynamic reference
+    #######m_probe = m_ref @ m_probe_ref
+    m_target_in_tracker[:3, :3] = m_probe_ref[:3, :3]
 
     return m_target_in_tracker
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -952,31 +952,35 @@ class Viewer(wx.Panel):
                 thrdist = False
                 self.aim_actor.GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('Yellow'))
 
-            coordx = self.target_coord[3] - coord[3]
-            if coordx > const.ARROW_UPPER_LIMIT:
-                coordx = const.ARROW_UPPER_LIMIT
-            elif coordx < -const.ARROW_UPPER_LIMIT:
-                coordx = -const.ARROW_UPPER_LIMIT
-            coordx = const.ARROW_SCALE * coordx
+            coordx = self.target_coord[0] - coord[0]
+            coordy = -self.target_coord[1] - coord[1]
+            coordz = self.target_coord[2] - coord[2]
+            coordrx = self.target_coord[3] - coord[3]
+            coordry = self.target_coord[4] - coord[4]
+            coordrz = self.target_coord[5] - coord[5]
 
-            coordy = self.target_coord[4] - coord[4]
-            if coordy > const.ARROW_UPPER_LIMIT:
-                coordy = const.ARROW_UPPER_LIMIT
-            elif coordy < -const.ARROW_UPPER_LIMIT:
-                coordy = -const.ARROW_UPPER_LIMIT
-            coordy = const.ARROW_SCALE * coordy
+            if coordrx > const.ARROW_UPPER_LIMIT:
+                coordrx = const.ARROW_UPPER_LIMIT
+            elif coordrx < -const.ARROW_UPPER_LIMIT:
+                coordrx = -const.ARROW_UPPER_LIMIT
+            coordrx_arrow = const.ARROW_SCALE * coordrx
 
-            coordz = self.target_coord[5] - coord[5]
-            if coordz > const.ARROW_UPPER_LIMIT:
-                coordz = const.ARROW_UPPER_LIMIT
-            elif coordz < -const.ARROW_UPPER_LIMIT:
-                coordz = -const.ARROW_UPPER_LIMIT
-            coordz = const.ARROW_SCALE * coordz
+            if coordry > const.ARROW_UPPER_LIMIT:
+                coordry = const.ARROW_UPPER_LIMIT
+            elif coordry < -const.ARROW_UPPER_LIMIT:
+                coordry = -const.ARROW_UPPER_LIMIT
+            coordry_arrow = const.ARROW_SCALE * coordry
+
+            if coordrz > const.ARROW_UPPER_LIMIT:
+                coordrz = const.ARROW_UPPER_LIMIT
+            elif coordrz < -const.ARROW_UPPER_LIMIT:
+                coordrz = -const.ARROW_UPPER_LIMIT
+            coordrz_arrow = const.ARROW_SCALE * coordrz
 
             for ind in self.arrow_actor_list:
                 self.ren2.RemoveActor(ind)
 
-            if self.anglethreshold * const.ARROW_SCALE > coordx > -self.anglethreshold * const.ARROW_SCALE:
+            if self.anglethreshold * const.ARROW_SCALE > coordrx_arrow > -self.anglethreshold * const.ARROW_SCALE:
                 thrcoordx = True
                 # self.obj_actor_list[0].GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('Green'))
                 self.obj_actor_list[0].GetProperty().SetColor(0, 1, 0)
@@ -987,17 +991,17 @@ class Viewer(wx.Panel):
 
             offset = 5
 
-            arrow_roll_x1 = self.CreateArrowActor([-55, -35, offset], [-55, -35, offset - coordx])
+            arrow_roll_x1 = self.CreateArrowActor([-55, -35, offset], [-55, -35, offset - coordrx_arrow])
             arrow_roll_x1.RotateX(-60)
             arrow_roll_x1.RotateZ(180)
             arrow_roll_x1.GetProperty().SetColor(1, 1, 0)
 
-            arrow_roll_x2 = self.CreateArrowActor([55, -35, offset], [55, -35, offset + coordx])
+            arrow_roll_x2 = self.CreateArrowActor([55, -35, offset], [55, -35, offset + coordrx_arrow])
             arrow_roll_x2.RotateX(-60)
             arrow_roll_x2.RotateZ(180)
             arrow_roll_x2.GetProperty().SetColor(1, 1, 0)
 
-            if self.anglethreshold * const.ARROW_SCALE > coordz > -self.anglethreshold * const.ARROW_SCALE:
+            if self.anglethreshold * const.ARROW_SCALE > coordrz_arrow > -self.anglethreshold * const.ARROW_SCALE:
                 thrcoordz = True
                 # self.obj_actor_list[1].GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('Green'))
                 self.obj_actor_list[1].GetProperty().SetColor(0, 1, 0)
@@ -1008,17 +1012,17 @@ class Viewer(wx.Panel):
 
             offset = -35
 
-            arrow_yaw_z1 = self.CreateArrowActor([-55, offset, 0], [-55, offset - coordz, 0])
+            arrow_yaw_z1 = self.CreateArrowActor([-55, offset, 0], [-55, offset - coordrz_arrow, 0])
             arrow_yaw_z1.SetPosition(0, -150, 0)
             arrow_yaw_z1.RotateZ(180)
             arrow_yaw_z1.GetProperty().SetColor(0, 1, 0)
 
-            arrow_yaw_z2 = self.CreateArrowActor([55, offset, 0], [55, offset + coordz, 0])
+            arrow_yaw_z2 = self.CreateArrowActor([55, offset, 0], [55, offset + coordrz_arrow, 0])
             arrow_yaw_z2.SetPosition(0, -150, 0)
             arrow_yaw_z2.RotateZ(180)
             arrow_yaw_z2.GetProperty().SetColor(0, 1, 0)
 
-            if self.anglethreshold * const.ARROW_SCALE > coordy > -self.anglethreshold * const.ARROW_SCALE:
+            if self.anglethreshold * const.ARROW_SCALE > coordry_arrow > -self.anglethreshold * const.ARROW_SCALE:
                 thrcoordy = True
                 #self.obj_actor_list[2].GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('Green'))
                 self.obj_actor_list[2].GetProperty().SetColor(0, 1, 0)
@@ -1028,14 +1032,14 @@ class Viewer(wx.Panel):
                 self.obj_actor_list[2].GetProperty().SetColor(1, 1, 1)
 
             offset = 38
-            arrow_pitch_y1 = self.CreateArrowActor([0, 65, offset], [0, 65, offset + coordy])
+            arrow_pitch_y1 = self.CreateArrowActor([0, 65, offset], [0, 65, offset + coordry_arrow])
             arrow_pitch_y1.SetPosition(0, -300, 0)
             arrow_pitch_y1.RotateY(90)
             arrow_pitch_y1.RotateZ(180)
             arrow_pitch_y1.GetProperty().SetColor(1, 0, 0)
 
             offset = 5
-            arrow_pitch_y2 = self.CreateArrowActor([0, -55, offset], [0, -55, offset - coordy])
+            arrow_pitch_y2 = self.CreateArrowActor([0, -55, offset], [0, -55, offset - coordry_arrow])
             arrow_pitch_y2.SetPosition(0, -300, 0)
             arrow_pitch_y2.RotateY(90)
             arrow_pitch_y2.RotateZ(180)
@@ -1047,6 +1051,9 @@ class Viewer(wx.Panel):
             else:
                 self.dummy_coil_actor.GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('DarkOrange'))
                 wx.CallAfter(Publisher.sendMessage, 'Coil at target', state=False)
+
+            wx.CallAfter(Publisher.sendMessage, 'Distance to the target',
+                         distance=[coordx, coordy, coordz, coordrx, coordry, coordrz])
 
             self.arrow_actor_list = arrow_roll_x1, arrow_roll_x2, arrow_yaw_z1, arrow_yaw_z2, \
                                     arrow_pitch_y1, arrow_pitch_y2

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -942,6 +942,8 @@ class Viewer(wx.Panel):
         distance = [m_relative_target[0, -1], m_relative_target[1, -1], m_relative_target[2, -1], \
                 np.degrees(angles[0]), np.degrees(angles[1]), np.degrees(angles[2])]
 
+        wx.CallAfter(Publisher.sendMessage, 'Distance to the target', distance=distance)
+
         return distance
 
     def OnUpdateObjectTargetGuide(self, m_img, coord):
@@ -1063,9 +1065,6 @@ class Viewer(wx.Panel):
             else:
                 self.dummy_coil_actor.GetProperty().SetDiffuseColor(vtk_colors.GetColor3d('DarkOrange'))
                 wx.CallAfter(Publisher.sendMessage, 'Coil at target', state=False)
-
-            wx.CallAfter(Publisher.sendMessage, 'Distance to the target',
-                         distance=distance_to_target)
 
             self.arrow_actor_list = arrow_roll_x1, arrow_roll_x2, arrow_yaw_z1, arrow_yaw_z2, \
                                     arrow_pitch_y1, arrow_pitch_y2

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1625,7 +1625,7 @@ class MarkersPanel(wx.Panel):
         coord_raw, markers_flag = self.tracker.TrackerCoordinates.GetCoordinates()
         m_target = dcr.image_to_tracker(self.navigation.m_change, coord_raw, nav_target, self.icp, self.navigation.obj_data)
 
-        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=target.tolist(), nav_target=self.markers[index].coord)
+        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=m_target.tolist())
 
     def OnDeleteAllMarkers(self, evt=None):
         if evt is not None:

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1517,14 +1517,13 @@ class MarkersPanel(wx.Panel):
         if self.tracker.tracker_id == const.ROBOT:
             send_target_to_robot_compensation = menu_id.Append(4, _('Sets target to robot head move compensation'))
             menu_id.Bind(wx.EVT_MENU, self.OnMenuSetRobotCompensation, send_target_to_robot_compensation)
-            send_target_to_robot = menu_id.Append(5, _('Send target from InVesalius to robot'))
+            send_target_to_robot = menu_id.Append(5, _('Send InVesalius target to robot'))
             menu_id.Bind(wx.EVT_MENU, self.OnMenuSendTargetToRobot, send_target_to_robot)
             send_target_to_robot_compensation.Enable(False)
             send_target_to_robot.Enable(False)
-            if self.nav_status and check_target_angles:
+            if self.nav_status and self.target_mode and (self.lc.GetFocusedItem() == self.__find_target_marker()):
                 send_target_to_robot_compensation.Enable(True)
-                if self.target_mode:
-                    send_target_to_robot.Enable(True)
+                send_target_to_robot.Enable(True)
 
         if check_target_angles:
             target_menu.Enable(True)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1621,8 +1621,9 @@ class MarkersPanel(wx.Panel):
         Publisher.sendMessage('Update tracker fiducials matrix',
                               matrix_tracker_fiducials=matrix_tracker_fiducials)
 
-        target_coord = self.markers[index].position
-        target = dcr.image_to_tracker(self.navigation.m_change, target_coord, self.icp)
+        nav_target = self.markers[index].position
+        coord_raw, markers_flag = self.tracker.TrackerCoordinates.GetCoordinates()
+        m_target = dcr.image_to_tracker(self.navigation.m_change, coord_raw, nav_target, self.icp, self.navigation.obj_data)
 
         Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=target.tolist(), nav_target=self.markers[index].coord)
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -786,7 +786,7 @@ class NeuronavigationPanel(wx.Panel):
         self.navigation.StopNavigation()
         if self.tracker.tracker_id == const.ROBOT:
             Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                  target_index=None, target=None, nav_target=None)
+                                  target_index=None, target=None)
 
         # Enable all navigation buttons
         choice_ref.Enable(True)
@@ -1575,7 +1575,7 @@ class MarkersPanel(wx.Panel):
         Publisher.sendMessage('Update target', coord=None)
         if self.tracker.tracker_id == const.ROBOT:
             Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                  target_index=None, target=None, nav_target=None)
+                                  target_index=None, target=None)
         wx.MessageBox(_("Target removed."), _("InVesalius 3"))
 
     def OnMenuSetColor(self, evt):
@@ -1606,7 +1606,7 @@ class MarkersPanel(wx.Panel):
         matrix_tracker_fiducials = self.tracker.GetMatrixTrackerFiducials()
         Publisher.sendMessage('Update tracker fiducials matrix',
                               matrix_tracker_fiducials=matrix_tracker_fiducials)
-        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=None, nav_target=None)
+        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=None)
 
     def OnMenuSendTargetToRobot(self, evt):
         if isinstance(evt, int):
@@ -1639,7 +1639,7 @@ class MarkersPanel(wx.Panel):
                 wx.MessageBox(_("Target deleted."), _("InVesalius 3"))
             if self.tracker.tracker_id == const.ROBOT:
                 Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                      target_index=None, target=None, nav_target=None)
+                                      target_index=None, target=None)
 
         self.markers = []
         Publisher.sendMessage('Remove all markers', indexes=self.lc.GetItemCount())
@@ -1671,7 +1671,7 @@ class MarkersPanel(wx.Panel):
                 Publisher.sendMessage('Update target', coord=None)
                 if self.tracker.tracker_id == const.ROBOT:
                     Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                          target_index=None, target=None, nav_target=None)
+                                          target_index=None, target=None)
                 wx.MessageBox(_("Target deleted."), _("InVesalius 3"))
 
             self.__delete_multiple_markers(index)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1298,6 +1298,7 @@ class MarkersPanel(wx.Panel):
 
         self.markers = []
         self.nav_status = False
+        self.target_mode = False
 
         self.marker_colour = const.MARKER_COLOUR
         self.marker_size = const.MARKER_SIZE
@@ -1398,6 +1399,7 @@ class MarkersPanel(wx.Panel):
         Publisher.subscribe(self.UpdateSeedCoordinates, 'Update tracts')
         Publisher.subscribe(self.OnChangeCurrentSession, 'Current session changed')
         Publisher.subscribe(self.UpdateMarkerOrientation, 'Open marker orientation dialog')
+        Publisher.subscribe(self.OnActivateTargetMode, 'Target navigation mode')
 
     def __find_target_marker(self):
         """
@@ -1517,12 +1519,12 @@ class MarkersPanel(wx.Panel):
             menu_id.Bind(wx.EVT_MENU, self.OnMenuSetRobotCompensation, send_target_to_robot_compensation)
             send_target_to_robot = menu_id.Append(5, _('Send target from InVesalius to robot'))
             menu_id.Bind(wx.EVT_MENU, self.OnMenuSendTargetToRobot, send_target_to_robot)
+            send_target_to_robot_compensation.Enable(False)
+            send_target_to_robot.Enable(False)
             if self.nav_status and check_target_angles:
                 send_target_to_robot_compensation.Enable(True)
-                send_target_to_robot.Enable(True)
-            else:
-                send_target_to_robot_compensation.Enable(False)
-                send_target_to_robot.Enable(False)
+                if self.target_mode:
+                    send_target_to_robot.Enable(True)
 
         if check_target_angles:
             target_menu.Enable(True)
@@ -1776,6 +1778,9 @@ class MarkersPanel(wx.Panel):
             Publisher.sendMessage('Update target orientation',
                                   target_id=marker_id, orientation=list(orientation))
         dialog.Destroy()
+
+    def OnActivateTargetMode(self, target_mode=None):
+        self.target_mode = target_mode
 
     def SetMarkers(self, markers):
         """

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -786,7 +786,7 @@ class NeuronavigationPanel(wx.Panel):
         self.navigation.StopNavigation()
         if self.tracker.tracker_id == const.ROBOT:
             Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                  target_index=None, target=None)
+                                  target_index=None, target=None, nav_target=None)
 
         # Enable all navigation buttons
         choice_ref.Enable(True)
@@ -1575,7 +1575,7 @@ class MarkersPanel(wx.Panel):
         Publisher.sendMessage('Update target', coord=None)
         if self.tracker.tracker_id == const.ROBOT:
             Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                  target_index=None, target=None)
+                                  target_index=None, target=None, nav_target=None)
         wx.MessageBox(_("Target removed."), _("InVesalius 3"))
 
     def OnMenuSetColor(self, evt):
@@ -1606,7 +1606,7 @@ class MarkersPanel(wx.Panel):
         matrix_tracker_fiducials = self.tracker.GetMatrixTrackerFiducials()
         Publisher.sendMessage('Update tracker fiducials matrix',
                               matrix_tracker_fiducials=matrix_tracker_fiducials)
-        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=None)
+        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=None, nav_target=None)
 
     def OnMenuSendTargetToRobot(self, evt):
         if isinstance(evt, int):
@@ -1624,7 +1624,7 @@ class MarkersPanel(wx.Panel):
         target_coord = self.markers[index].position
         target = dcr.image_to_tracker(self.navigation.m_change, target_coord, self.icp)
 
-        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=target.tolist())
+        Publisher.sendMessage('Update robot target', robot_tracker_flag=True, target_index=self.lc.GetFocusedItem(), target=target.tolist(), nav_target=self.markers[index].coord)
 
     def OnDeleteAllMarkers(self, evt=None):
         if evt is not None:
@@ -1638,7 +1638,7 @@ class MarkersPanel(wx.Panel):
                 wx.MessageBox(_("Target deleted."), _("InVesalius 3"))
             if self.tracker.tracker_id == const.ROBOT:
                 Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                      target_index=None, target=None)
+                                      target_index=None, target=None, nav_target=None)
 
         self.markers = []
         Publisher.sendMessage('Remove all markers', indexes=self.lc.GetItemCount())
@@ -1670,7 +1670,7 @@ class MarkersPanel(wx.Panel):
                 Publisher.sendMessage('Update target', coord=None)
                 if self.tracker.tracker_id == const.ROBOT:
                     Publisher.sendMessage('Update robot target', robot_tracker_flag=False,
-                                          target_index=None, target=None)
+                                          target_index=None, target=None, nav_target=None)
                 wx.MessageBox(_("Target deleted."), _("InVesalius 3"))
 
             self.__delete_multiple_markers(index)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1621,7 +1621,7 @@ class MarkersPanel(wx.Panel):
         Publisher.sendMessage('Update tracker fiducials matrix',
                               matrix_tracker_fiducials=matrix_tracker_fiducials)
 
-        nav_target = self.markers[index].position
+        nav_target = self.markers[index].position+self.markers[index].orientation
         coord_raw, markers_flag = self.tracker.TrackerCoordinates.GetCoordinates()
         m_target = dcr.image_to_tracker(self.navigation.m_change, coord_raw, nav_target, self.icp, self.navigation.obj_data)
 

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -122,7 +122,6 @@ class UpdateNavigationScene(threading.Thread):
                 wx.CallAfter(Publisher.sendMessage, 'Sensor ID', markers_flag=markers_flag)
 
                 if view_obj:
-                    wx.CallAfter(Publisher.sendMessage, 'Update object matrix to robot', m_img=m_img.tolist())
                     wx.CallAfter(Publisher.sendMessage, 'Update object matrix', m_img=m_img, coord=coord)
                     wx.CallAfter(Publisher.sendMessage, 'Update object arrow matrix', m_img=m_img, coord=coord, flag= self.peel_loaded)
 

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -122,6 +122,7 @@ class UpdateNavigationScene(threading.Thread):
                 wx.CallAfter(Publisher.sendMessage, 'Sensor ID', markers_flag=markers_flag)
 
                 if view_obj:
+                    wx.CallAfter(Publisher.sendMessage, 'Update object matrix to robot', m_img=m_img.tolist())
                     wx.CallAfter(Publisher.sendMessage, 'Update object matrix', m_img=m_img, coord=coord)
                     wx.CallAfter(Publisher.sendMessage, 'Update object arrow matrix', m_img=m_img, coord=coord, flag= self.peel_loaded)
 

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -152,6 +152,7 @@ class Navigation(metaclass=Singleton):
         self.obj_reg = None
         self.track_obj = False
         self.m_change = None
+        self.obj_data = None
         self.all_fiducials = np.zeros((6, 6))
 
         self.event = threading.Event()
@@ -283,8 +284,8 @@ class Navigation(metaclass=Singleton):
                 else:
                     coord_raw = np.array([None])
 
-                obj_data = db.object_registration(obj_fiducials, obj_orients, coord_raw, self.m_change)
-                coreg_data.extend(obj_data)
+                self.obj_data = db.object_registration(obj_fiducials, obj_orients, coord_raw, self.m_change)
+                coreg_data.extend(self.obj_data)
 
                 queues = [self.coord_queue, self.coord_tracts_queue, self.icp_queue, self.object_at_target_queue]
                 jobs_list.append(dcr.CoordinateCorregistrate(self.ref_mode_id, tracker, coreg_data,

--- a/invesalius/net/remote_control.py
+++ b/invesalius/net/remote_control.py
@@ -45,7 +45,7 @@ class RemoteControl:
         if data is None:
             data = {}
 
-        print("Received an event into topic '{}' with data {}".format(topic, str(data)))
+        #print("Received an event into topic '{}' with data {}".format(topic, str(data)))
         Publisher.sendMessage_no_hook(
             topicName=topic,
             **data
@@ -70,7 +70,7 @@ class RemoteControl:
             time.sleep(1.0)
 
         def _emit(topic, data):
-            print("Emitting data {} to topic {}".format(data, topic))
+            #print("Emitting data {} to topic {}".format(data, topic))
             try:
                 if isinstance(topic, str):
                     self._sio.emit("from_neuronavigation", {


### PR DESCRIPTION
- Add the feature to set a robot target, using InVesalius, and send it to the robotic positioning
- Fix the distance to target estimation, instead of using the absolute subtraction, it's using the relative distance between the actual coil position and the targe `m_relative_target = np.linalg.inv(m_target) @ m_img`