### PR TITLE
Pixel size unit

### DIFF
--- a/invesalius/data/cursor_actors.py
+++ b/invesalius/data/cursor_actors.py
@@ -86,6 +86,7 @@ class CursorBase(object):
         self.colour = (0.0, 0.0, 1.0)
         self.opacity = 1
         self.size = 15.0
+        self.unit = 'mm'
         self.orientation = "AXIAL"
         self.spacing = (1, 1, 1)
         self.position = (0, 0, 0)
@@ -106,7 +107,12 @@ class CursorBase(object):
         self.radius = diameter/2.0
         self._build_actor()
         self._calculate_area_pixels()
-        
+
+    def SetUnit(self, unit):
+        self.unit = unit
+        self._build_actor()
+        self._calculate_area_pixels()
+
     def SetColour(self, colour):
         self.colour = colour
         self._build_actor()
@@ -252,7 +258,12 @@ class CursorCircle(CursorBase):
         Function to plot the circle
         """
         r = self.radius
-        sx, sy, sz = self.spacing
+        if self.unit == "µm":
+            r /= 1000.0
+        if self.unit == "px":
+            sx, sy, sz = 1.0, 1.0, 1.0
+        else:
+            sx, sy, sz = self.spacing
         if self.orientation == 'AXIAL':
             xi = math.floor(-r/sx)
             xf = math.ceil(r/sx) + 1
@@ -298,15 +309,20 @@ class CursorCircle(CursorBase):
         Return the cursor's pixels.
         """
         r = self.radius
-        if self.orientation == 'AXIAL':
-            sx = self.spacing[0]
-            sy = self.spacing[1]
-        elif self.orientation == 'CORONAL':
-            sx = self.spacing[0]
-            sy = self.spacing[2]
-        elif self.orientation == 'SAGITAL':
-            sx = self.spacing[1]
-            sy = self.spacing[2]
+        if self.unit == "µm":
+            r /= 1000.0
+        if self.unit == "px":
+            sx, sy, sz = 1.0, 1.0, 1.0
+        else:
+            if self.orientation == 'AXIAL':
+                sx = self.spacing[0]
+                sy = self.spacing[1]
+            elif self.orientation == 'CORONAL':
+                sx = self.spacing[0]
+                sy = self.spacing[2]
+            elif self.orientation == 'SAGITAL':
+                sx = self.spacing[1]
+                sy = self.spacing[2]
 
         xi = math.floor(-r/sx)
         xf = math.ceil(r/sx) + 1
@@ -331,7 +347,12 @@ class CursorRectangle(CursorBase):
         """
         print("Building rectangle cursor", self.orientation)
         r = self.radius
-        sx, sy, sz = self.spacing
+        if self.unit == "µm":
+            r /= 1000.0
+        if self.unit == "px":
+            sx, sy, sz = 1.0, 1.0, 1.0
+        else:
+            sx, sy, sz = self.spacing
         if self.orientation == 'AXIAL':
             x = int(math.floor(2*r/sx))
             y = int(math.floor(2*r/sy))
@@ -361,7 +382,12 @@ class CursorRectangle(CursorBase):
 
     def _calculate_area_pixels(self):
         r = self.radius
-        sx, sy, sz = self.spacing
+        if self.unit == "µm":
+            r /= 1000.0
+        if self.unit == "px":
+            sx, sy, sz = 1.0, 1.0, 1.0
+        else:
+            sx, sy, sz = self.spacing
         if self.orientation == 'AXIAL':
             x = int(math.floor(2*r/sx))
             y = int(math.floor(2*r/sy))

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -1224,6 +1224,7 @@ class EditorConfig(metaclass=utils.Singleton):
         self.operation = const.BRUSH_THRESH
         self.cursor_type = const.BRUSH_CIRCLE
         self.cursor_size = const.BRUSH_SIZE
+        self.cursor_unit = 'mm'
 
 
 class EditorInteractorStyle(DefaultInteractorStyle):
@@ -1252,6 +1253,7 @@ class EditorInteractorStyle(DefaultInteractorStyle):
         self.AddObserver("MouseWheelBackwardEvent", self.EOnScrollBackward)
 
         Publisher.subscribe(self.set_bsize, 'Set edition brush size')
+        Publisher.subscribe(self.set_bunit, 'Set edition brush unit')
         Publisher.subscribe(self.set_bformat, 'Set brush format')
         Publisher.subscribe(self.set_boperation, 'Set edition operation')
 
@@ -1272,6 +1274,7 @@ class EditorInteractorStyle(DefaultInteractorStyle):
 
     def CleanUp(self):
         Publisher.unsubscribe(self.set_bsize, 'Set edition brush size')
+        Publisher.unsubscribe(self.set_bunit, 'Set edition brush unit')
         Publisher.unsubscribe(self.set_bformat, 'Set brush format')
         Publisher.unsubscribe(self.set_boperation, 'Set edition operation')
 
@@ -1282,6 +1285,10 @@ class EditorInteractorStyle(DefaultInteractorStyle):
     def set_bsize(self, size):
         self.config.cursor_size = size
         self.viewer.slice_data.cursor.SetSize(size)
+
+    def set_bunit(self, unit):
+        self.config.cursor_unit = unit
+        self.viewer.slice_data.cursor.SetUnit(unit)
 
     def set_bformat(self, cursor_format):
         self.config.cursor_type = cursor_format
@@ -1306,6 +1313,7 @@ class EditorInteractorStyle(DefaultInteractorStyle):
         cursor.SetSpacing(spacing)
         cursor.SetColour(self.viewer._brush_cursor_colour)
         cursor.SetSize(self.config.cursor_size)
+        cursor.SetUnit(self.config.cursor_unit)
         self.viewer.slice_data.SetCursor(cursor)
 
     def OnEnterInteractor(self, obj, evt):

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -694,6 +694,8 @@ class EditionTools(wx.Panel):
             default_colour = wx.SystemSettings_GetColour(wx.SYS_COLOUR_MENUBAR)
         self.SetBackgroundColour(default_colour)
 
+        self.unit = 'mm'
+
         ## LINE 1
         text1 = wx.StaticText(self, -1, _("Choose brush type, size or operation:"))
 
@@ -720,12 +722,15 @@ class EditionTools(wx.Panel):
         btn_brush_format.SetMenu(menu)
         self.btn_brush_format = btn_brush_format
 
-        spin_brush_size = InvSpinCtrl(self, -1, value=const.BRUSH_SIZE, min_value=1, max_value=1000, spin_button=False, unit="mm")
+        spin_brush_size = InvSpinCtrl(self, -1, value=const.BRUSH_SIZE, min_value=1, max_value=1000, spin_button=False)
         # To calculate best width to spinctrl
-        spin_brush_size.CalcSizeFromTextSize("MMMMM")
+        spin_brush_size.CalcSizeFromTextSize("MMMM")
         spin_brush_size.Bind(wx.EVT_SPINCTRL, self.OnBrushSize)
-        spin_brush_size.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
         self.spin = spin_brush_size
+
+        self.txt_unit = wx.StaticText(self, -1, "mm")
+        self.txt_unit.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
+        self.txt_unit.SetBackgroundColour(self.spin.GetBackgroundColour())
 
         combo_brush_op = wx.ComboBox(self, -1, "", size=(15,-1),
                                      choices = const.BRUSH_OP_NAME,
@@ -738,7 +743,8 @@ class EditionTools(wx.Panel):
         # Sizer which represents the second line
         line2 = wx.BoxSizer(wx.HORIZONTAL)
         line2.Add(btn_brush_format, 0, wx.EXPAND|wx.GROW|wx.RIGHT, 5)
-        line2.Add(spin_brush_size, 0, wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
+        line2.Add(spin_brush_size, 0, wx.ALIGN_CENTER_VERTICAL)
+        line2.Add(self.txt_unit, 0, wx.ALIGN_CENTER_VERTICAL)
         line2.Add(combo_brush_op, 1, wx.RIGHT|wx.LEFT|wx.ALIGN_CENTER_VERTICAL, 5)
 
         ## LINE 3
@@ -842,16 +848,16 @@ class EditionTools(wx.Panel):
         um_item = menu.AppendRadioItem(MENU_UNIT_UM, "µm")
         px_item = menu.AppendRadioItem(MENU_UNIT_PX, "px")
 
-        if self.spin.GetUnit() == "mm":
+        if self.unit == "mm":
             mm_item.Check()
-        elif self.spin.GetUnit() == "µm":
+        elif self.unit == "µm":
             um_item.Check()
         else:
             px_item.Check()
 
 
         menu.Bind(wx.EVT_MENU, self.OnSetUnit)
-        self.spin.PopupMenu(menu)
+        self.txt_unit.PopupMenu(menu)
         menu.Destroy()
 
     def _set_threshold_range_gui(self, threshold_range):
@@ -870,11 +876,13 @@ class EditionTools(wx.Panel):
 
     def OnSetUnit(self, evt):
         if evt.GetId() == MENU_UNIT_MM:
-            self.spin.SetUnit("mm")
+            self.txt_unit.SetLabel("mm")
         elif evt.GetId() == MENU_UNIT_UM:
-            self.spin.SetUnit("µm")
+            self.txt_unit.SetLabel("µm")
         else:
-            self.spin.SetUnit("px")
+            self.txt_unit.SetLabel("px")
+        self.unit = self.txt_unit.GetLabel()
+        Publisher.sendMessage('Set edition brush unit', unit=self.unit)
 
 
 class WatershedTool(EditionTools):

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -730,7 +730,6 @@ class EditionTools(wx.Panel):
 
         self.txt_unit = wx.StaticText(self, -1, "mm")
         self.txt_unit.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
-        self.txt_unit.SetBackgroundColour(self.spin.GetBackgroundColour())
 
         combo_brush_op = wx.ComboBox(self, -1, "", size=(15,-1),
                                      choices = const.BRUSH_OP_NAME,

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -54,6 +54,10 @@ MENU_BRUSH_ADD = wx.NewId()
 MENU_BRUSH_DEL = wx.NewId()
 MENU_BRUSH_THRESH = wx.NewId()
 
+MENU_UNIT_MM = wx.NewId()
+MENU_UNIT_UM = wx.NewId()
+MENU_UNIT_PX = wx.NewId()
+
 MASK_LIST = []
 
 class TaskPanel(wx.Panel):
@@ -716,10 +720,11 @@ class EditionTools(wx.Panel):
         btn_brush_format.SetMenu(menu)
         self.btn_brush_format = btn_brush_format
 
-        spin_brush_size = InvSpinCtrl(self, -1, value=const.BRUSH_SIZE, min_value=1, max_value=1000, spin_button=False)
+        spin_brush_size = InvSpinCtrl(self, -1, value=const.BRUSH_SIZE, min_value=1, max_value=1000, spin_button=False, unit="mm")
         # To calculate best width to spinctrl
-        spin_brush_size.CalcSizeFromTextSize("MMMM")
+        spin_brush_size.CalcSizeFromTextSize("MMMMM")
         spin_brush_size.Bind(wx.EVT_SPINCTRL, self.OnBrushSize)
+        spin_brush_size.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
         self.spin = spin_brush_size
 
         combo_brush_op = wx.ComboBox(self, -1, "", size=(15,-1),
@@ -767,7 +772,7 @@ class EditionTools(wx.Panel):
 
 
     def __bind_events_wx(self):
-        self.Bind(wx.EVT_MENU, self.OnMenu)
+        self.btn_brush_format.Bind(wx.EVT_MENU, self.OnMenu)
         self.Bind(grad.EVT_THRESHOLD_CHANGED, self.OnGradientChanged,
                   self.gradient_thresh)
         self.combo_brush_op.Bind(wx.EVT_COMBOBOX, self.OnComboBrushOp)
@@ -830,6 +835,25 @@ class EditionTools(wx.Panel):
         # Strangelly this is being called twice
         Publisher.sendMessage('Set edition brush size', size=self.spin.GetValue())
 
+    def OnContextMenu(self, evt):
+        print("Context")
+        menu = wx.Menu()
+        mm_item = menu.AppendRadioItem(MENU_UNIT_MM, "mm")
+        um_item = menu.AppendRadioItem(MENU_UNIT_UM, "µm")
+        px_item = menu.AppendRadioItem(MENU_UNIT_PX, "px")
+
+        if self.spin.GetUnit() == "mm":
+            mm_item.Check()
+        elif self.spin.GetUnit() == "µm":
+            um_item.Check()
+        else:
+            px_item.Check()
+
+
+        menu.Bind(wx.EVT_MENU, self.OnSetUnit)
+        self.spin.PopupMenu(menu)
+        menu.Destroy()
+
     def _set_threshold_range_gui(self, threshold_range):
         self.SetThresholdValues(threshold_range)
 
@@ -843,6 +867,14 @@ class EditionTools(wx.Panel):
             self.gradient_thresh.Enable()
         else:
             self.gradient_thresh.Disable()
+
+    def OnSetUnit(self, evt):
+        if evt.GetId() == MENU_UNIT_MM:
+            self.spin.SetUnit("mm")
+        elif evt.GetId() == MENU_UNIT_UM:
+            self.spin.SetUnit("µm")
+        else:
+            self.spin.SetUnit("px")
 
 
 class WatershedTool(EditionTools):

--- a/invesalius/gui/widgets/inv_spinctrl.py
+++ b/invesalius/gui/widgets/inv_spinctrl.py
@@ -31,6 +31,7 @@ class InvSpinCtrl(wx.Panel):
         max_value=100,
         increment=1,
         spin_button=True,
+        unit='',
         size=wx.DefaultSize,
         style=wx.TE_RIGHT,
     ):
@@ -47,6 +48,8 @@ class InvSpinCtrl(wx.Panel):
         self._min_value = 0
         self._max_value = 100
         self._increment = 1
+
+        self.unit = unit
 
         self.SetMin(min_value)
         self.SetMax(max_value)
@@ -103,8 +106,16 @@ class InvSpinCtrl(wx.Panel):
             value = self._max_value
 
         self._value = value
-        self._textctrl.SetValue("{}".format(self._value))
+        self._textctrl.SetValue("{} {}".format(self._value, self.unit))
         self._last_value = self._value
+
+
+    def GetUnit(self):
+        return self.unit
+
+    def SetUnit(self, unit):
+        self.unit = unit
+        self.SetValue(self.GetValue())
 
     def CalcSizeFromTextSize(self, text=None):
         # To calculate best width to spinctrl


### PR DESCRIPTION
Allows the user to set the unit (milimeters (mm), micrometer (µm) and px (pixels)) to the manual edition and watershed brush. Fixes #493