### PR TITLE
FIX: Fix initializing tracker sintax

### DIFF
--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -142,7 +142,7 @@ def PolarisTracker(tracker_id):
         try:
             if sys.platform == 'win32':
                 import pypolaris
-                trck_init = pypolaris()
+                trck_init = pypolaris.pypolaris()
             else:
                 from pypolaris import pypolaris
                 trck_init = pypolaris.pypolaris()


### PR DESCRIPTION
I tested on Windows, does not work with only trck_init = pypolaris()