### PR TITLE
Avoid assigning a variable to its own value

### DIFF
--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -345,7 +345,7 @@ def PlhUSBConnection(tracker_id):
         for i in cfg:
             for x in i:
                 # TODO: try better code
-                x = x
+                pass # print(x)
         trck_init.set_configuration()
         endpoint = trck_init[0][(0, 0)][0]
         if tracker_id == 2:


### PR DESCRIPTION
The variable is being assigned to itself, which is redundant and unnecessary. Since no modifications are being made to the variable, we can safely remove this assignment operation.