### PR TITLE
Remove unused imports

### DIFF
--- a/invesalius/data/cursor_actors.py
+++ b/invesalius/data/cursor_actors.py
@@ -32,8 +32,6 @@ from vtkmodules.vtkRenderingCore import (
     vtkImageSliceMapper,
 )
 
-import invesalius.data.imagedata_utils as imagedata_utils
-from invesalius.project import Project as project
 import invesalius.constants as const
 
 

--- a/invesalius/data/editor.py
+++ b/invesalius/data/editor.py
@@ -17,7 +17,6 @@
 #    detalhes.
 #--------------------------------------------------------------------------
 
-import math
 from invesalius.pubsub import pub as Publisher
 
 from vtkmodules.vtkCommonCore import vtkLookupTable

--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -18,7 +18,6 @@
 # --------------------------------------------------------------------------
 
 import math
-import os
 import sys
 import tempfile
 
@@ -35,15 +34,10 @@ from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth
 from vtkmodules.vtkInteractionImage import vtkImageViewer
 from vtkmodules.vtkIOXML import vtkXMLImageDataReader, vtkXMLImageDataWriter
 
-from invesalius.pubsub import pub as Publisher
-import invesalius.constants as const
 import invesalius.data.converters as converters
 import invesalius.data.coordinates as dco
 import invesalius.data.slice_ as sl
-import invesalius.data.transformations as tr
 import invesalius.reader.bitmap_reader as bitmap_reader
-import invesalius.utils as utils
-from invesalius import inv_paths
 from invesalius.data import vtk_utils as vtk_utils
 from skimage.color import rgb2gray
 

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -27,7 +27,6 @@ import weakref
 
 import invesalius.constants as const
 import invesalius.data.converters as converters
-import invesalius.data.imagedata_utils as iu
 import invesalius.session as ses
 from invesalius.data.volume import VolumeMask
 import numpy as np

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -1,14 +1,12 @@
 # -*- coding: UTF-8 -*-
 
 import math
-import random
 import sys
 
 from invesalius.pubsub import pub as Publisher
 
 import numpy as np
 
-from imageio import imsave
 from vtkmodules.vtkCommonCore import vtkMath
 from vtkmodules.vtkFiltersCore import vtkAppendPolyData
 from vtkmodules.vtkFiltersSources import (
@@ -31,7 +29,7 @@ import invesalius.session as ses
 import invesalius.utils as utils
 
 from invesalius import math_utils
-from invesalius.gui.widgets.canvas_renderer import TextBox, CircleHandler, Ellipse, Polygon, CanvasHandlerBase
+from invesalius.gui.widgets.canvas_renderer import TextBox, Ellipse, Polygon, CanvasHandlerBase
 
 TYPE = {const.LINEAR: _(u"Linear"),
         const.ANGULAR: _(u"Angular"),

--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -37,7 +37,7 @@ from vtkmodules.vtkIOXML import vtkXMLPolyDataReader, vtkXMLPolyDataWriter
 import invesalius.constants as const
 import invesalius.data.vtk_utils as vu
 from invesalius.utils import touch
-from invesalius.pubsub import pub as Publisher
+
 
 if sys.platform == 'win32':
     try:

--- a/invesalius/data/serial_port_connection.py
+++ b/invesalius/data/serial_port_connection.py
@@ -21,7 +21,6 @@ import queue
 import threading
 import time
 
-import wx
 
 from invesalius import constants
 from invesalius.pubsub import pub as Publisher

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -17,7 +17,6 @@
 #    detalhes.
 #--------------------------------------------------------------------------
 
-import math
 import multiprocessing
 import os
 import tempfile
@@ -27,7 +26,6 @@ from concurrent import futures
 import numpy as np
 import wx
 from scipy import ndimage
-from imageio import imsave
 from scipy.ndimage import generate_binary_structure, watershed_ift
 try:
     # Skimage >= 0.19
@@ -51,7 +49,6 @@ from vtkmodules.vtkRenderingCore import (
 from invesalius.pubsub import pub as Publisher
 
 import invesalius.constants as const
-import invesalius.data.converters as converters
 import invesalius.data.cursor_actors as ca
 import invesalius.data.geometry as geom
 import invesalius.data.transformations as transformations
@@ -68,8 +65,7 @@ from invesalius_cy import floodfill
 # For tracts
 import invesalius.data.tractography as dtr
 # import invesalius.project as prj
-import invesalius.data.slice_ as sl
-import invesalius.data.bases as bases
+
 # from time import sleep
 # ---
 

--- a/invesalius/data/surface_process.py
+++ b/invesalius/data/surface_process.py
@@ -1,7 +1,5 @@
-import multiprocessing
 import os
 import tempfile
-import time
 import weakref
 
 try:
@@ -10,7 +8,6 @@ except ImportError:
     import Queue as queue
 
 import numpy
-from scipy import ndimage
 from vtkmodules.vtkCommonCore import vtkFileOutputWindow, vtkOutputWindow
 from vtkmodules.vtkFiltersCore import (
     vtkAppendPolyData,
@@ -26,7 +23,6 @@ from vtkmodules.vtkImagingCore import vtkImageFlip, vtkImageResample
 from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth
 from vtkmodules.vtkIOXML import vtkXMLPolyDataReader, vtkXMLPolyDataWriter
 
-import invesalius.i18n as i18n
 import invesalius.data.converters as converters
 from invesalius_cy import cy_mesh
 


### PR DESCRIPTION
Removed some unused imports from the invesalius/data folder. Some unused imports had commented out code referring to it, so I have let them be. If these changes are required, I can clean out unused imports from other files too