### PR TITLE
Improve security: `eval()` -> `ast.literal_eval()`

### DIFF
--- a/invesalius/reader/dicom.py
+++ b/invesalius/reader/dicom.py
@@ -18,6 +18,7 @@
 #    detalhes.
 # ---------------------------------------------------------------------
 # import gdcm
+import ast
 import sys
 import time
 
@@ -443,7 +444,7 @@ class Parser:
         except (KeyError):
             return ""
         if data:
-            return [eval(value) for value in data.split("\\")]
+            return [ast.literal_eval(value) for value in data.split("\\")]
         return ""
 
     def GetImageLocation(self):
@@ -456,7 +457,7 @@ class Parser:
         """
         data = self.data_image[str(0x020)][str(0x1041)]
         if data:
-            return eval(data)
+            return ast.literal_eval(data)
         return ""
 
     def GetImageOffset(self):
@@ -1779,7 +1780,7 @@ def BuildDictionary(filename):
     # file, given keys in info_keys list. Example:
     # info["AcquisitionDate"] = dicom.GetAcquisitionDate()
     for key in INFO_KEYS:
-        info[key] = eval("parser.Get" + key + "()")
+        info[key] = ast.literal_eval("parser.Get" + key + "()")
 
     return info
 


### PR DESCRIPTION
Replacing the usage of the potentially insecure `eval()` function with the safer `ast.literal_eval()` function. The recommended change aims to improve the overall security of the codebase.