### PR TITLE
Refactor comparison test for improved accuracy

### DIFF
--- a/invesalius/gui/widgets/listctrl.py
+++ b/invesalius/gui/widgets/listctrl.py
@@ -140,7 +140,7 @@ class ColumnSorterMixin:
         item2 = self.itemDataMap[key2][col]
 
         #--- Internationalization of string sorting with locale module
-        if type(item1) == type('') or type(item2) == type(''):
+        if type(item1) is type('') or type(item2) is type(''):
             cmpVal = locale.strcoll(str(item1), str(item2))
         else:
             cmpVal = cmp(item1, item2)


### PR DESCRIPTION
In general, using the "is" operator when we want to test object identity and the "==" operator when we wish to test object equality is recommended.