### PR TITLE
Console cleanup and mask density measure ui fix

### DIFF
--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -347,7 +347,6 @@ class Mask():
         shutil.copyfile(self.temp_file, filename)
 
     def _open_mask(self, filename, shape, dtype='uint8'):
-        print(">>", filename, shape)
         self.temp_file = filename
         self.matrix = np.memmap(filename, shape=shape, dtype=dtype, mode="r+")
 

--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -148,7 +148,7 @@ def Export(polydata, filename, bin=False):
 def Import(filename):
     reader = vtkXMLPolyDataReader()
     try:
-        reader.SetFileName(filename.encode(wx.GetDefaultPyEncoding()))
+        reader.SetFileName(filename.encode())
     except AttributeError:
         reader.SetFileName(filename)
     reader.Update()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2171,7 +2171,6 @@ class Viewer(wx.Panel):
         self.UpdateRender()
 
     def LoadActor(self, actor):
-        print(actor)
         self.added_actor = 1
         ren = self.ren
         ren.AddActor(actor)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -1230,7 +1230,6 @@ class MenuBar(wx.MenuBar):
             self._plugins_menu_ids[_new_id] = items[item]
             menu_item = self.plugins_menu.Append(_new_id, item, items[item]["description"])
             menu_item.Enable(items[item]["enable_startup"])
-            print(">>> menu", item)
 
     def OnEnableState(self, state):
         """

--- a/invesalius/presets.py
+++ b/invesalius/presets.py
@@ -80,8 +80,6 @@ class Presets():
             for key in presets:
                 (t_min, t_max) = presets[key]
 
-                print(key, t_min, t_max)
-
                 if (t_min is None) or (t_max is None): # setting custom preset
                     t_min = thresh_min
                     t_max = thresh_max

--- a/invesalius/utils.py
+++ b/invesalius/utils.py
@@ -78,8 +78,8 @@ def debug(error_str):
     """
     from invesalius.session import Session
     session = Session()
-    #if session.GetConfig('debug'):
-    print(error_str)
+    if session.GetConfig('debug'):
+        print(error_str)
 
 def next_copy_name(original_name, names_list):
     """


### PR DESCRIPTION
- The function `debug()` now prints only with the `--debug`-argument.
- Remove the following clutter from the console when starting invesalius:
  - wxPyDeprecationWarning from wx.GetDefaultPyEncoding()
  - prints from UpdateThresholdModes()
  - prints of full vtk actor data in LoadActor()
- Fix mask density measure dialog box not working on macOS as it would on other operating systems.
