### PR TITLE
implements inner1d because the numpy one is being deprecated

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1409,7 +1409,7 @@ class Viewer(wx.Panel):
         v0 = cam_pos0 - cam_focus0
         v0n = np.sqrt(inner1d(v0, v0))
 
-        v1 = (cam_focus[0] - cam_focus0[0], cam_focus[1] - cam_focus0[1], cam_focus[2] - cam_focus0[2])
+        v1 = np.array([cam_focus[0] - cam_focus0[0], cam_focus[1] - cam_focus0[1], cam_focus[2] - cam_focus0[2]])
         v1n = np.sqrt(inner1d(v1, v1))
         if not v1n:
             v1n = 1.0
@@ -2114,9 +2114,9 @@ class Viewer(wx.Panel):
             v0n = np.sqrt(inner1d(v0, v0))
 
             if self.show_object:
-                v1 = (cam_focus[0] - self.pTarget[0], cam_focus[1] - self.pTarget[1], cam_focus[2] - self.pTarget[2])
+                v1 = np.array([cam_focus[0] - self.pTarget[0], cam_focus[1] - self.pTarget[1], cam_focus[2] - self.pTarget[2]])
             else:
-                v1 = (cam_focus - self.initial_focus)
+                v1 = cam_focus - self.initial_focus
 
             v1n = np.sqrt(inner1d(v1, v1))
             if not v1n:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -24,7 +24,6 @@ import os
 import sys
 
 import numpy as np
-from numpy.core.umath_tests import inner1d
 import wx
 import queue
 
@@ -110,6 +109,7 @@ import invesalius.style as st
 import invesalius.utils as utils
 
 from invesalius import inv_paths
+from invesalius.math_utils import inner1d
 
 if sys.platform == 'win32':
     try:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -101,9 +101,9 @@ import invesalius.data.polydata_utils as pu
 from invesalius.gui.widgets.inv_spinctrl import InvSpinCtrl, InvFloatSpinCtrl
 from invesalius.gui.widgets.clut_imagedata import CLUTImageDataWidget, EVT_CLUT_NODE_CHANGED
 import numpy as np
-from numpy.core.umath_tests import inner1d
 
 from invesalius import inv_paths
+from invesalius.math_utils import inner1d
 
 
 class MaskEvent(wx.PyCommandEvent):

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -4020,7 +4020,7 @@ class ICPCorregistrationDialog(wx.Dialog):
         v0 = cam_pos0 - cam_focus0
         v0n = np.sqrt(inner1d(v0, v0))
 
-        v1 = (cam_focus - self.initial_focus)
+        v1 = cam_focus - self.initial_focus
 
         v1n = np.sqrt(inner1d(v1, v1))
         if not v1n:
@@ -5203,7 +5203,7 @@ class SetCoilOrientationDialog(wx.Dialog):
         v0 = cam_pos0 - cam_focus0
         v0n = np.sqrt(inner1d(v0, v0))
 
-        v1 = (cam_focus - self.initial_focus)
+        v1 = cam_focus - self.initial_focus
 
         v1n = np.sqrt(inner1d(v1, v1))
         if not v1n:

--- a/invesalius/math_utils.py
+++ b/invesalius/math_utils.py
@@ -76,6 +76,29 @@ def calc_polygon_area(points):
     area = abs(area / 2.0)
     return area
 
+
+def inner1d(v0: np.ndarray, v1: np.ndarray) -> np.ndarray:
+    """
+    inner on the last dimension and broadcast on the rest
+
+    imports from numpy.core.umath_tests is being deprecated
+
+    This implementation is based on
+    https://github.com/numpy/numpy/issues/10815#issuecomment-376847774
+
+    >>> a = np.array((1, 2, 3))
+    >>> b = np.array((4, 5, 6))
+    >>> inner1d(a, b)
+    32
+
+    >>> a = np.arange(9).reshape(3,3)
+    >>> b = np.arange(9).reshape(3,3)
+    >>> inner1d(a, b)
+    array([  5,  50, 149])
+    """
+    return (v0 * v1).sum(axis=-1)
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()


### PR DESCRIPTION
inner1d is being [deprecated](https://github.com/numpy/numpy/blob/5047644af5fc65830fdadcf930695d4a941448c8/doc/source/release/1.15.0-notes.rst#deprecations). I tried with numpy 1.25 and it's not even importing:

```
In [1]: from numpy.core.umath_tests import inner1d
<ipython-input-1-cbece234166d>:1: DeprecationWarning: numpy.core.umath_tests is an internal NumPy module and should not be imported. It will be removed in a future NumPy release.
  from numpy.core.umath_tests import inner1d
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
RuntimeError: The new DType API is currently in an exploratory phase and should NOT be used for production code.  Expect modifications and crashes!  To experiment with the new API you must set `NUMPY_EXPERIMENTAL_DTYPE_API=1` as an environment variable.
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[1], line 1
----> 1 from numpy.core.umath_tests import inner1d

File /nix/store/ppihfx4wzp87wj0915v7xcrjj3p13wck-python3-3.11.4-env/lib/python3.11/site-packages/numpy/core/umath_tests.py:13
      7 # 2018-04-04, numpy 1.15.0
      8 warnings.warn(("numpy.core.umath_tests is an internal NumPy "
      9                "module and should not be imported. It will "
     10                "be removed in a future NumPy release."),
     11               category=DeprecationWarning, stacklevel=2)
---> 13 from ._umath_tests import *

RuntimeError: cannot load _umath_tests module.
```

So I implemented in InVesalius [this implementation of inner1d](https://github.com/numpy/numpy/issues/10815#issuecomment-376847774). 

Please, @rmatsuda test it to see if it works.