### PR TITLE
Improve showing/hiding the slices' cross intersection tool

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -492,12 +492,12 @@ class CrossInteractorStyle(DefaultInteractorStyle):
         self.AddObserver("LeftButtonReleaseEvent", self.OnReleaseLeftButton)
 
     def SetUp(self):
-        self.viewer._set_cross_visibility(1)
+        self.viewer.set_cross_visibility(1)
         Publisher.sendMessage('Toggle toolbar item',
                               _id=self.state_code, value=True)
 
     def CleanUp(self):
-        self.viewer._set_cross_visibility(0)
+        self.viewer.set_cross_visibility(0)
         Publisher.sendMessage('Remove tracts')
         Publisher.sendMessage('Toggle toolbar item',
                               _id=self.state_code, value=False)
@@ -557,12 +557,12 @@ class TractsInteractorStyle(CrossInteractorStyle):
         self.AddObserver("LeftButtonReleaseEvent", self.OnTractsReleaseLeftButton)
 
     # def SetUp(self):
-    #     self.viewer._set_cross_visibility(1)
+    #     self.viewer.set_cross_visibility(1)
     #     Publisher.sendMessage('Toggle toolbar item',
     #                           _id=self.state_code, value=True)
 
     # def CleanUp(self):
-    #     self.viewer._set_cross_visibility(0)
+    #     self.viewer.set_cross_visibility(0)
     #     Publisher.sendMessage('Toggle toolbar item',
     #                           _id=self.state_code, value=False)
 

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -498,7 +498,6 @@ class CrossInteractorStyle(DefaultInteractorStyle):
 
     def CleanUp(self):
         self.viewer.set_cross_visibility(0)
-        Publisher.sendMessage('Remove tracts')
         Publisher.sendMessage('Toggle toolbar item',
                               _id=self.state_code, value=False)
 

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -436,10 +436,10 @@ class CrossInteractorStyle(DefaultInteractorStyle):
         self.AddObserver("LeftButtonPressEvent", self.OnCrossMouseClick)
 
     def SetUp(self):
-        print("SetUP")
+        self.viewer.check_ball_reference()
 
     def CleanUp(self):
-        print("CleanUp")
+        self.viewer.uncheck_ball_reference()
 
     def OnCrossMouseClick(self, obj, evt):
         x, y = self.viewer.get_vtk_mouse_position()

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -885,9 +885,6 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.UpdateWindowLevelText,
                             'Update window level text')
 
-        Publisher.subscribe(self._set_cross_visibility,
-                                 'Set cross visibility')
-
         Publisher.subscribe(self.__set_layout,
                                 'Set slice viewer layout')
 

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1189,7 +1189,7 @@ class Viewer(wx.Panel):
     #     # self.cross.SetFocalPoint(position[:3])
     #     self.UpdateSlicesPosition(None, position)
 
-    def _set_cross_visibility(self, visibility):
+    def set_cross_visibility(self, visibility):
         self.cross_actor.SetVisibility(visibility)
 
     def _set_editor_cursor_visibility(self, visibility):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1443,13 +1443,14 @@ class Viewer(wx.Panel):
 
     def UpdateCameraBallPosition(self, position):
         #if not self.actor_peel:
-        coord_flip = list(position[:3])
-        coord_flip[1] = -coord_flip[1]
-        self.ball_actor.SetPosition(coord_flip)
-        if self.set_camera_position:
-            self.SetVolumeCamera(coord_flip)
-        if not self.nav_status:
-            self.UpdateRender()
+        if self.ball_actor is not None:
+            coord_flip = list(position[:3])
+            coord_flip[1] = -coord_flip[1]
+            self.ball_actor.SetPosition(coord_flip)
+            if self.set_camera_position:
+                self.SetVolumeCamera(coord_flip)
+            if not self.nav_status:
+                self.UpdateRender()
 
     def AddObjectActor(self, obj_name):
         """

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -347,8 +347,6 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.RemoveVolume, 'Remove Volume')
 
         Publisher.subscribe(self.UpdateCameraBallPosition, 'Set cross focal point')
-        Publisher.subscribe(self._check_ball_reference, 'Enable style')
-        Publisher.subscribe(self._uncheck_ball_reference, 'Disable style')
 
         Publisher.subscribe(self.OnSensors, 'Sensors ID')
         Publisher.subscribe(self.OnRemoveSensorsID, 'Remove sensors ID')
@@ -481,32 +479,30 @@ class Viewer(wx.Panel):
 
         self.UpdateRender()
 
-    def _check_ball_reference(self, style):
-        if style == const.SLICE_STATE_CROSS:
-            self._mode_cross = True
-            # self._check_and_set_ball_visibility()
-            #if not self.actor_peel:
-            self._ball_ref_visibility = True
-            #else:
-            #    self._ball_ref_visibility = False
-            # if self._to_show_ball:
-            if not self.ball_actor: #and not self.actor_peel:
-                self.CreateBallReference()
-                #self.ball_actor.SetVisibility(1)
-            #else:
-             #   self.ball_actor.SetVisibility(0)
-            self.UpdateRender()
+    def check_ball_reference(self):
+        self._mode_cross = True
+        # self._check_and_set_ball_visibility()
+        #if not self.actor_peel:
+        self._ball_ref_visibility = True
+        #else:
+        #    self._ball_ref_visibility = False
+        # if self._to_show_ball:
+        if not self.ball_actor: #and not self.actor_peel:
+            self.CreateBallReference()
+            #self.ball_actor.SetVisibility(1)
+        #else:
+         #   self.ball_actor.SetVisibility(0)
+        self.UpdateRender()
 
-    def _uncheck_ball_reference(self, style):
-        if style == const.SLICE_STATE_CROSS:
-            self._mode_cross = False
-            # self.RemoveBallReference()
-            self._ball_ref_visibility = True
-            if self.ball_actor:
-                self.ren.RemoveActor(self.ball_actor)
-                self.ball_actor = None
+    def uncheck_ball_reference(self):
+        self._mode_cross = False
+        # self.RemoveBallReference()
+        self._ball_ref_visibility = True
+        if self.ball_actor:
+            self.ren.RemoveActor(self.ball_actor)
+            self.ball_actor = None
 
-            self.UpdateRender()
+        self.UpdateRender()
     
     
     def OnSensors(self, markers_flag):

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -1987,8 +1987,8 @@ class SliceToolBar(AuiToolBar):
             if state:
                 self.ToggleTool(id, False)
                 if id == const.SLICE_STATE_CROSS:
-                    msg = 'Set cross visibility'
-                    Publisher.sendMessage(msg, visibility=0)
+                    msg = 'Disable style'
+                    Publisher.sendMessage(msg, style=const.SLICE_STATE_CROSS)
         self.Refresh()
 
     def OnToggle(self, evt=None, id=None):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -949,7 +949,7 @@ class NeuronavigationPanel(wx.Panel):
         Publisher.sendMessage('Delete all markers')
         Publisher.sendMessage("Update marker offset state", create=False)
         Publisher.sendMessage("Remove tracts")
-        Publisher.sendMessage("Set cross visibility", visibility=0)
+        Publisher.sendMessage("Disable style", style=const.SLICE_STATE_CROSS)
         # TODO: Reset camera initial focus
         Publisher.sendMessage('Reset cam clipping range')
         self.navigation.StopNavigation()


### PR DESCRIPTION
Removed the _'Set cross visibility'_-messages in closing the project and changing the tool in favour of _'Enable style'_-messages, which have previously been used elsewhere in the invesalius code. 

The visibility of the ball reference on the 3D-surface is now controlled in the _SetUp_ and _CleanUp_ functions in _styles_3d.py_ instead of directly subscribing to _'Enable style'_. This is similar to how the visibility of the cross slices is controlled in _styles.py_.

Tracts are no longer removed when deselecting the cross tool.

Reduced console spam.

Fixes #216 resolves #618 resolves #620