### PR TITLE
Improve showing the coil and target mode

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -232,7 +232,7 @@ class Viewer(wx.Panel):
         self.obj_actor = None
         self.obj_axes = None
         self.obj_name = False
-        self.show_object = None
+        self.show_object = False
         self.obj_actor_list = None
         self.arrow_actor_list = None
         self.pTarget = [0., 0., 0.]
@@ -1262,7 +1262,7 @@ class Viewer(wx.Panel):
         self.dummy_coil_actor.GetProperty().SetSpecular(0.5)
         self.dummy_coil_actor.GetProperty().SetSpecularPower(10)
         self.dummy_coil_actor.GetProperty().SetOpacity(.3)
-        self.dummy_coil_actor.SetVisibility(1)
+        self.dummy_coil_actor.SetVisibility(self.show_object)
         self.dummy_coil_actor.SetUserMatrix(self.m_img_vtk)
 
         self.ren.AddActor(self.dummy_coil_actor)
@@ -2161,6 +2161,8 @@ class Viewer(wx.Panel):
 
     def ShowObject(self, checked):
         self.show_object = checked
+        if self.dummy_coil_actor is not None:
+            self.dummy_coil_actor.SetVisibility(self.show_object)
 
         if self.obj_actor and not self.show_object:
             self.obj_actor.SetVisibility(self.show_object)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -225,6 +225,7 @@ class Viewer(wx.Panel):
         self.added_actor = 0
 
         self.camera_state = const.CAM_MODE
+        self.camera_show_object = None
 
         self.nav_status = False
 
@@ -1027,6 +1028,7 @@ class Viewer(wx.Panel):
 
         else:
             self.DisableCoilTracker()
+            self.camera_show_object = None
             if self.actor_peel:
                 if self.object_orientation_torus_actor:
                     self.object_orientation_torus_actor.SetVisibility(1)
@@ -2074,6 +2076,7 @@ class Viewer(wx.Panel):
                 #self.z_actor.SetVisibility(self.show_object)
                 #self.object_orientation_torus_actor.SetVisibility(self.show_object)
                 #self.obj_projection_arrow_actor.SetVisibility(self.show_object)
+        self.camera_show_object = None
         self.UpdateRender()
 
     def UpdateSeedOffset(self, data):
@@ -2285,6 +2288,7 @@ class Viewer(wx.Panel):
 
     def SetVolumeCameraState(self, camera_state):
         self.camera_state = camera_state
+        self.camera_show_object = None
 
     # def SetVolumeCamera(self, arg, position):
     def SetVolumeCamera(self, cam_focus):
@@ -2302,7 +2306,10 @@ class Viewer(wx.Panel):
             v0 = cam_pos0 - cam_focus0
             v0n = np.sqrt(inner1d(v0, v0))
 
-            if self.show_object:
+            if self.camera_show_object is None:
+                self.camera_show_object = self.show_object
+
+            if self.camera_show_object:
                 v1 = np.array([cam_focus[0] - self.pTarget[0], cam_focus[1] - self.pTarget[1], cam_focus[2] - self.pTarget[2]])
             else:
                 v1 = cam_focus - self.initial_focus

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2164,7 +2164,7 @@ class Viewer(wx.Panel):
         if self.dummy_coil_actor is not None:
             self.dummy_coil_actor.SetVisibility(self.show_object)
 
-        if self.obj_actor and not self.show_object:
+        if self.obj_actor:
             self.obj_actor.SetVisibility(self.show_object)
             self.x_actor.SetVisibility(self.show_object)
             self.y_actor.SetVisibility(self.show_object)

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -391,7 +391,6 @@ class VolumeToolPanel(wx.Panel):
         self.navigation_status = False
 
         self.target_selected = False
-        self.show_coil_checked = False
 
         sizer.Fit(self)
 
@@ -415,7 +414,6 @@ class VolumeToolPanel(wx.Panel):
         Publisher.subscribe(self.DisableTargetMode, 'Disable target mode')
 
         # Conditions for enabling target button:
-        Publisher.subscribe(self.ShowCoilChecked, 'Show-coil checked')
         Publisher.subscribe(self.TargetSelected, 'Target selected')
 
     def DisablePreset(self):
@@ -443,10 +441,6 @@ class VolumeToolPanel(wx.Panel):
     def OnButtonSlicePlane(self, evt):
         self.button_slice_plane.PopupMenu(self.slice_plane_menu)
 
-    def ShowCoilChecked(self, checked):
-        self.show_coil_checked = checked
-        self.UpdateTargetButton()
-
     def TargetSelected(self, status):
         self.target_selected = status
         self.UpdateTargetButton()
@@ -462,7 +456,7 @@ class VolumeToolPanel(wx.Panel):
         self.button_target._SetState(0)
 
     def UpdateTargetButton(self):
-        if self.target_selected and self.show_coil_checked:
+        if self.target_selected:
             self.button_target.Enable(1)
         else:
             self.DisableTargetMode()

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -390,7 +390,9 @@ class VolumeToolPanel(wx.Panel):
 
         self.navigation_status = False
 
+        # Conditions for enabling Target button:
         self.target_selected = False
+        self.track_obj = False
 
         sizer.Fit(self)
 
@@ -415,6 +417,7 @@ class VolumeToolPanel(wx.Panel):
 
         # Conditions for enabling target button:
         Publisher.subscribe(self.TargetSelected, 'Target selected')
+        Publisher.subscribe(self.TrackObject, 'Track object')
 
     def DisablePreset(self):
         self.off_item.Check(1)
@@ -445,6 +448,10 @@ class VolumeToolPanel(wx.Panel):
         self.target_selected = status
         self.UpdateTargetButton()
 
+    def TrackObject(self, enabled):
+        self.track_obj = enabled
+        self.UpdateTargetButton()
+
     def ShowTargetButton(self):
         self.button_target.Show()
 
@@ -456,7 +463,7 @@ class VolumeToolPanel(wx.Panel):
         self.button_target._SetState(0)
 
     def UpdateTargetButton(self):
-        if self.target_selected:
+        if self.target_selected and self.track_obj:
             self.button_target.Enable(1)
         else:
             self.DisableTargetMode()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -314,8 +314,6 @@ class InnerFoldPanel(wx.Panel):
         sizer.Add(line_sizer, 1, wx.GROW | wx.EXPAND)
         sizer.Fit(self)
 
-        self.track_obj = False
-
         self.SetSizer(sizer)
         self.Update()
         self.SetAutoLayout(1)
@@ -341,11 +339,8 @@ class InnerFoldPanel(wx.Panel):
     def OnCheckStatus(self, nav_status, vis_status):
         if nav_status:
             self.checkbox_serial_port.Enable(False)
-            self.checkobj.Enable(False)
         else:
             self.checkbox_serial_port.Enable(True)
-            if self.track_obj:
-                self.checkobj.Enable(True)
 
     def OnEnableSerialPort(self, evt, ctrl):
         if ctrl.GetValue():
@@ -367,7 +362,6 @@ class InnerFoldPanel(wx.Panel):
 
     def CheckShowCoil(self, checked=False):
         self.checkobj.SetValue(checked)
-        self.track_obj = checked
 
         self.OnShowCoil()
 
@@ -1158,9 +1152,6 @@ class ObjectRegistrationPanel(wx.Panel):
 
     def EnableTrackObjectCheckbox(self, enabled):
         self.checkbox_track_object.Enable(enabled)
-        if enabled:
-            checked = self.checkbox_track_object.IsChecked()
-            Publisher.sendMessage('Enable show-coil checkbox', enabled=checked)
 
     def CheckTrackObjectCheckbox(self, checked):
         self.checkbox_track_object.SetValue(checked)


### PR DESCRIPTION
Target mode no longer requires coil to be shown.
Orange coil for targeting now also hidden with the show-coil checkbox

Resolve #628
