### PR TITLE
Fix loading markers from file

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -548,7 +548,8 @@ def ShowLoadCSVDebugEfield(message=_(u"Load debug CSV Enorm file"), current_dir=
         return None
 
 def ShowLoadSaveDialog(message=_(u"Load File"), current_dir=os.path.abspath("."), style=wx.FD_OPEN | wx.FD_CHANGE_DIR,
-                       wildcard=_("Registration files (*.obr)|*.obr"), default_filename="", save_ext=None):
+                       wildcard=_("Registration files (*.obr)|*.obr"), default_filename="", save_ext=None,
+                       customize_hook=None):
 
     dlg = wx.FileDialog(None, message=message, defaultDir="", defaultFile=default_filename,
                         wildcard=wildcard, style=style)
@@ -556,6 +557,10 @@ def ShowLoadSaveDialog(message=_(u"Load File"), current_dir=os.path.abspath(".")
     # Show the dialog and retrieve the user response. If it is the OK response,
     # process the data.
     filepath = None
+
+    if customize_hook is not None:
+        dlg.SetCustomizeHook(customize_hook)
+
     try:
         if dlg.ShowModal() == wx.ID_OK:
             # This returns a Python list of files that were selected.

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -543,7 +543,7 @@ class ImagePage(wx.Panel):
         Publisher.subscribe(self.OnResetImageFiducials, "Reset image fiducials")
 
     def LoadImageFiducials(self, label, position):
-        fiducial = self.GetFiducialByAttribute(const.IMAGE_FIDUCIALS, 'label', label)
+        fiducial = self.GetFiducialByAttribute(const.IMAGE_FIDUCIALS, 'fiducial_name', label[:2])
 
         fiducial_index = fiducial['fiducial_index']
         fiducial_name = fiducial['fiducial_name']
@@ -2544,8 +2544,8 @@ class MarkersPanel(wx.Panel):
             with open(filename, 'r') as file:
                 magick_line = file.readline()
                 assert magick_line.startswith(const.MARKER_FILE_MAGICK_STRING)
-                ver = int(magick_line.split('_')[-1])
-                if ver != 0:
+                version = int(magick_line.split('_')[-1])
+                if version != 0:
                     wx.MessageBox(_("Unknown version of the markers file."), _("InVesalius 3"))
                     return
                 
@@ -2555,8 +2555,9 @@ class MarkersPanel(wx.Panel):
                 for line in file.readlines():
                     marker = self.Marker()
                     marker.from_string(line)
-                    self.CreateMarker(position=marker.position, orientation=marker.orientation, colour=marker.colour, size=marker.size,
-                                      label=marker.label, is_target=False, seed=marker.seed, session_id=marker.session_id, is_brain_target=marker.is_brain_target)
+                    self.CreateMarker(position=marker.position, orientation=marker.orientation, colour=marker.colour,
+                                      size=marker.size, label=marker.label, is_target=False, seed=marker.seed,
+                                      session_id=marker.session_id, is_brain_target=marker.is_brain_target)
 
                     if marker.label in self.__list_fiducial_labels():
                         Publisher.sendMessage('Load image fiducials', label=marker.label, position=marker.position)
@@ -2568,6 +2569,7 @@ class MarkersPanel(wx.Panel):
 
         except Exception as e:
             wx.MessageBox(_("Invalid markers file."), _("InVesalius 3"))
+            utils.debug(e)
 
         self.SaveState()
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1873,6 +1873,8 @@ class MarkersPanel(wx.Panel):
                     setattr(self, field.name, str_val[1:-1]) # remove the quotation marks
                 if field.type is bool:
                     setattr(self, field.name, str_val=='True')
+                if field.type is int and str_val != 'None':
+                    setattr(self, field.name, int(str_val))
 
         def to_dict(self):
             return {


### PR DESCRIPTION
Fixes loading markers from file not working with image fiducial markers.

Fixes session not being correctly loaded from marker file.

New "Overwrite image fiducials"-checkbox when loading marker file for overwriting current image fiducials. Replaces old feature to load unset image fiducials from marker file..