### PR TITLE
Replace FileDialogCustomizeHook uses with another dialog type

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -315,6 +315,11 @@ SURFACE_QUALITY_LIST = [_("Low"),_("Medium"),_("High"),_("Optimal *")]
 SURFACE_TRANSPARENCY = 0.0
 SURFACE_NAME_PATTERN = _("Surface %d")
 
+# Surface importing/exporting options
+SURFACE_SPACE_WORLD = 0
+SURFACE_SPACE_INV = 1
+SURFACE_SPACE_CHOICES = [_("world/scanner space"), _("InVesalius space")]
+
 # Imagedata - window and level presets
 WINDOW_LEVEL = {_("Abdomen"):(350,50),
                 _("Bone"):(2000, 300),

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6367,7 +6367,7 @@ class PeelsCreationDlg(wx.Dialog):
         self.get_all_masks()
 
     def _init_gui(self):
-        self.SetTitle("dialog")
+        self.SetTitle(_("Peels creation"))
 
         from_mask_stbox = self._from_mask_gui()
         from_files_stbox = self._from_files_gui()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2564,6 +2564,7 @@ class MarkersPanel(wx.Panel):
             utils.debug(e)
 
         self.SaveState()
+        Publisher.sendMessage("Update UI for refine tab")
 
     def OnLoadMarkers(self, evt):
         """Loads markers from file and appends them to the current marker list.


### PR DESCRIPTION
Changes to GUI used for importing/exporting 3D surfaces with a defined affine and when loading markers from file.