### PR TITLE
Fix color management with wxPython color buttons and surface

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1088,17 +1088,15 @@ class Slice(metaclass=utils.Singleton):
         "Set a mask colour given its index and colour (RGB 0-1 values)"
         proj = Project()
         proj.mask_dict[index].set_colour(colour)
+        colour_wx = [int(value * 255) for value in colour]
 
-        (r, g, b) = colour[:3]
-        colour_wx = [r * 255, g * 255, b * 255]
-        Publisher.sendMessage(
-            "Change mask colour in notebook", index=index, colour=(r, g, b)
-        )
+        Publisher.sendMessage("Change mask colour in notebook", index=index, colour=colour[:3])
         Publisher.sendMessage("Set GUI items colour", colour=colour_wx)
         if update:
             # Updating mask colour on vtkimagedata.
             for buffer_ in self.buffer_slices.values():
                 buffer_.discard_vtk_mask()
+
             Publisher.sendMessage("Reload actual slice")
 
         session = ses.Session()

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -580,7 +580,7 @@ class SurfaceManager():
             self.last_surface_index = index
 
         # Set actor colour and transparency
-        actor.GetProperty().SetColor(surface.colour)
+        actor.GetProperty().SetColor(surface.colour[:3])
         actor.GetProperty().SetOpacity(1-surface.transparency)
 
         if overwrite and self.actors_dict.keys():

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -1206,8 +1206,8 @@ class NewMask(wx.Dialog):
         import invesalius.project as prj
         proj = prj.Project()
         (thresh_min, thresh_max) = proj.threshold_modes[evt.GetString()]
-        self.gradient.SetMinimun(thresh_min)
-        self.gradient.SetMaximun(thresh_max)
+        self.gradient.SetMinValue(thresh_min)
+        self.gradient.SetMaxValue(thresh_max)
 
     def OnSlideChanged(self, evt):
         import invesalius.project as prj

--- a/invesalius/gui/task_surface.py
+++ b/invesalius/gui/task_surface.py
@@ -569,7 +569,7 @@ class SurfaceProperties(scrolled.ScrolledPanel):
     def InsertNewSurface(self, surface):
         index = surface.index
         name = surface.name
-        colour = [value*255 for value in surface.colour]
+        colour = [int(value*255) for value in surface.colour]
         i = 0
         try:
             i = self.surface_list.index([name, index])
@@ -586,6 +586,7 @@ class SurfaceProperties(scrolled.ScrolledPanel):
         self.combo_surface_name.SetItems([n[0] for n in self.surface_list])
         self.combo_surface_name.SetSelection(i)
         transparency = 100*surface.transparency
+        # print("Button color: ", colour)
         self.button_colour.SetColour(colour)
         self.slider_transparency.SetValue(int(transparency))
         #  Publisher.sendMessage('Update surface data', (index))


### PR DESCRIPTION
Fix 3 bugs with surface and mask color management and wx controls

1. wx color buttons require integers and float were given, making all color buttons white
2. wx gradient methods to set min and max values were updated, as they were raising errors due to deprecated use of methods
3. remove_non_visible_faces plugin was raising an error when the color of the surface was changed before applying the plugin due to the variable having 4 values while the method expected 3