### PR TITLE
UPD: Bump opencv and pyacvd in optional requirements which was incomp…

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -5,5 +5,3 @@ python-rtmidi==1.4.9
 python-socketio[client]==5.3.0
 requests==2.26.0
 uvicorn[standard]==0.15.0
-opencv-python==4.7.0.72
-pyacvd==0.2.9

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -5,5 +5,5 @@ python-rtmidi==1.4.9
 python-socketio[client]==5.3.0
 requests==2.26.0
 uvicorn[standard]==0.15.0
-opencv-python==4.5.3.56
-pyacvd==0.2.7
+opencv-python==4.7.0.72
+pyacvd==0.2.9


### PR DESCRIPTION
Current version of opencv in optional-requirements was incompatible to the given numpy version. Also updated the pyacvd version to match the environment.yml.