### PR TITLE
FIX: target toggle button update

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1730,7 +1730,7 @@ class ControlPanel(wx.Panel):
     def UpdateTargetButton(self):
         if self.target_selected and self.track_obj:
             self.EnableToggleButton(self.target_checkbox, True)
-            self.UpdateToggleButton(self.target_checkbox, False)
+            self.UpdateToggleButton(self.target_checkbox, self.target_checkbox.GetValue())
         else:
             self.DisableTargetMode()
             self.EnableToggleButton(self.target_checkbox, False)


### PR DESCRIPTION
If target mode is on, and a new target is set, it turns to false. This pull request fixes that