### PR TITLE
Replaced `mktemp` with `mkstemp`

### DIFF
--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -304,12 +304,14 @@ def create_dicom_thumbnails(image, window=None, level=None):
 
 
 def array2memmap(arr, filename=None):
+    fd = None
     if filename is None:
         fd, filename = tempfile.mkstemp(prefix="inv3_", suffix=".dat")
     matrix = numpy.memmap(filename, mode="w+", dtype=arr.dtype, shape=arr.shape)
     matrix[:] = arr[:]
     matrix.flush()
-    os.close(fd)
+    if fd:
+        os.close(fd)
     return matrix
 
 

--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import os
 import math
 import sys
 import tempfile
@@ -132,9 +133,10 @@ def resize_slice(im_array, resolution_percentage):
 def resize_image_array(image, resolution_percentage, as_mmap=False):
     out = zoom(image, resolution_percentage, image.dtype, order=2)
     if as_mmap:
-        fname = tempfile.mktemp(suffix="_resized")
+        fd, fname = tempfile.mkstemp(suffix="_resized")
         out_mmap = np.memmap(fname, shape=out.shape, dtype=out.dtype, mode="w+")
         out_mmap[:] = out
+        os.close(fd)
         return out_mmap
     return out
 
@@ -282,12 +284,13 @@ def create_dicom_thumbnails(image, window=None, level=None):
             thumb_image = np.array(
                 get_LUT_value_255(thumb_image, window, level), dtype=np.uint8
             )
-            thumbnail_path = tempfile.mktemp(prefix="thumb_", suffix=".png")
+            fd, thumbnail_path = tempfile.mkstemp(prefix="thumb_", suffix=".png")
             imageio.imsave(thumbnail_path, thumb_image)
             thumbnail_paths.append(thumbnail_path)
+            os.close(fd)
         return thumbnail_paths
     else:
-        thumbnail_path = tempfile.mktemp(prefix="thumb_", suffix=".png")
+        fd, thumbnail_path = tempfile.mkstemp(prefix="thumb_", suffix=".png")
         if pf.GetSamplesPerPixel() == 1:
             thumb_image = zoom(np_image, 0.25)
             thumb_image = np.array(
@@ -296,15 +299,17 @@ def create_dicom_thumbnails(image, window=None, level=None):
         else:
             thumb_image = zoom(np_image, (0.25, 0.25, 1))
         imageio.imsave(thumbnail_path, thumb_image)
+        os.close(fd)
         return thumbnail_path
 
 
 def array2memmap(arr, filename=None):
     if filename is None:
-        filename = tempfile.mktemp(prefix="inv3_", suffix=".dat")
+        fd, filename = tempfile.mkstemp(prefix="inv3_", suffix=".dat")
     matrix = numpy.memmap(filename, mode="w+", dtype=arr.dtype, shape=arr.shape)
     matrix[:] = arr[:]
     matrix.flush()
+    os.close(fd)
     return matrix
 
 
@@ -319,7 +324,7 @@ def bitmap2memmap(files, slice_size, orientation, spacing, resolution_percentage
             len(files) - 1, dialog_type="ProgressDialog"
         )
 
-    temp_file = tempfile.mktemp()
+    temp_fd, temp_file = tempfile.mkstemp()
 
     if orientation == "SAGITTAL":
         if resolution_percentage == 1.0:
@@ -424,6 +429,7 @@ def bitmap2memmap(files, slice_size, orientation, spacing, resolution_percentage
 
     matrix.flush()
     scalar_range = min_scalar, max_scalar
+    os.close(temp_fd)
 
     return matrix, scalar_range, temp_file
 
@@ -442,7 +448,7 @@ def dcm2memmap(files, slice_size, orientation, resolution_percentage):
     first_slice = read_dcm_slice_as_np2(files[0], resolution_percentage)
     slice_size = first_slice.shape[::-1]
 
-    temp_file = tempfile.mktemp()
+    temp_fd, temp_file = tempfile.mkstemp()
 
     if orientation == "SAGITTAL":
         shape = slice_size[0], slice_size[1], len(files)
@@ -469,6 +475,7 @@ def dcm2memmap(files, slice_size, orientation, resolution_percentage):
 
     matrix.flush()
     scalar_range = matrix.min(), matrix.max()
+    os.close(temp_fd)
 
     return matrix, scalar_range, temp_file
 
@@ -484,7 +491,7 @@ def dcmmf2memmap(dcm_file, orientation):
     np_image = converters.gdcm_to_numpy(image, pf.GetSamplesPerPixel() == 1)
     if samples_per_pixel == 3:
         np_image = image_normalize(rgb2gray(np_image), 0, 255)
-    temp_file = tempfile.mktemp()
+    temp_fd, temp_file = tempfile.mkstemp()
     matrix = numpy.memmap(temp_file, mode="w+", dtype="int16", shape=np_image.shape)
     z, y, x = np_image.shape
     if orientation == "CORONAL":
@@ -503,6 +510,7 @@ def dcmmf2memmap(dcm_file, orientation):
 
     matrix.flush()
     scalar_range = matrix.min(), matrix.max()
+    os.close(temp_fd)
 
     return matrix, scalar_range, spacing, temp_file
 
@@ -513,7 +521,7 @@ def img2memmap(group):
     returns it and its related filename.
     """
 
-    temp_file = tempfile.mktemp()
+    temp_fd, temp_file = tempfile.mkstemp()
 
     data = group.get_fdata()
 
@@ -533,6 +541,7 @@ def img2memmap(group):
     matrix.flush()
 
     scalar_range = numpy.amin(matrix), numpy.amax(matrix)
+    os.close(temp_fd)
 
     return matrix, scalar_range, temp_file
 

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -40,7 +40,7 @@ class EditionHistoryNode(object):
     def __init__(self, index, orientation, array, clean=False):
         self.index = index
         self.orientation = orientation
-        self.filename = tempfile.mktemp(suffix='.npy')
+        self.fd, self.filename = tempfile.mkstemp(suffix='.npy')
         self.clean = clean
 
         self._save_array(array)
@@ -70,6 +70,7 @@ class EditionHistoryNode(object):
 
     def __del__(self):
         print("Removing", self.filename)
+        os.close(self.fd)
         os.remove(self.filename)
 
 
@@ -295,11 +296,12 @@ class Mask():
         plist_filename = filename + u'.plist'
         #plist_filepath = os.path.join(dir_temp, plist_filename)
 
-        temp_plist = tempfile.mktemp()
+        temp_fd, temp_plist = tempfile.mkstemp()
         with open(temp_plist, 'w+b') as f:
             plistlib.dump(mask, f)
 
         filelist[temp_plist] = plist_filename
+        os.close(temp_fd)
 
         return plist_filename
 
@@ -377,7 +379,7 @@ class Mask():
         Parameters:
             shape(int, int, int): The shape of the new mask.
         """
-        self.temp_file = tempfile.mktemp()
+        self.temp_fd, self.temp_file = tempfile.mkstemp()
         shape = shape[0] + 1, shape[1] + 1, shape[2] + 1
         self.matrix = np.memmap(self.temp_file, mode='w+', dtype='uint8', shape=shape)
 
@@ -487,4 +489,5 @@ class Mask():
             del self.matrix
         except AttributeError:
             pass
+        os.close(self.temp_fd)
         os.remove(self.temp_file)

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -527,9 +527,10 @@ class Slice(metaclass=utils.Singleton):
         f.close()
 
     def create_temp_mask(self):
-        temp_file = tempfile.mktemp()
+        temp_fd, temp_file = tempfile.mkstemp()
         shape = self.matrix.shape
         matrix = np.memmap(temp_file, mode="w+", dtype="uint8", shape=shape)
+        os.close(temp_fd)
         return temp_file, matrix
 
     def edit_mask_pixel(self, operation, index, position, radius, orientation):
@@ -1713,7 +1714,7 @@ class Slice(metaclass=utils.Singleton):
         Publisher.sendMessage("Reload actual slice")
 
     def apply_reorientation(self):
-        temp_file = tempfile.mktemp()
+        temp_fd, temp_file = tempfile.mkstemp()
         mcopy = np.memmap(
             temp_file, shape=self.matrix.shape, dtype=self.matrix.dtype, mode="w+"
         )
@@ -1737,6 +1738,7 @@ class Slice(metaclass=utils.Singleton):
         )
 
         del mcopy
+        os.close(temp_fd)
         os.remove(temp_file)
 
         self.q_orientation = np.array((1, 0, 0, 0))

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -1941,7 +1941,7 @@ class WaterShedInteractorStyle(DefaultInteractorStyle):
         if BRUSH_BACKGROUND in markers and BRUSH_FOREGROUND in markers:
             #w_algorithm = WALGORITHM[self.config.algorithm]
             bstruct = generate_binary_structure(3, CON3D[self.config.con_3d])
-            tfile = tempfile.mktemp()
+            fd, tfile = tempfile.mkstemp()
             tmp_mask = np.memmap(tfile, shape=mask.shape, dtype=mask.dtype,
                                  mode='w+')
             q = multiprocessing.Queue()
@@ -1951,6 +1951,7 @@ class WaterShedInteractorStyle(DefaultInteractorStyle):
                                         self.config.mg_size,
                                         self.config.use_ww_wl, wl, ww, q))
 
+            os.close(fd)
             wp = WatershedProgressWindow(p)
             p.start()
 

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -119,9 +119,10 @@ class Surface():
         else:
             filename = u'surface_%d' % self.index
             vtp_filename = filename + u'.vtp'
-            vtp_filepath = tempfile.mktemp()
+            vtp_fd, vtp_filepath = tempfile.mkstemp()
             pu.Export(self.polydata, vtp_filepath, bin=True)
             self.filename = vtp_filepath
+            os.close(vtp_fd)
 
         filelist[vtp_filepath] = vtp_filename
 
@@ -136,11 +137,12 @@ class Surface():
                   }
         plist_filename = filename + u'.plist'
         #plist_filepath = os.path.join(dir_temp, filename + '.plist')
-        temp_plist = tempfile.mktemp()
+        temp_fd, temp_plist = tempfile.mkstemp()
         with open(temp_plist, 'w+b') as f:
             plistlib.dump(surface, f)
 
         filelist[temp_plist] = plist_filename
+        os.close(temp_fd)
 
         return plist_filename
 
@@ -1052,12 +1054,12 @@ class SurfaceManager():
             const.FILETYPE_STL_ASCII: '.stl',
         }
         if filetype in ftype_prefix:
-            temp_file = tempfile.mktemp(suffix=ftype_prefix[filetype])
+            temp_fd, temp_file = tempfile.mkstemp(suffix=ftype_prefix[filetype])
 
             if _has_win32api:
-                utl.touch(temp_file)
                 _temp_file = temp_file
                 temp_file = win32api.GetShortPathName(temp_file)
+                os.close(temp_fd)
                 os.remove(_temp_file)
 
             temp_file = utl.decode(temp_file, const.FS_ENCODE)

--- a/invesalius/data/surface_process.py
+++ b/invesalius/data/surface_process.py
@@ -75,11 +75,12 @@ def create_surface_piece(filename, shape, dtype, mask_filename, mask_shape,
                          from_binary, algorithm, imagedata_resolution, fill_border_holes):
 
 
-    log_path = tempfile.mktemp('vtkoutput.txt')
+    log_fd, log_path = tempfile.mkstemp('vtkoutput.txt')
     fow = vtkFileOutputWindow()
     fow.SetFileName(log_path)
     ow = vtkOutputWindow()
     ow.SetInstance(fow)
+    os.close(log_fd)
 
 
     pad_bottom = (roi.start == 0)
@@ -176,7 +177,7 @@ def create_surface_piece(filename, shape, dtype, mask_filename, mask_shape,
     del image
     del contour
 
-    filename = tempfile.mktemp(suffix='_%d_%d.vtp' % (roi.start, roi.stop))
+    fd, filename = tempfile.mkstemp(suffix='_%d_%d.vtp' % (roi.start, roi.stop))
     writer = vtkXMLPolyDataWriter()
     writer.SetInputData(polydata)
     writer.SetFileName(filename)
@@ -184,6 +185,7 @@ def create_surface_piece(filename, shape, dtype, mask_filename, mask_shape,
 
     print("Writing piece", roi, "to", filename)
     print("MY PID MC", os.getpid())
+    os.close(fd)
     return filename
 
 
@@ -194,11 +196,12 @@ def join_process_surface(filenames, algorithm, smooth_iterations, smooth_relaxat
         except queue.Full as e:
             print(e)
 
-    log_path = tempfile.mktemp('vtkoutput.txt')
+    log_fd, log_path = tempfile.mkstemp('vtkoutput.txt')
     fow = vtkFileOutputWindow()
     fow.SetFileName(log_path)
     ow = vtkOutputWindow()
     ow.SetInstance(fow)
+    os.close(log_fd)
 
     send_message('Joining surfaces ...')
     polydata_append = vtkAppendPolyData()
@@ -423,7 +426,7 @@ def join_process_surface(filenames, algorithm, smooth_iterations, smooth_relaxat
     area =  float(measured_polydata.GetSurfaceArea())
     del measured_polydata
 
-    filename = tempfile.mktemp(suffix='_full.vtp')
+    fd, filename = tempfile.mkstemp(suffix='_full.vtp')
     writer = vtkXMLPolyDataWriter()
     writer.SetInputData(polydata)
     writer.SetFileName(filename)
@@ -431,4 +434,5 @@ def join_process_surface(filenames, algorithm, smooth_iterations, smooth_relaxat
     del writer
 
     print("MY PID", os.getpid())
+    os.close(fd)
     return filename, {'volume': volume, 'area': area}

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -256,20 +256,22 @@ class Project(metaclass=Singleton):
         # Saving the measurements
         measurements = self.GetMeasuresDict()
         measurements_filename = 'measurements.plist'
-        temp_mplist = tempfile.mktemp()
+        fd_mplist, temp_mplist = tempfile.mkstemp()
         with open(temp_mplist, 'w+b') as f:
             plistlib.dump(measurements, f)
         filelist[temp_mplist] = measurements_filename
         project['measurements'] = measurements_filename
+        os.close(fd_mplist)
 
         # Saving the annotations (empty in this version)
         project['annotations'] = {}
 
         # Saving the main plist
-        temp_plist = tempfile.mktemp()
+        temp_fd, temp_plist = tempfile.mkstemp()
         with open(temp_plist, 'w+b') as f:
             plistlib.dump(project, f)
         filelist[temp_plist] = 'main.plist'
+        os.close(temp_fd)
 
         # Compressing and generating the .inv3 file
         path = os.path.join(dir_,filename)
@@ -469,9 +471,8 @@ class Project(metaclass=Singleton):
 def Compress(folder, filename, filelist, compress=False):
     tmpdir, tmpdir_ = os.path.split(folder)
     current_dir = os.path.abspath(".")
-    temp_inv3 = tempfile.mktemp()
+    fd_inv3, temp_inv3 = tempfile.mkstemp()
     if _has_win32api:
-        touch(temp_inv3)
         temp_inv3 = win32api.GetShortPathName(temp_inv3)
 
     temp_inv3 = decode(temp_inv3, const.FS_ENCODE)
@@ -484,6 +485,7 @@ def Compress(folder, filename, filelist, compress=False):
     for name in filelist:
         tar.add(name, arcname=os.path.join(tmpdir_, filelist[name]))
     tar.close()
+    os.close(fd_inv3)
     shutil.move(temp_inv3, filename)
     #os.chdir(current_dir)
 

--- a/invesalius/reader/bitmap_reader.py
+++ b/invesalius/reader/bitmap_reader.py
@@ -185,7 +185,7 @@ class LoadBitmap:
         image_copy = vtkImageData()
         image_copy.DeepCopy(img.GetOutput())
 
-        thumbnail_path = tempfile.mktemp()
+        fd, thumbnail_path = tempfile.mkstemp()
 
         write_png = vtkPNGWriter()
         write_png.SetInputConnection(img.GetOutputPort())
@@ -219,6 +219,7 @@ class LoadBitmap:
             file_name,
             id,
         ]
+        os.close(fd)
         self.bmp_file.Add(bmp_item)
 
 

--- a/invesalius/segmentation/deep_learning/segment.py
+++ b/invesalius/segmentation/deep_learning/segment.py
@@ -220,15 +220,19 @@ class SegmentProcess(ctx.Process):
         self._image_dtype = image.dtype
         self._image_shape = image.shape
 
+        fd, fname = tempfile.mkstemp()
         self._probability_array = np.memmap(
-            tempfile.mktemp(), shape=image.shape, dtype=np.float32, mode="w+"
+            filename=fname, shape=image.shape, dtype=np.float32, mode="w+"
         )
         self._prob_array_filename = self._probability_array.filename
+        self._prob_array_fd = fd
 
+        fd, fname = tempfile.mkstemp()
         self._comm_array = np.memmap(
-            tempfile.mktemp(), shape=(1,), dtype=np.float32, mode="w+"
+            filename=fname, shape=(1,), dtype=np.float32, mode="w+"
         )
         self._comm_array_filename = self._comm_array.filename
+        self._comm_array_fd = fd
 
         self.create_new_mask = create_new_mask
         self.backend = backend
@@ -354,9 +358,11 @@ class SegmentProcess(ctx.Process):
 
     def __del__(self):
         del self._comm_array
+        os.close(self._comm_array_fd)
         os.remove(self._comm_array_filename)
 
         del self._probability_array
+        os.close(self._prob_array_fd)
         os.remove(self._prob_array_filename)
 
 


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file(s): [mask.py](https://github.com/invesalius/invesalius3/blob/master/invesalius/data/mask.py), [slice_.py](https://github.com/invesalius/invesalius3/blob/master/invesalius/data/slice_.py), [styles.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/data/styles.py), [surface.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/data/surface.py), [imagedata_utils.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/data/imagedata_utils.py), [surface_process.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/data/surface_process.py#L81), [bitmap_reader.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/reader/bitmap_reader.py), [project.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/project.py), [segment.py](https://github.com/invesalius/invesalius3/tree/master/invesalius/segmentation/deep_learning/segment.py), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

#### Here are a few reasons why you shouldn't use `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced method `mktemp` with a safer method: `mkstemp`
- Closed the file-descriptors associated with `mkstemp` to prevent file-descriptor leaks


## Testing
No tests were performed due to lack of documentation/script. With proper guidance, I'd be happy to test the code on your behalf.


## Previously Found & Fixed
- [azure-linux-extensions](https://www.github.com/Azure/azure-linux-extensions/pull/1816)


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
