### PR TITLE
HOTFIX: Load image fiducials from file

### DIFF
--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -178,7 +178,7 @@ class LowerTaskPanel(wx.Panel):
         image_list.Add(GetCollapsedIconBitmap())
 
         # Fold 1 - Data
-        item = fold_panel.AddFoldPanel(_("Data"), collapsed=True,
+        item = fold_panel.AddFoldPanel(_("Data"), collapsed=False,
                                        foldIcons=image_list)
         style = fold_panel.GetCaptionStyle(item)
         col = style.GetFirstColour()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -342,10 +342,10 @@ class InnerFoldPanel(wx.Panel):
 
         if id == self.__id_nav:
             status = self.CheckRegistration()
-            if not status:
+            """ if not status:
                 self.fold_panel.Expand(self.fold_panel.GetFoldPanel(0))
                 wx.MessageBox(_("Complete coregistration first!"), _("InVesalius 3"))
-                return
+                return """
         if not expanded:
             self.fold_panel.Expand(evt.GetTag())
         else:


### PR DESCRIPTION
Tweaks:
- Removed restriction on entering navigation panel without completing coregistration.
- Data notebook now unfolded by default.