### PR TITLE
FIX: Data notebook covers content while folded

### DIFF
--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -161,6 +161,7 @@ class LowerTaskPanel(wx.Panel):
                                       agwStyle=fpb.FPB_COLLAPSE_TO_BOTTOM)
 
         self.fold_panel = fold_panel
+        fold_panel.Bind(fpb.EVT_CAPTIONBAR, self.OnCaptionBar)
 
         self.enable_items = []
         self.overwrite = False
@@ -196,6 +197,7 @@ class LowerTaskPanel(wx.Panel):
         gbs.Add(fold_panel, (0, 0), flag=wx.EXPAND)
         gbs.Layout()
         item.ResizePanel()
+        self.ResizeFPB()
 
         sizer.Fit(self)
         self.Fit()
@@ -231,6 +233,10 @@ class LowerTaskPanel(wx.Panel):
     def __bind_events(self):
         Publisher.subscribe(self.OnEnableState, "Enable state project")
 
+    def OnCaptionBar(self, evt):
+        evt.Skip()
+        wx.CallAfter(self.ResizeFPB)
+
     def OnEnableState(self, state):
         if state:
             self.SetStateProjectOpen()
@@ -246,9 +252,10 @@ class LowerTaskPanel(wx.Panel):
             item.Enable()
 
     def ResizeFPB(self):
-        sizeNeeded = self.fold_panel.GetPanelsLength(0, 0)[2]
-        self.fold_panel.SetMinSize((self.fold_panel.GetSize()[0], sizeNeeded ))
-        self.fold_panel.SetSize((self.fold_panel.GetSize()[0], sizeNeeded))
+        y_needed = self.fold_panel.GetPanelsLength(0, 0)[2]
+        x_current, _ = self.GetSize()
+        self.SetMinSize((x_current, y_needed))
+        self.GetParent().Layout()
 
 # Upper fold panel
 class UpperTaskPanel(wx.Panel):


### PR DESCRIPTION
Data notebook minimal size now updates when collapsing/expanding the fold panel bar.

Resolve #682