### PR TITLE
Improve navigation performance slice

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -299,7 +299,8 @@ class Viewer(wx.Panel):
     def UpdateCanvas(self):
         if self.canvas is not None:
             self.canvas.modified = True
-            self.interactor.Render()
+            if not self.nav_status:
+                self.UpdateRender()
 
     def EnableRuler(self):
         self.ruler = GenericLeftRulerVolume(self)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -2068,7 +2068,7 @@ class LayoutToolBar(AuiToolBar):
         self.ontool_layout = False
         self.ontool_text = True
         self.ontool_ruler = True
-        self.enable_items = [ID_TEXT, ID_RULER]
+        self.enable_items = [ID_TEXT]
 
         self.Realize()
         self.SetStateProjectClose()
@@ -2215,7 +2215,7 @@ class LayoutToolBar(AuiToolBar):
         Disable menu items (e.g. text) when project is closed.
         """
         self.ontool_text = False
-        self.ontool_ruler = False
+        self.ontool_ruler = True
         self.ToggleText()
         self.ToggleRulers()
         for tool in self.enable_items:


### PR DESCRIPTION
The ruler update canvas was affecting the navigation performance. Now, if the navigation is on, the canvas updates only in the navigation loop.
Also, the ruler was set as disabled by default.