### PR TITLE
FIX: Closing project with keystroke pedal enabled

### DIFF
--- a/invesalius/net/pedal_connection.py
+++ b/invesalius/net/pedal_connection.py
@@ -98,7 +98,10 @@ class PedalConnector:
 
         panel = panel or self.frame
         if panel is not None and const.KEYSTROKE_PEDAL_ENABLED:
-            self.panel_callbacks[panel.GetId()].pop(name)
+            try:
+                self.panel_callbacks[panel.GetId()].pop(name)
+            except KeyError:
+                pass
 
 
 class MidiPedal(Thread, metaclass=Singleton):


### PR DESCRIPTION
Catch keystroke pedal -related KeyError when trying to stop navigation without having started it first. This happens e.g. when loading a new project on top of an existing one.

Fixes #710 
