### PR TITLE
ADD tractografy mask position correction

### DIFF
--- a/invesalius/data/brainmesh_handler.py
+++ b/invesalius/data/brainmesh_handler.py
@@ -183,7 +183,8 @@ class Brain:
     def CreateTransformedVTKAffine(self):
         affine_transformed = self.affine.copy()
         matrix_shape = tuple(self.inv_proj.matrix_shape)
-        affine_transformed[1, -1] -= matrix_shape[1]
+        slic = sl.Slice()
+        affine_transformed[1, -1] -= matrix_shape[1]*slic.spacing[1]
 
         return vtk_utils.numpy_to_vtkMatrix4x4(affine_transformed)
 


### PR DESCRIPTION
Images acquired with a 7T MRI scanner typically have a spacing different from 1. When importing the tractography mask with this non-unit spacing, an offset occurs. Therefore, this correction involves multiplying the affine matrix by the appropriate spacing factor to align the images accurately