### PR TITLE
FIX: Slices failed to update when using the cross function

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1566,6 +1566,8 @@ class Viewer(wx.Panel):
         self.scroll.SetThumbPosition(int(index))
         pos = self.scroll.GetThumbPosition()
         self.set_slice_number(pos)
+        if not self.nav_status:
+            self.UpdateRender()
 
     def ReloadActualSlice(self):
         pos = self.scroll.GetThumbPosition()


### PR DESCRIPTION
When clicking on one slice panel with the cross function enabled, the other two slices were not updated until a second click was made. This fix this issue by rendering whenever the navigation is off. 

Important! Cannot have the rendering during navigation as it will slow down due to high computational load.