### PR TITLE
CLN: Error on deleting mask

### DIFF
--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -488,5 +488,11 @@ class Mask():
             del self.matrix
         except AttributeError:
             pass
-        os.close(self.temp_fd)
+
+        # Used for masks not loaded from plist project.
+        try:
+            os.close(self.temp_fd)
+        except AttributeError:
+            pass
+
         os.remove(self.temp_file)


### PR DESCRIPTION
Clean error message on deleting a mask loaded from a project file. Error was introduced in #679, and is caused by the cleanup code attempting to delete a file through a file descriptor that doesn't exist.

Resolve #728
