### PR TITLE
FIX: Always use default coil for creating target guides

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -876,7 +876,8 @@ class Viewer(wx.Panel):
             for ind in self.guide_arrow_actors:
                 self.target_guide_renderer.RemoveActor(ind)
 
-        obj_polydata = vtku.CreateObjectPolyData(self.coil_path)
+        coil_path = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl")
+        obj_polydata = vtku.CreateObjectPolyData(coil_path)
 
         normals = vtkPolyDataNormals()
         normals.SetInputData(obj_polydata)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -876,6 +876,7 @@ class Viewer(wx.Panel):
             for ind in self.guide_arrow_actors:
                 self.target_guide_renderer.RemoveActor(ind)
 
+        # Using default coil for target guide model as using self.coil_path can cause custom models to overlap.
         coil_path = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl")
         obj_polydata = vtku.CreateObjectPolyData(coil_path)
 


### PR DESCRIPTION
Custom coil models could cause target guide models to overlap and cover content.