### PR TITLE
FIX: AttributeError when starting navigation

### DIFF
--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -55,6 +55,7 @@ class Robot(metaclass=Singleton):
         self.robot_coregistration_dialog = None
 
         self.objective = RobotObjective.NONE
+        self.target = None
 
         # If tracker already has fiducials set, send them to the robot; this can happen, e.g.,
         # when a pre-existing state is loaded at start-up.


### PR DESCRIPTION
Added field self.target to __init__() in Robot class.

Fixes error message when starting navigation without having set a target before.