### PR TITLE
FIX: Use a new marker object instead of a reference when duplicating markers

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2136,7 +2136,7 @@ class MarkersPanel(wx.Panel):
             return
 
         # Create a duplicate of the selected marker.
-        new_marker = self.__get_marker(idx)
+        new_marker = self.__get_marker(idx).duplicate()
         self.AddMarker(new_marker, render=True)
 
     def GetEfieldDataStatus(self, efield_data_loaded, indexes_saved_list):


### PR DESCRIPTION
Previously when duplicating marker, a reference to the marker being duplicated was added to the marker list so there were two references to the same marker object, which caused issues with marker id's and unexpected changes in marker data. Now duplicating a marker creates a new marker object and deep copies the data from the existing marker. 