### PR TITLE
Fix macos tracker freeze

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -618,9 +618,10 @@ class TrackerPage(wx.Panel):
         return True
 
     def OnChooseTracker(self, evt, ctrl):
-        # self.GetParent().Enable(False)
-        # self.HideParent()
-        wx.CallAfter(self.GetParent().Hide)
+        if sys.platform == 'darwin':
+            wx.CallAfter(self.GetParent().Hide)
+        else:
+            self.HideParent()
         Publisher.sendMessage('Begin busy cursor')
         Publisher.sendMessage('Update status text in GUI',
                               label=_("Configuring tracker ..."))
@@ -635,10 +636,11 @@ class TrackerPage(wx.Panel):
         Publisher.sendMessage('Update status text in GUI', label=_("Ready"))
         Publisher.sendMessage("Tracker changed")
         ctrl.SetSelection(self.tracker.tracker_id)
-        # self.ShowParent()
-        # self.GetParent().Enable(True)
         Publisher.sendMessage('End busy cursor')
-        wx.CallAfter(self.GetParent().Show)
+        if sys.platform == 'darwin':
+            wx.CallAfter(self.GetParent().Show)
+        else:
+            self.ShowParent()
 
     def OnChooseReferenceMode(self, evt, ctrl):
         # Probably need to refactor object registration as a whole to use the 

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -668,9 +668,15 @@ class TrackerPage(wx.Panel):
             Publisher.sendMessage('Neuronavigation to Robot: Connect to robot', robot_IP=self.robot_ip)
 
     def OnRobotRegister(self, evt):
-        self.HideParent()
+        if sys.platform == 'darwin':
+            wx.CallAfter(self.GetParent().Hide)
+        else:
+            self.HideParent()
         self.robot.RegisterRobot()
-        self.ShowParent()
+        if sys.platform == 'darwin':
+            wx.CallAfter(self.GetParent().Show)
+        else:
+            self.ShowParent()
     
     def OnRobotStatus(self, data):
         if data:

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -618,7 +618,9 @@ class TrackerPage(wx.Panel):
         return True
 
     def OnChooseTracker(self, evt, ctrl):
-        self.HideParent()
+        # self.GetParent().Enable(False)
+        # self.HideParent()
+        wx.CallAfter(self.GetParent().Hide)
         Publisher.sendMessage('Begin busy cursor')
         Publisher.sendMessage('Update status text in GUI',
                               label=_("Configuring tracker ..."))
@@ -633,8 +635,10 @@ class TrackerPage(wx.Panel):
         Publisher.sendMessage('Update status text in GUI', label=_("Ready"))
         Publisher.sendMessage("Tracker changed")
         ctrl.SetSelection(self.tracker.tracker_id)
-        self.ShowParent()
+        # self.ShowParent()
+        # self.GetParent().Enable(True)
         Publisher.sendMessage('End busy cursor')
+        wx.CallAfter(self.GetParent().Show)
 
     def OnChooseReferenceMode(self, evt, ctrl):
         # Probably need to refactor object registration as a whole to use the 


### PR DESCRIPTION
In MacOS, any updates to the GUI must be initiated from the Main Thread, this is because MacOS enforces the principle that only the main thread can interact with the user interface.

Therefore, Show and Hide of the dialog for selecting the tracker devices and the robot registration was "stealing" the input even after the dialog was closed due to not releasing the dialog modal behavior after the desired operation.

The solution was to have different processes for MacOS and Windows/Linux, to maintain the Show/Hide functionality, which is more tidy.