### PR TITLE
Update cython and fix reorientation slowness

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
 dependencies:
   - python=3.11
-  - cython==3.0.2
+  - cython==3.0.10
   - pillow==9.4.0
   - pypubsub==4.0.3
   - h5py==3.8.0

--- a/invesalius_cy/cy_mesh.pyx
+++ b/invesalius_cy/cy_mesh.pyx
@@ -416,7 +416,7 @@ cdef vector[vertex_id_t]* find_staircase_artifacts(Mesh mesh, double[3] stack_or
     return output
 
 
-cdef void taubin_smooth(Mesh mesh, vector[weight_t]& weights, float l, float m, int steps) nogil:
+cdef void taubin_smooth(Mesh mesh, vector[weight_t]& weights, float l, float m, int steps) noexcept nogil:
     """
     Implementation of Taubin's smooth algorithm described in the paper "A
     Signal Processing Approach To Fair Surface Design". His benefeat is it

--- a/invesalius_cy/floodfill.pyx
+++ b/invesalius_cy/floodfill.pyx
@@ -28,11 +28,11 @@ cdef struct s_coord:
 ctypedef s_coord coord
 
 
-cdef inline void append_queue(cdeque[int]& stack, int x, int y, int z, int d, int h, int w) nogil:
+cdef inline void append_queue(cdeque[int]& stack, int x, int y, int z, int d, int h, int w) noexcept nogil:
     stack.push_back(z*h*w + y*w + x)
 
 
-cdef inline void pop_queue(cdeque[int]& stack, int* x, int* y, int* z, int d, int h, int w) nogil:
+cdef inline void pop_queue(cdeque[int]& stack, int* x, int* y, int* z, int d, int h, int w) noexcept nogil:
     cdef int i = stack.front()
     stack.pop_front()
     x[0] = i % w

--- a/invesalius_cy/interpolation.pxd
+++ b/invesalius_cy/interpolation.pxd
@@ -1,8 +1,7 @@
 from .cy_my_types cimport image_t
 
-cdef double interpolate(image_t[:, :, :], double, double, double) nogil
-cdef double tricub_interpolate(image_t[:, :, :], double, double, double) nogil
-cdef double tricubicInterpolate (image_t[:, :, :], double, double, double) nogil
-cdef double lanczos3 (image_t[:, :, :], double, double, double) nogil
-
-cdef double nearest_neighbour_interp(image_t[:, :, :], double, double, double) nogil
+cdef double interpolate(image_t[:, :, :], double, double, double) noexcept nogil
+cdef double tricub_interpolate(image_t[:, :, :], double, double, double) noexcept nogil
+cdef double tricubicInterpolate (image_t[:, :, :], double, double, double) noexcept nogil
+cdef double lanczos3 (image_t[:, :, :], double, double, double) noexcept nogil
+cdef double nearest_neighbour_interp(image_t[:, :, :], double, double, double) noexcept nogil

--- a/invesalius_cy/interpolation.pyx
+++ b/invesalius_cy/interpolation.pyx
@@ -305,7 +305,7 @@ cdef void calc_coef_tricub(image_t[:, :, :] V, double x, double y, double z, dou
                 coef[j] += (temp[j][i] * _x[i])
 
 
-cdef double tricub_interpolate(image_t[:, :, :] V, double x, double y, double z) nogil:
+cdef double tricub_interpolate(image_t[:, :, :] V, double x, double y, double z) noexcept nogil:
     # From: Tricubic interpolation in three dimensions. Lekien and Marsden
     cdef double[64] coef
     cdef double result = 0.0

--- a/invesalius_cy/transforms.pyx
+++ b/invesalius_cy/transforms.pyx
@@ -16,19 +16,18 @@ from .interpolation cimport interpolate, tricub_interpolate, tricubicInterpolate
 from libc.math cimport floor, ceil, sqrt, fabs, round
 from cython.parallel cimport prange
 
-ctypedef double (*interp_function)(image_t[:, :, :], double, double, double) nogil
+ctypedef double (*interp_function)(image_t[:, :, :], double, double, double) noexcept nogil
 
 cdef void mul_mat4_vec4(double[:, :] M,
                             double* coord,
-                            double* out) nogil:
-
+                            double* out) noexcept nogil:
     out[0] = coord[0] * M[0, 0] + coord[1] * M[0, 1] + coord[2] * M[0, 2] + coord[3] * M[0, 3]
     out[1] = coord[0] * M[1, 0] + coord[1] * M[1, 1] + coord[2] * M[1, 2] + coord[3] * M[1, 3]
     out[2] = coord[0] * M[2, 0] + coord[1] * M[2, 1] + coord[2] * M[2, 2] + coord[3] * M[2, 3]
     out[3] = coord[0] * M[3, 0] + coord[1] * M[3, 1] + coord[2] * M[3, 2] + coord[3] * M[3, 3]
 
 
-cdef image_t coord_transform(image_t[:, :, :] volume, double[:, :] M, int x, int y, int z, double sx, double sy, double sz, int minterpol, image_t cval) nogil:
+cdef image_t coord_transform(image_t[:, :, :] volume, double[:, :] M, int x, int y, int z, double sx, double sy, double sz, int minterpol, image_t cval) noexcept nogil:
 
     cdef double coord[4]
     coord[0] = z*sz

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ torch==2.0.1
 plaidml-keras==0.7.0
 
 # Utilities
-Cython==3.0.2
+Cython==3.0.10
 Pypubsub==4.0.3
 h5py==3.8.0
 psutil==5.9.4


### PR DESCRIPTION
* Updated cython to 3.0.10 
* Added noexcept to transforms, cy_mesh, interpolation and floodfill
* reorientation is faster now