### PR TITLE
Use inv_paths in i18n and language_dialog

### DIFF
--- a/invesalius/gui/language_dialog.py
+++ b/invesalius/gui/language_dialog.py
@@ -28,6 +28,7 @@ except ImportError:
 
 import invesalius.i18n as i18n
 from invesalius.i18n import tr as _
+from invesalius.inv_paths import ICON_DIR
 
 file_path = os.path.split(__file__)[0]
 
@@ -38,8 +39,6 @@ if hasattr(sys, "frozen") and (
         file_path + os.sep + ".." + os.sep + ".." + os.sep + ".." + os.sep + ".."
     )
     ICON_DIR = os.path.abspath(os.path.join(abs_file_path, "icons"))
-else:
-    ICON_DIR = os.path.abspath(os.path.join(file_path, "..", "..", "icons"))
 
 # MAC App
 if not os.path.exists(ICON_DIR):

--- a/invesalius/i18n.py
+++ b/invesalius/i18n.py
@@ -31,6 +31,7 @@ import sys
 from invesalius.session import Session
  
 import invesalius.utils as utl
+from invesalius.inv_paths import LOCALE_DIR
  
 def GetLocales(): 
     """Return a dictionary which defines supported languages""" 
@@ -68,13 +69,11 @@ def GetLocaleOS():
  
 def InstallLanguage(language):
     file_path = os.path.split(__file__)[0]
-
-    abs_file_path = os.path.abspath(file_path + os.sep + "..")
-
+    language_dir = LOCALE_DIR
     if hasattr(sys, "frozen") and (sys.frozen == "windows_exe" or sys.frozen == "console_exe"):
+        abs_file_path = os.path.abspath(file_path + os.sep + "..")
         abs_file_path = os.path.abspath(abs_file_path + os.sep + ".." + os.sep + "..")
-
-    language_dir = os.path.join(abs_file_path, 'locale')
+        language_dir = os.path.join(abs_file_path, 'locale')
 
     # MAC app
     if not os.path.exists(language_dir):

--- a/invesalius/inv_paths.py
+++ b/invesalius/inv_paths.py
@@ -50,6 +50,7 @@ RAYCASTING_PRESETS_COLOR_DIRECTORY = INV_TOP_DIR.joinpath(
 )
 
 MODELS_DIR = INV_TOP_DIR.joinpath("ai")
+LOCALE_DIR = INV_TOP_DIR.joinpath("locale")
 
 # Inside the windows executable
 if hasattr(sys, "frozen") and (


### PR DESCRIPTION
`invesalius/i18n.py` and `invesalius/gui/language_dialog.py` are not using `inv_paths`.