### PR TITLE
FIX: Change project after loading fMRI overlay

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -359,6 +359,7 @@ class Slice(metaclass=utils.Singleton):
         self.value_range = (0, 1)
 
         self.interaction_style.Reset()
+        self.to_show_aux = ""
 
         Publisher.sendMessage("Select first item from slice menu")
 


### PR DESCRIPTION
Reset Slice.to_show_aux when closing the project to prevent InVesalius from trying to load the discarded overlay.

Fixes #744