### PR TITLE
FIX: Height of markers list was occluding robot buttons

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1810,7 +1810,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         # The marker list height is set to 120 pixels (accommodating 4 markers) if the screen height is
         # at most 1080 pixels (a commonly used height in laptops). Otherwise, the height grows linearly with
         # the screen height.
-        marker_list_height = max(120, screen_height - 960)
+        marker_list_height = max(120, int(screen_height/4))
 
         marker_list_ctrl = wx.ListCtrl(self, -1, style=wx.LC_REPORT, size=wx.Size(0, marker_list_height))
         marker_list_ctrl.InsertColumn(const.ID_COLUMN, '#')


### PR DESCRIPTION
The marker's list height was too long for both small and bigger resolutions. Tested in MacOS at 1440p on a 27" monitor and 14" laptop monitor. 

This broken UI was also occurring in the mTMS lab with Windows on a 27" screen.

The fix is to adjust the increase of the list height less steep than the previous implementation.