### PR TITLE
FIX: Coil visibility issue #764

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -646,6 +646,7 @@ class Controller():
             Publisher.sendMessage('Enable Go-to-Coord', status=False)
         
         Publisher.sendMessage('End busy cursor')
+        Publisher.sendMessage('Project loaded successfully')
 
     def CreateDicomProject(self, dicom, matrix, matrix_filename):
         name_to_const = {"AXIAL":const.AXIAL,

--- a/invesalius/data/visualization/coil_visualizer.py
+++ b/invesalius/data/visualization/coil_visualizer.py
@@ -180,7 +180,7 @@ class CoilVisualizer:
         if self.is_navigating and self.coil_actor is not None:
             self.coil_actor.SetVisibility(self.show_coil_pressed)
 
-    # Called when 'track object' button is pressed in the user interface.
+    # Called when 'track object' button is pressed in the user interface or in code.
     def TrackObject(self, enabled):
         self.track_object_pressed = enabled
 
@@ -195,19 +195,17 @@ class CoilVisualizer:
         if enabled:
             self.AddCoilActor(self.coil_path)
 
-    # Called when 'show coil' button is pressed in the user interface.
+    # Called when 'show coil' button is pressed in the user interface or in code.
     def ShowCoil(self, state):
         self.show_coil_pressed = state
-        print("show_coil:", self.show_coil_pressed)
 
         # Initially, if the tracker fiducials are not set but the show coil button is pressed,
         # press it again to hide the coil
         if not self.tracker_fiducials_set and self.show_coil_pressed and self.initial_button_press:
-            print("Show coil pressed")
 
-            # After the initial in-code button press, don't undo subsequent button presses in UI
             self.initial_button_press = False
 
+            # Press the show coil button to turn it off
             Publisher.sendMessage('Press show-coil button', pressed=False)
             return
 


### PR DESCRIPTION
Fixes issue [#764](https://github.com/invesalius/invesalius3/issues/764) on coil visibility.

- When opening a new project or starting a new session without recovering previous state, the coil is no longer immediately visible.
- Coil turns visible once tracker fiducials have been set and the coil is hidden when resetting tracker fiducials or changing the tracker.
- Loading a new project resets the tracker fiducials which in turn hides the coil until tracker fiducials are set.