### PR TITLE
Improved object and tracker fiducial registration UI

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -186,8 +186,10 @@ SLICE_COLOR_TABLE = {_("Default "):(None,(0,0),(0,0),(0,1)),
 #Colors for errors and positives
 RED_COLOR_FLOAT = (0.99, 0.55, 0.38)
 GREEN_COLOR_FLOAT = (0.40, 0.76, 0.65)
+YELLOW_COLOR_FLOAT = (1.0, 0.77, 0.0)
 RED_COLOR_RGB = (252, 141, 98)
 GREEN_COLOR_RGB = (102, 194, 165)
+YELLOW_COLOR_RGB = (255, 196, 0)
 
 # Volume view angle
 VOL_FRONT = wx.NewIdRef()

--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -753,6 +753,7 @@ TR3 = wx.NewIdRef()
 SET = wx.NewIdRef()
 
 FIDUCIAL_LABELS = ["Left Ear: ", "Right Ear: ", "Nose: "]
+FIDUCIAL_REGISTRATION_ORDER = [0, 2, 1]
 IMAGE_FIDUCIALS = [
     {
         'button_id': IR1,

--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -739,6 +739,7 @@ DYNAMIC_REF = 1
 DEFAULT_REF_MODE = DYNAMIC_REF
 REF_MODE = [_("Static ref."), _("Dynamic ref.")]
 FT_SENSOR_MODE = [_("Sensor 3"), _("Sensor 4")]
+TRACKERS_WITH_SENSOR_OPTIONS = [FASTRAK, ISOTRAKII, PATRIOT, DEBUGTRACKRANDOM, DEBUGTRACKAPPROACH]
 
 DEFAULT_COIL = SELECT
 COIL = [_("Select coil:"), _("Neurosoft Figure-8"),
@@ -811,6 +812,9 @@ OBJR = wx.NewIdRef()
 OBJA = wx.NewIdRef()
 OBJF = wx.NewIdRef()
 
+OBJECT_FIDUCIAL_ANTERIOR = 2
+OBJECT_FIDUCIAL_FIXED = 3
+
 OBJECT_FIDUCIALS = [
     {
         'fiducial_index': 0,
@@ -825,13 +829,13 @@ OBJECT_FIDUCIALS = [
         'tip': _("Select right object fiducial"),
     },
     {
-        'fiducial_index': 2,
+        'fiducial_index': OBJECT_FIDUCIAL_ANTERIOR,
         'button_id': OBJA,
         'label': _('Anterior'),
         'tip': _("Select anterior object fiducial"),
     },
     {
-        'fiducial_index': 3,
+        'fiducial_index': OBJECT_FIDUCIAL_FIXED,
         'button_id': OBJF,
         'label': _('Fixed'),
         'tip': _("Attach sensor to object"),

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -3618,6 +3618,16 @@ class ObjectCalibrationDialog(wx.Dialog):
         self.ball_actors[1], self.text_actors[1] = self.OnCreateObjectText('Right', (0,-55,0))
         self.ball_actors[2], self.text_actors[2] = self.OnCreateObjectText('Anterior', (23,0,0))
 
+        # Match actor colors with fiducial buttons
+        def set_actor_colors(n, color_float):
+            if n != const.OBJECT_FIDUCIAL_FIXED:
+                self.ball_actors[n].GetProperty().SetColor(color_float)
+                self.text_actors[n].GetProperty().SetColor(color_float)
+                self.Refresh()
+
+        self.buttons.set_actor_colors = set_actor_colors
+        self.buttons.Update()
+
         self.ren.AddActor(obj_actor)
         self.ren.ResetCamera()
 
@@ -3671,7 +3681,7 @@ class ObjectCalibrationDialog(wx.Dialog):
         ball_actor = vtkActor()
         ball_actor.SetMapper(mapper)
         ball_actor.SetPosition(coord)
-        ball_actor.GetProperty().SetColor(1, 0, 0)
+        ball_actor.GetProperty().SetColor(const.RED_COLOR_FLOAT)
 
         textSource = vtkVectorText()
         textSource.SetText(name)
@@ -3680,7 +3690,7 @@ class ObjectCalibrationDialog(wx.Dialog):
         mapper.SetInputConnection(textSource.GetOutputPort())
         tactor = vtkFollower()
         tactor.SetMapper(mapper)
-        tactor.GetProperty().SetColor(1.0, 0.0, 0.0)
+        tactor.GetProperty().SetColor(const.RED_COLOR_FLOAT)
         tactor.SetScale(5)
         ball_position = ball_actor.GetPosition()
         tactor.SetPosition(ball_position[0]+5, ball_position[1]+5, ball_position[2]+10)
@@ -3750,9 +3760,6 @@ class ObjectCalibrationDialog(wx.Dialog):
             self.buttons.SetFocused()
             for i in [0, 1, 2]:
                 self.txt_coord[fiducial_index][i].SetLabel(str(round(coord[i], 1)))
-                if self.text_actors[fiducial_index]:
-                    self.text_actors[fiducial_index].GetProperty().SetColor(0.0, 1.0, 0.0)
-                    self.ball_actors[fiducial_index].GetProperty().SetColor(0.0, 1.0, 0.0)
             self.Refresh()
         else:
             ShowNavigationTrackerWarning(0, 'choose')

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -3503,14 +3503,19 @@ class ObjectCalibrationDialog(wx.Dialog):
             choice_sensor.Show(False)
         self.choice_sensor = choice_sensor
 
+        tooltip = _("Reset all fiducials")
+        btn_reset = wx.Button(self, -1, _("Reset"), size=wx.Size(90, 30))
+        btn_reset.SetToolTip(tooltip)
+        btn_reset.Bind(wx.EVT_BUTTON, self.OnReset)
+
         # Buttons to finish or cancel object registration
         tooltip = _(u"Registration done")
-        # btn_ok = wx.Button(self, -1, _(u"Done"), size=wx.Size(90, 30))
         btn_ok = wx.Button(self, wx.ID_OK, _(u"Done"), size=wx.Size(90, 30))
         btn_ok.SetToolTip(tooltip)
 
-        extra_sizer = wx.FlexGridSizer(rows=3, cols=1, hgap=5, vgap=30)
+        extra_sizer = wx.FlexGridSizer(cols=1, hgap=5, vgap=10)
         extra_sizer.AddMany([choice_ref,
+                             btn_reset,
                              btn_ok,
                              choice_sensor])
 
@@ -3753,6 +3758,9 @@ class ObjectCalibrationDialog(wx.Dialog):
         for coord_index in range(0, 3):
             self.txt_coord[index][coord_index].SetLabel('-')
         self.buttons.Unset(index)
+
+    def OnReset(self, evt):
+        self.ResetObjectFiducials()
 
     def OnChooseReferenceMode(self, evt):
         # When ref mode is changed the tracker coordinates are set to nan

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -100,6 +100,7 @@ import invesalius.data.transformations as tr
 import invesalius.data.polydata_utils as pu
 from invesalius.gui.widgets.inv_spinctrl import InvSpinCtrl, InvFloatSpinCtrl
 from invesalius.gui.widgets.clut_imagedata import CLUTImageDataWidget, EVT_CLUT_NODE_CHANGED
+from invesalius.gui.widgets.fiducial_buttons import OrderedFiducialButtons
 from invesalius.i18n import tr as _
 import numpy as np
 
@@ -3461,12 +3462,8 @@ class ObjectCalibrationDialog(wx.Dialog):
                            style=wx.DEFAULT_DIALOG_STYLE | wx.FRAME_FLOAT_ON_PARENT|wx.STAY_ON_TOP)
 
         self._init_gui()
+        self._init_pedal()
         self.InitializeObject()
-
-        self.__bind_events()
-
-    def __bind_events(self):
-        pass
 
     def _init_gui(self):
         self.interactor = wxVTKRenderWindowInteractor(self, -1, size=self.GetSize())
@@ -3517,19 +3514,15 @@ class ObjectCalibrationDialog(wx.Dialog):
                              btn_ok,
                              choice_sensor])
 
-        # Push buttons for object fiducials
-        for object_fiducial in const.OBJECT_FIDUCIALS:
-            index = object_fiducial['fiducial_index']
-            label = object_fiducial['label']
-            button_id = object_fiducial['button_id']
-            tip = object_fiducial['tip']
+        # Buttons for object fiducials
+        self.buttons = OrderedFiducialButtons(self, const.OBJECT_FIDUCIALS, self.IsObjectFiducialSet)
 
-            ctrl = wx.ToggleButton(self, button_id, label=label, size=wx.Size(60, 23))
-            ctrl.SetToolTip(tip)
-            ctrl.Bind(wx.EVT_TOGGLEBUTTON, partial(self.OnObjectFiducialButton, index, ctrl=ctrl))
+        for index, btn in enumerate(self.buttons):
+            btn.Bind(wx.EVT_BUTTON, partial(self.OnObjectFiducialButton, index))
 
-            self.btns_coord[index] = ctrl
+        self.buttons.FocusNext()
 
+        # Display fiducial coordinates
         for m in range(0, 4):
             for n in range(0, 3):
                 self.txt_coord[m].append(wx.StaticText(self, -1, label='-',
@@ -3537,8 +3530,8 @@ class ObjectCalibrationDialog(wx.Dialog):
 
         coord_sizer = wx.GridBagSizer(hgap=20, vgap=5)
 
-        for m in range(0, 4):
-            coord_sizer.Add(self.btns_coord[m], pos=wx.GBPosition(m, 0))
+        for m, button in enumerate(self.buttons):
+            coord_sizer.Add(button, pos=wx.GBPosition(m, 0))
             for n in range(0, 3):
                 coord_sizer.Add(self.txt_coord[m][n], pos=wx.GBPosition(m, n + 1), flag=wx.TOP, border=5)
 
@@ -3553,6 +3546,15 @@ class ObjectCalibrationDialog(wx.Dialog):
 
         self.SetSizer(main_sizer)
         main_sizer.Fit(self)
+
+    def _init_pedal(self):
+        def set_fiducial_callback(state):
+            index = self.buttons.focused_index
+            if state and index is not None:
+                self.SetObjectFiducial(index)
+
+        self.pedal_connector.add_callback('fiducial', set_fiducial_callback, remove_when_released=False, panel=self)
+        self.Bind(wx.EVT_BUTTON, self.OnOk)
 
     def ObjectImportDialog(self):
         msg = _("Would like to use InVesalius default object?")
@@ -3672,42 +3674,25 @@ class ObjectCalibrationDialog(wx.Dialog):
         self.ren.AddActor(ball_actor)
         return ball_actor, tactor
 
-    def OnObjectFiducialButton(self, index, evt, ctrl):
+    def IsObjectFiducialSet(self, fiducial_index):
+        fiducial = self.obj_fiducials[fiducial_index]
+        return not np.isnan(fiducial).any()
+
+    def OnObjectFiducialButton(self, index, evt):
+        button = self.buttons[index]
+
+        if button is self.buttons.focused:
+            self.SetObjectFiducial(index)
+        elif self.IsObjectFiducialSet(index):
+            self.ResetObjectFiducial(index)
+        else:
+            self.buttons.Focus(index)
+
+    def SetObjectFiducial(self, fiducial_index):
         if not self.tracker.IsTrackerInitialized():
             ShowNavigationTrackerWarning(0, 'choose')
             return
 
-        # TODO: The code below until the end of the function is essentially copy-paste from
-        #       OnTrackerFiducials function in NeuronavigationPanel class. Probably the easiest
-        #       way to deduplicate this would be to create a Fiducial class, which would contain
-        #       this code just once.
-        #
-
-        # Do not allow several object fiducials to be set at the same time.
-        if self.object_fiducial_being_set is not None and self.object_fiducial_being_set != index:
-            ctrl.SetValue(False)
-            return
-
-        # Called when the button for setting the object fiducial is enabled and either pedal is pressed
-        # or the button is pressed again.
-        #
-        def set_fiducial_callback(state):
-            if state:
-                self.SetObjectFiducial(index)
-                Publisher.sendMessage('Set object fiducial', fiducial_index=index)
-
-                ctrl.SetValue(False)
-                self.object_fiducial_being_set = None
-
-        if ctrl.GetValue():
-            self.object_fiducial_being_set = index
-            self.pedal_connector.add_callback('fiducial', set_fiducial_callback, remove_when_released=True, panel=self)
-
-        else:
-            set_fiducial_callback(True)
-            self.pedal_connector.remove_callback('fiducial', panel=self)
-
-    def SetObjectFiducial(self, fiducial_index):
         marker_visibilities, coord, coord_raw = self.tracker.GetTrackerCoordinates(
             # XXX: Always use static reference mode when getting the coordinates. This is what the
             #      code did previously, as well. At some point, it should probably be thought through
@@ -3741,10 +3726,13 @@ class ObjectCalibrationDialog(wx.Dialog):
         else:
             coord = coord_raw[0, :]
 
-        # Update text controls with tracker coordinates
+        Publisher.sendMessage('Set object fiducial', fiducial_index=fiducial_index)
+
+        # Update buttons and text controls with tracker coordinates
         if coord is not None or np.sum(coord) != 0.0:
             self.obj_fiducials[fiducial_index, :] = coord[:3]
             self.obj_orients[fiducial_index, :] = coord[3:]
+            self.buttons.SetFocused()
             for i in [0, 1, 2]:
                 self.txt_coord[fiducial_index][i].SetLabel(str(round(coord[i], 1)))
                 if self.text_actors[fiducial_index]:
@@ -3753,6 +3741,18 @@ class ObjectCalibrationDialog(wx.Dialog):
             self.Refresh()
         else:
             ShowNavigationTrackerWarning(0, 'choose')
+
+    def ResetObjectFiducials(self):
+        for m in range(0, 4):
+            self.ResetObjectFiducial(m)
+        self.buttons.Update()
+
+    def ResetObjectFiducial(self, index):
+        self.obj_fiducials[index, :] = np.full([1, 3], np.nan)
+        self.obj_orients[index, :] = np.full([1, 3], np.nan)
+        for coord_index in range(0, 3):
+            self.txt_coord[index][coord_index].SetLabel('-')
+        self.buttons.Unset(index)
 
     def OnChooseReferenceMode(self, evt):
         # When ref mode is changed the tracker coordinates are set to nan
@@ -3770,11 +3770,7 @@ class ObjectCalibrationDialog(wx.Dialog):
             self.obj_ref_id = 0
             self.choice_sensor.Show(self.obj_ref_id)
 
-        for m in range(0, 4):
-            self.obj_fiducials[m, :] = np.full([1, 3], np.nan)
-            self.obj_orients[m, :] = np.full([1, 3], np.nan)
-            for n in range(0, 3):
-                self.txt_coord[m][n].SetLabel('-')
+        self.ResetObjectFiducials()
 
         # Used to update choice sensor controls
         self.Layout()
@@ -3787,6 +3783,14 @@ class ObjectCalibrationDialog(wx.Dialog):
 
     def GetValue(self):
         return self.obj_fiducials, self.obj_orients, self.obj_ref_id, self.coil_path, self.polydata
+
+    def OnOk(self, evt):
+        if evt.GetId() == wx.ID_OK:
+            # This should always be called when the dialog is closed. Seems to be working correctly.
+            self.pedal_connector.remove_callback('fiducial', panel=self)
+
+        evt.Skip()
+
 
 class ICPCorregistrationDialog(wx.Dialog):
 

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -1966,6 +1966,10 @@ class SliceToolBar(AuiToolBar):
         else:
             Publisher.sendMessage('Disable style', style=id)
 
+        # const.STATE_REGISTRATION can be disabled with the same button as const.SLICE_STATE_CROSS
+        if id == const.SLICE_STATE_CROSS and not state:
+            Publisher.sendMessage('Stop image registration')
+
         for item in self.enable_items:
             state = self.GetToolToggled(item)
             if state and (item != id):

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -58,7 +58,7 @@ class Preferences(wx.Dialog):
 
             self.book.AddPage(self.navigation_tab, _("Navigation"))
             self.book.AddPage(self.tracker_tab, _("Tracker"))
-            self.book.AddPage(self.object_tab, _("Stimulator"))
+            self.book.AddPage(self.object_tab, _("TMS Coil"))
 
         self.book.AddPage(self.language_tab, _("Language"))
 
@@ -279,24 +279,22 @@ class ObjectTab(wx.Panel):
         self.timestamp = const.TIMESTAMP
         self.state = self.LoadConfig()
 
-        # Button for creating new stimulator
-        tooltip = _("Create new stimulator")
+        # Buttons for TMS coil configuration
+        tooltip = _("New TMS coil configuration")
         btn_new = wx.Button(self, -1, _("New"), size=wx.Size(65, 23))
         btn_new.SetToolTip(tooltip)
         btn_new.Enable(1)
         btn_new.Bind(wx.EVT_BUTTON, self.OnCreateNewCoil)
         self.btn_new = btn_new
 
-        # Button for loading stimulator config file
-        tooltip = _("Load stimulator configuration file")
+        tooltip = _("Load TMS coil configuration from a file")
         btn_load = wx.Button(self, -1, _("Load"), size=wx.Size(65, 23))
         btn_load.SetToolTip(tooltip)
         btn_load.Enable(1)
         btn_load.Bind(wx.EVT_BUTTON, self.OnLoadCoil)
         self.btn_load = btn_load
 
-        # Save button for saving stimulator config file
-        tooltip = _(u"Save stimulator configuration file")
+        tooltip = _(u"Save current TMS coil configuration to a file")
         btn_save = wx.Button(self, -1, _(u"Save"), size=wx.Size(65, 23))
         btn_save.SetToolTip(tooltip)
         btn_save.Enable(1)
@@ -311,11 +309,11 @@ class ObjectTab(wx.Panel):
         self.config_txt = config_txt    
         lbl = wx.StaticText(self, -1, _("Current Configuration:"))
         lbl.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD))
-        lbl_new = wx.StaticText(self, -1, _("Create a new stimulator registration: "))
-        lbl_load = wx.StaticText(self, -1, _("Load a stimulator registration: "))
-        lbl_save = wx.StaticText(self, -1, _("Save current stimulator registration: "))
+        lbl_new = wx.StaticText(self, -1, _("Create new configuration: "))
+        lbl_load = wx.StaticText(self, -1, _("Load configuration from file: "))
+        lbl_save = wx.StaticText(self, -1, _("Save configuration to file: "))
 
-        load_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("Stimulator registration"))
+        load_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("TMS coil registration"))
         inner_load_sizer = wx.FlexGridSizer(2, 4, 5)
         inner_load_sizer.AddMany([
             (lbl, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
@@ -373,7 +371,7 @@ class ObjectTab(wx.Panel):
             ])
 
         # Add line sizers into main sizer
-        conf_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("Stimulator configuration"))
+        conf_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("Settings"))
         conf_sizer.AddMany([
             (line_angle_threshold, 0, wx.GROW | wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 20),
             (line_dist_threshold, 0, wx.GROW | wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 20),

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -277,7 +277,7 @@ class ObjectTab(wx.Panel):
         self.coil_path = None
         self.__bind_events()
         self.timestamp = const.TIMESTAMP
-        self.state = self.LoadConfig()
+        self.LoadConfig()
 
         # Buttons for TMS coil configuration
         tooltip = _("New TMS coil configuration")
@@ -300,13 +300,11 @@ class ObjectTab(wx.Panel):
         btn_save.Enable(1)
         btn_save.Bind(wx.EVT_BUTTON, self.OnSaveCoil)
         self.btn_save = btn_save
-        
-        if self.state:
-            config_txt = wx.StaticText(self, -1, os.path.basename(self.coil_path))
-        else:
-            config_txt = wx.StaticText(self, -1, "None")
 
-        self.config_txt = config_txt    
+        self.config_txt = config_txt = wx.StaticText(self, -1, 'None')
+        data = self.navigation.GetObjectRegistration()
+        self.OnObjectUpdate(data)
+
         lbl = wx.StaticText(self, -1, _("Current Configuration:"))
         lbl.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD))
         lbl_new = wx.StaticText(self, -1, _("Create new configuration: "))
@@ -516,7 +514,11 @@ class ObjectTab(wx.Panel):
         self.timestamp = ctrl.GetValue()
 
     def OnObjectUpdate(self, data=None):
-        self.config_txt.SetLabel(os.path.basename(data[-1]))
+        if data:
+            label = os.path.basename(data[-1])
+        else:
+            label = 'None'
+        self.config_txt.SetLabel(label)
 
 
 class TrackerTab(wx.Panel):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -780,6 +780,7 @@ class TrackerPage(wx.Panel):
     def OnStartRegistration(self, evt, ctrl):
         started = ctrl.GetValue()
         if started:
+            self.tracker.ResetTrackerFiducials()
             self.StartRegistration()
         else:
             self.StopRegistration()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -496,6 +496,9 @@ class ImagePage(wx.Panel):
         fiducial_index = fiducial['fiducial_index']
 
         self.image.SetImageFiducial(fiducial_index, position)
+
+        if self.image.AreImageFiducialsSet():
+            self.StopRegistration()
         self.UpdateNextButton()
 
     def UpdateImageCoordinates(self, position):
@@ -537,18 +540,26 @@ class ImagePage(wx.Panel):
         self.start_button.SetValue(False)
         self.OnStartRegistration(self.start_button, self.start_button)
 
+    def StartRegistration(self):
+        Publisher.sendMessage("Enable style", style=const.STATE_REGISTRATION)
+        for button in self.btns_set_fiducial:
+            button.Enable()
+        self.start_button.SetLabel("Stop Registration")
+        self.start_button.SetValue(True)
+
+    def StopRegistration(self):
+        self.start_button.SetLabel("Start Registration")
+        self.start_button.SetValue(False)
+        for button in self.btns_set_fiducial:
+            button.Disable()
+        Publisher.sendMessage("Disable style", style=const.STATE_REGISTRATION)
+
     def OnStartRegistration(self, evt, ctrl):
         value = ctrl.GetValue()
         if value:
-            Publisher.sendMessage("Enable style", style=const.STATE_REGISTRATION)
-            for button in self.btns_set_fiducial:
-                button.Enable()
-            self.start_button.SetLabel("Stop Registration")
+            self.StartRegistration()
         else:
-            self.start_button.SetLabel("Start Registration")
-            for button in self.btns_set_fiducial:
-                button.Disable()
-            Publisher.sendMessage("Disable style", style=const.STATE_REGISTRATION)
+            self.StopRegistration()
 
 class TrackerPage(wx.Panel):
     def __init__(self, parent, nav_hub):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -454,6 +454,7 @@ class ImagePage(wx.Panel):
         Publisher.subscribe(self.UpdateImageCoordinates, 'Set cross focal point')
         Publisher.subscribe(self.OnResetImageFiducials, "Reset image fiducials")
         Publisher.subscribe(self._OnStateProject, "Enable state project")
+        Publisher.subscribe(self.StopRegistration, 'Stop image registration')
 
     def _OnStateProject(self, state):
         self.UpdateData()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -366,29 +366,18 @@ class CoregistrationPanel(wx.Panel):
                 self.book.SetSelection(1)
                 wx.MessageBox(_("Please do the tracker registration first."), _("InVesalius 3"))
 
+    # Unfold specific notebook pages
     def _FoldImage(self):
-        """
-        Fold image notebook page.
-        """
         self.book.SetSelection(0)
 
     def _FoldTracker(self):
-        """
-        Fold tracker notebook page.
-        """
         Publisher.sendMessage("Disable style", style=const.SLICE_STATE_CROSS)
         self.book.SetSelection(1)
 
     def _FoldRefine(self):
-        """
-        Fold refine notebook page.
-        """
         self.book.SetSelection(2)
 
     def _FoldStimulator(self):
-        """
-        Fold mask notebook page.
-        """
         self.book.SetSelection(3)
 
 class ImagePage(wx.Panel):

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -318,9 +318,9 @@ class CoregistrationPanel(wx.Panel):
         self.image = nav_hub.image
 
         book.AddPage(ImagePage(book, nav_hub), _("Image"))
-        book.AddPage(TrackerPage(book, nav_hub), _("Tracker"))
+        book.AddPage(TrackerPage(book, nav_hub), _("Patient"))
         book.AddPage(RefinePage(book, nav_hub), _("Refine"))
-        book.AddPage(StimulatorPage(book, nav_hub), _("Stimulator"))
+        book.AddPage(StimulatorPage(book, nav_hub), _("TMS Coil"))
 
         book.SetSelection(0)
 
@@ -945,7 +945,7 @@ class StimulatorPage(wx.Panel):
         object_reg = self.navigation.GetObjectRegistration()
         self.object_reg = object_reg
         
-        lbl = wx.StaticText(self, -1, _("No stimulator selected!"))
+        lbl = wx.StaticText(self, -1, _("No TMS coil configured!"))
         lbl.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD))
         self.lbl = lbl
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -742,6 +742,8 @@ class TrackerPage(wx.Panel):
             self.next_button.Enable()
             self.StopRegistration()
 
+        self.Refresh()
+
     def OnFiducialButton(self, index, evt):
         button = self.fiducial_buttons[index]
 
@@ -762,6 +764,7 @@ class TrackerPage(wx.Panel):
 
     def OnReset(self, evt):
         self.tracker.ResetTrackerFiducials()
+        self.Refresh()
 
     def OnResetTrackerFiducials(self):
         self.UpdateElements()

--- a/invesalius/gui/widgets/fiducial_buttons.py
+++ b/invesalius/gui/widgets/fiducial_buttons.py
@@ -1,0 +1,159 @@
+# --------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------
+from functools import partial
+
+import wx
+import invesalius.constants as const
+from wx.lib.masked.numctrl import NumCtrl
+
+
+class OrderedFiducialButtons:
+    def __init__(self, parent, fiducial_definitions, is_fiducial_set, get_fiducial_coord=None, order=None):
+        """
+        :param parent: parent for wx elements
+        :param fiducial_definitions: const.OBJECT_FIDUCIALS or const.TRACKER_FIDUCIALS
+        :param is_fiducial_set: Function taking fiducial index as parameter, returning True if that
+                                fiducial is set, False otherwise.
+        :param get_fiducial_coord: Function to retrieve value for NumCtrl. Takes fiducial index and
+                                   coordinate index as parameters, returns value.
+        :param order: list of indices representing default order to record fiducials
+        """
+        count = len(fiducial_definitions)
+        self.is_fiducial_set = is_fiducial_set
+        self.get_fiducial_coord = get_fiducial_coord
+        self.order: list[int] = order or list(range(count))
+
+        self.buttons: list[wx.Button] = []  # list of buttons
+        self.numctrls: list[list[NumCtrl]] = []
+
+        self.focused_index: int | None = None
+        self.focused: wx.Button | None = None
+
+        # Initialize buttons
+        for n, fiducial in enumerate(fiducial_definitions):
+            button_id = fiducial['button_id']
+            label = fiducial['label']
+            tip = fiducial['tip']
+
+            w, h = wx.ScreenDC().GetTextExtent("M"*len(label))
+            ctrl = wx.Button(parent, button_id, label='', size=(55, h+5))
+            ctrl.SetLabel(label)
+            ctrl.SetToolTip(tip)
+            ctrl.Bind(wx.EVT_BUTTON, partial(self._OnButton, n=n))
+            self.buttons.append(ctrl)
+
+        # Initialize NumCtrls
+        for n in range(count):
+            coords = []
+            for coord_index in range(3):
+                numctrl = wx.lib.masked.numctrl.NumCtrl(parent=parent, integerWidth=4, fractionWidth=1)
+                numctrl.Hide()
+                coords.append(numctrl)
+            self.numctrls.append(coords)
+
+        self.Update()
+
+    def __getitem__(self, n):
+        return self.buttons[n]
+
+    def __iter__(self):
+        return iter(self.buttons)
+
+    @property
+    def focused(self):
+        if self.focused_index is None:
+            return None
+        else:
+            return self.buttons[self.focused_index]
+
+    @focused.setter
+    def focused(self, new_focus):
+        if new_focus is None:
+            self.focused_index = None
+            return
+
+        for n, button in enumerate(self.buttons):
+            if new_focus is button:
+                self.focused_index = n
+                return
+        raise ValueError
+
+    def _RefreshColors(self):
+        for n, button in enumerate(self.buttons):
+            if self.is_fiducial_set(n):
+                button.SetBackgroundColour(const.GREEN_COLOR_RGB)
+            else:
+                button.SetBackgroundColour(const.RED_COLOR_RGB)
+        if self.focused is not None:
+            self.focused.SetBackgroundColour(const.YELLOW_COLOR_RGB)
+
+    def _UpdateControls(self):
+        if self.get_fiducial_coord is None:
+            return
+
+        for n, element in enumerate(self.numctrls):
+            for i, numctrl in enumerate(element):
+                value = self.get_fiducial_coord(n, i)
+                numctrl.SetValue(value)
+
+    def _UpdateControl(self, n):
+        if self.get_fiducial_coord is None:
+            return
+
+        for i, numctrl in enumerate(self.numctrls[n]):
+            value = self.get_fiducial_coord(n, i)
+            numctrl.SetValue(value)
+
+    def Update(self):
+        self._UpdateControls()
+        self._RefreshColors()
+
+    def FocusNext(self):
+        for n in self.order:
+            if not self.is_fiducial_set(n):
+                self.Focus(n)
+                break
+
+    def ClearFocus(self):
+        if self.focused is not None:
+            self.focused.SetBackgroundColour(const.RED_COLOR_RGB)
+            self.focused = None
+
+    def _OnButton(self, evt, n):
+        self.Focus(n)
+
+    def Focus(self, n):
+        self.ClearFocus()
+        self.focused = self.buttons[n]
+        self.focused.SetBackgroundColour(const.YELLOW_COLOR_RGB)
+
+    def SetFocused(self):
+        self.focused.SetBackgroundColour(const.GREEN_COLOR_RGB)
+        self._UpdateControl(self.focused_index)
+        self.focused = None
+        self.FocusNext()
+
+    def Set(self, n):
+        self.Focus(n)
+        self.SetFocused()
+
+    def Unset(self, n):
+        button = self.buttons[n]
+        button.SetBackgroundColour(const.RED_COLOR_RGB)
+        self.FocusNext()

--- a/invesalius/net/pedal_connection.py
+++ b/invesalius/net/pedal_connection.py
@@ -46,7 +46,7 @@ class PedalConnector:
 
         if const.KEYSTROKE_PEDAL_ENABLED:
             self._set_frame(window)
-            self.panel_callbacks = {}
+            self.panel_callbacks = {}  # dict[wxpanel_id, dict[callback_name, function]]
 
     def _set_frame(self, panel):
         try:
@@ -70,6 +70,7 @@ class PedalConnector:
                     if remove_when_released:
                         self.panel_callbacks[panel_id].pop(name)
             evt.Skip()
+
         panel.Bind(wx.EVT_CHAR_HOOK, partial(OnKeyPress, state=True))
 
     def add_callback(self, name, callback, remove_when_released=False, panel=None):


### PR DESCRIPTION
New class for creating fiducial buttons and keeping track of which button to set next: used to reimplement fiducial buttons for object and tracker.

Object fiducials:
 - Register fiducials with a single click
 - Colored buttons

Tracker fiducials:
 - Changed fiducial registration order to left ear, nasion, right ear.
 - Allow changing default fiducial registration order through constants.py.
 - Allow setting fiducials outside default order.
 - Improved code structure.