### PR TITLE
FIX: Refine called non-existing UpdateGUI

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -995,7 +995,7 @@ class RefinePage(wx.Panel):
     def OnRefine(self, evt):
         self.icp.RegisterICP(self.navigation, self.tracker)
         if self.icp.use_icp:
-            self.UpdateUI()
+            self.OnUpdateUI()
 
 
 class StimulatorPage(wx.Panel):


### PR DESCRIPTION
After Refine dialog, in task_navigator it was calling a non-existing UpdateUI method and raised an error.