### PR TITLE
Update static/dynamic ref_mode in Navigation class based on GUI selection

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -850,10 +850,7 @@ class TrackerTab(wx.Panel):
             self.ShowParent()
 
     def OnChooseReferenceMode(self, evt, ctrl):
-        # Probably need to refactor object registration as a whole to use the 
-        # OnChooseReferenceMode function which was used earlier. It can be found in
-        # the deprecated code in ObjectRegistrationPanel in task_navigator.py.
-        pass
+        Navigation().SetReferenceMode(evt.GetSelection())
 
     def HideParent(self):  # hide preferences dialog box
         self.GetGrandParent().Hide()


### PR DESCRIPTION
Currently the choice "Dynamic/Static navigation reference mode" in Tracker Preferences is unresponsive. There's no way for the user to set static mode. 
With this commit, the ref_mode_id is actually updated in Navigation class and static mode is enabled. Maybe static mode should be removed though, if unused?