### PR TITLE
Fix launch new instance of InVesalius

### DIFF
--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -404,7 +404,7 @@ class Project(metaclass=Singleton):
             "scalar_range": (int(image.min()), int(image.max())),
             "spacing": spacing,
             "affine": affine,
-            "image_fiducials": np.full([3, 3], np.nan),
+            "image_fiducials": np.full([3, 3], np.nan).tolist(),
             "matrix": matrix,
         }
 


### PR DESCRIPTION
It's not possible to launch new instance of invesalius because `image_fiducials` is a numpy array. So this PR converts `image_fiducials` to list.