### PR TITLE
Update "Getting Started" link to the new user manual

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -793,13 +793,12 @@ class Frame(wx.Frame):
         session = ses.Session()
         if session.GetConfig("language") == "pt_BR":
             user_guide = "user_guide_pt_BR.pdf"
+            path = os.path.join(inv_paths.DOC_DIR, user_guide)
+            if sys.platform == "darwin":
+                path = r"file://" + path
+            webbrowser.open(path)
         else:
-            user_guide = "user_guide_en.pdf"
-
-        path = os.path.join(inv_paths.DOC_DIR, user_guide)
-        if sys.platform == "darwin":
-            path = r"file://" + path
-        webbrowser.open(path)
+            user_guide = webbrowser.open("https://invesalius.github.io/docs/user_guide/user_guide.html")
 
     def ShowImportDicomPanel(self):
         """


### PR DESCRIPTION
This pull request addresses issue [https://github.com/invesalius/invesalius3/issues/789](url) by updating the "Getting Started" link in the Help menu. The previous link pointed to an outdated PDF manual. Now, clicking "Getting Started" will open the new user manual available at [https://invesalius.github.io/docs/user_guide/user_guide.html](https://github.com/invesalius/invesalius3/pull/url)

**Changes made:**
Updated the URL in the frame.py file to point to the new user manual.

**Testing:**
Verified that the Help > Getting started link opens the new user manual in the default web browser.
![image](https://github.com/user-attachments/assets/25d0742a-3711-4b50-93ee-5adf820a6125)


Hi @henrikkauppi @vhosouza @tfmoraes please review this new PR.