### PR TITLE
Fix positioning of coregistration fiducial buttons

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -854,22 +854,22 @@ TR2 = wx.NewIdRef()
 TR3 = wx.NewIdRef()
 SET = wx.NewIdRef()
 
-FIDUCIAL_LABELS = ["Left Ear: ", "Right Ear: ", "Nose: "]
+FIDUCIAL_LABELS = ["Right Ear: ", "Left Ear: ", "Nose: "]
 FIDUCIAL_REGISTRATION_ORDER = [0, 2, 1]
 IMAGE_FIDUCIALS = [
     {
         "button_id": IR1,
-        "label": "Left Ear",
-        "fiducial_name": "LE",
+        "label": "Right Ear",
+        "fiducial_name": "RE",
         "fiducial_index": 0,
-        "tip": _("Select left ear in image"),
+        "tip": _("Select right ear in image"),
     },
     {
         "button_id": IR2,
-        "label": "Right Ear",
-        "fiducial_name": "RE",
+        "label": "Left Ear",
+        "fiducial_name": "LE",
         "fiducial_index": 1,
-        "tip": _("Select right ear in image"),
+        "tip": _("Select left ear in image"),
     },
     {
         "button_id": IR3,
@@ -883,17 +883,17 @@ IMAGE_FIDUCIALS = [
 TRACKER_FIDUCIALS = [
     {
         "button_id": TR1,
-        "label": "Left Ear",
-        "fiducial_name": "LE",
+        "label": "Right Ear",
+        "fiducial_name": "RE",
         "fiducial_index": 0,
-        "tip": _("Select left ear with spatial tracker"),
+        "tip": _("Select right ear with spatial tracker"),
     },
     {
         "button_id": TR2,
-        "label": "Right Ear",
-        "fiducial_name": "RE",
+        "label": "Left Ear",
+        "fiducial_name": "LE",
         "fiducial_index": 1,
-        "tip": _("Select right ear with spatial tracker"),
+        "tip": _("Select left ear with spatial tracker"),
     },
     {
         "button_id": TR3,
@@ -904,7 +904,7 @@ TRACKER_FIDUCIALS = [
     },
 ]
 
-BTNS_IMG_MARKERS = {IR1: {0: "LEI"}, IR2: {1: "REI"}, IR3: {2: "NAI"}}
+BTNS_IMG_MARKERS = {IR1: {0: "REI"}, IR2: {1: "LEI"}, IR3: {2: "NAI"}}
 
 OBJL = wx.NewIdRef()
 OBJR = wx.NewIdRef()
@@ -917,15 +917,15 @@ OBJECT_FIDUCIAL_FIXED = 3
 OBJECT_FIDUCIALS = [
     {
         "fiducial_index": 0,
-        "button_id": OBJL,
-        "label": _("Left"),
-        "tip": _("Select left object fiducial"),
-    },
-    {
-        "fiducial_index": 1,
         "button_id": OBJR,
         "label": _("Right"),
         "tip": _("Select right object fiducial"),
+    },
+    {
+        "fiducial_index": 1,
+        "button_id": OBJL,
+        "label": _("Left"),
+        "tip": _("Select left object fiducial"),
     },
     {
         "fiducial_index": OBJECT_FIDUCIAL_ANTERIOR,

--- a/invesalius/data/markers/marker.py
+++ b/invesalius/data/markers/marker.py
@@ -236,7 +236,7 @@ class Marker:
         if "marker_type" in d:
             marker_type = d["marker_type"]
         else:
-            if d["label"] in ["LEI", "REI", "NAI"]:
+            if d["label"] in ["REI", "LEI", "NAI"]:
                 marker_type = MarkerType.FIDUCIAL.value
 
             elif orientation == [None, None, None]:

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -793,13 +793,12 @@ class Frame(wx.Frame):
         session = ses.Session()
         if session.GetConfig("language") == "pt_BR":
             user_guide = "user_guide_pt_BR.pdf"
+            path = os.path.join(inv_paths.DOC_DIR, user_guide)
+            if sys.platform == "darwin":
+                path = r"file://" + path
+            webbrowser.open(path)
         else:
-            user_guide = "user_guide_en.pdf"
-
-        path = os.path.join(inv_paths.DOC_DIR, user_guide)
-        if sys.platform == "darwin":
-            path = r"file://" + path
-        webbrowser.open(path)
+            user_guide = webbrowser.open("https://invesalius.github.io/docs/user_guide/user_guide.html")
 
     def ShowImportDicomPanel(self):
         """


### PR DESCRIPTION
This PR fixes issue [#790](https://github.com/invesalius/invesalius3/issues/790), which involves the incorrect positioning of the fiducial buttons for the Left Ear and Right Ear in the coregistration Image and Patient tabs. Previously, the buttons were incorrectly placed, with the Left Ear button on the right side and the Right Ear button on the left side. This update switches their positions to correctly match the top-down view of the head.

**Changes Made:**
Updated the positions of the buttons in the constants.py file for both tabs.
Updated the labels in the marker.py file.

**Testing:**
Verified that the Left Ear and Right Ear buttons are now correctly positioned in the Image tab.
Verified that the Left Ear and Right Ear buttons are now correctly positioned in the Patient tab.


Hi @henrikkauppi @vhosouza @tfmoraes please review this PR.