### PR TITLE
Update "Getting Started" always link to new documentation

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -790,15 +790,7 @@ class Frame(wx.Frame):
         """
         Show getting started window.
         """
-        session = ses.Session()
-        if session.GetConfig("language") == "pt_BR":
-            user_guide = "user_guide_pt_BR.pdf"
-            path = os.path.join(inv_paths.DOC_DIR, user_guide)
-            if sys.platform == "darwin":
-                path = r"file://" + path
-            webbrowser.open(path)
-        else:
-            user_guide = webbrowser.open("https://invesalius.github.io/docs/user_guide/user_guide.html")
+        webbrowser.open("https://invesalius.github.io/docs/user_guide/user_guide.html")
 
     def ShowImportDicomPanel(self):
         """


### PR DESCRIPTION
This pull request addresses issue [https://github.com/invesalius/invesalius3/issues/789](https://github.com/invesalius/invesalius3/pull/url) by updating the "Getting Started" link in the Help menu. The previous link pointed to an outdated PDF manual. Now, clicking "Getting Started" will open the new user manual available at [https://invesalius.github.io/docs/user_guide/user_guide.html](https://github.com/invesalius/invesalius3/pull/url). It always link to the newest documentation regardless of the selected language?

**Changes made:**
Updated the URL in the frame.py file to point to the new user manual.

Hi @henrikkauppi @vhosouza @tfmoraes  please review this new PR.