### PR TITLE
Change TMS-mode switching to make it less prone to bugs

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -122,8 +122,6 @@ class Controller:
         Publisher.subscribe(self.disable_mask_preview, "Disable mask 3D preview")
         Publisher.subscribe(self.update_mask_preview, "Update mask 3D preview")
 
-        Publisher.subscribe(self.LoadProject, "Load project data")
-
     def SetBitmapSpacing(self, spacing: Tuple[float, float, float]) -> None:
         proj = prj.Project()
         proj.spacing = spacing

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -145,17 +145,14 @@ class Panel(wx.Panel):
         else:
             Publisher.sendMessage("Hide target button")
             session.SetConfig("mode", const.MODE_RP)
+        Publisher.sendMessage("Close Project")
+        Publisher.sendMessage("Disconnect tracker")
         self.gbs.Hide(self.uppertaskpanel)
         self.uppertaskpanel.Destroy()
         self.uppertaskpanel = UpperTaskPanel(self)
         self.gbs.Add(self.uppertaskpanel, (0, 0), flag=wx.EXPAND)
         self.Layout()
         self.Refresh()
-        project_status = session.GetConfig("project_status")
-        if project_status != const.PROJECT_STATUS_CLOSED:
-            Publisher.sendMessage("Load project data")
-            Publisher.sendMessage("Enable state project", state=True)
-
 
 # Lower fold panel
 class LowerTaskPanel(wx.Panel):

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -142,6 +142,7 @@ class Panel(wx.Panel):
         Publisher.sendMessage("Close Project")
         project_status = session.GetConfig("project_status")
         if project_status != const.PROJECT_STATUS_CLOSED:
+            Publisher.sendMessage("Update Navigation Mode MenuBar")
             return
 
         if status:

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -138,15 +138,19 @@ class Panel(wx.Panel):
         Publisher.subscribe(self.SetNavigationMode, "Set navigation mode")
 
     def SetNavigationMode(self, status):
-        self.navigation_mode_status = status
         session = ses.Session()
+        Publisher.sendMessage("Close Project")
+        project_status = session.GetConfig("project_status")
+        if project_status != const.PROJECT_STATUS_CLOSED:
+            return
+
         if status:
             session.SetConfig("mode", const.MODE_NAVIGATOR)
         else:
             Publisher.sendMessage("Hide target button")
             session.SetConfig("mode", const.MODE_RP)
-        Publisher.sendMessage("Close Project")
         Publisher.sendMessage("Disconnect tracker")
+
         self.gbs.Hide(self.uppertaskpanel)
         wx.GetApp().ProcessPendingEvents()
         self.uppertaskpanel.Destroy()
@@ -353,7 +357,6 @@ class UpperTaskPanel(wx.Panel):
             Publisher.subscribe(self.OnFoldSurface, "Fold surface task")
             Publisher.subscribe(self.OnFoldExport, "Fold export task")
         Publisher.subscribe(self.OnEnableState, "Enable state project")
-        # Publisher.subscribe(self.SetNavigationMode, "Set navigation mode")
 
     def OnOverwrite(self, surface_parameters):
         self.overwrite = surface_parameters["options"]["overwrite"]

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -148,6 +148,7 @@ class Panel(wx.Panel):
         Publisher.sendMessage("Close Project")
         Publisher.sendMessage("Disconnect tracker")
         self.gbs.Hide(self.uppertaskpanel)
+        wx.GetApp().ProcessPendingEvents()
         self.uppertaskpanel.Destroy()
         self.uppertaskpanel = UpperTaskPanel(self)
         self.gbs.Add(self.uppertaskpanel, (0, 0), flag=wx.EXPAND)

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -51,7 +51,12 @@ class Tracker(metaclass=Singleton):
 
         self.TrackerCoordinates = dco.TrackerCoordinates()
 
+        self.__bind_events()
+
         self.LoadState()
+
+    def __bind_events(self):
+        Publisher.subscribe(self.DisconnectTracker, 'Disconnect tracker')
 
     def SaveState(self):
         tracker_id = self.tracker_id


### PR DESCRIPTION
Previously, switching TMS-mode used to partially reload the project, causing various issues.

Changed switching TMS-mode to always close the project, prompting the user to save unsaved changes to project if such exist.

Fixes the following mode switching bugs:
 - overlapping slice numbers 
 - red cross tool stuck turned on

Also includes fix for #775