### PR TITLE
Remove unnecessary text tms coil

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1024,7 +1024,6 @@ class StimulatorPage(wx.Panel):
         self.config_txt = config_txt
         self.config_txt.Hide()
 
-        lbl_edit = wx.StaticText(self, -1, _("Edit Configuration:"))
         btn_edit = wx.Button(self, -1, _("Preferences"))
         btn_edit.SetToolTip("Open preferences menu")
         btn_edit.Bind(wx.EVT_BUTTON, self.OnEditPreferences)
@@ -1035,8 +1034,7 @@ class StimulatorPage(wx.Panel):
                 (0, 0),
                 (config_txt, 1, wx.EXPAND | wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 10),
                 (0, 0),
-                (lbl_edit, 1, wx.EXPAND | wx.ALL | wx.ALIGN_CENTER_VERTICAL, 10),
-                (btn_edit, 0, wx.EXPAND | wx.ALL | wx.ALIGN_LEFT, 10),
+                (btn_edit, 0, wx.EXPAND | wx.ALL | wx.ALIGN_CENTER_VERTICAL, 10),
             ]
         )
 


### PR DESCRIPTION
This PR fixes issue [#836](https://github.com/invesalius/invesalius3/issues/836), which removes the unnecessary "Edit Configuration" text from the TMS Coil tab in coregistration and repositions the "Preferences" button to the left where the removed text was.

Changes Made:
- Updated the task_navigator.py file.

Testing:
- Verified that the "Preferences" button is correctly positioned on the TMS Coil tab.
- Ensured there are no alignment issues or UI breakages after the change.


Hi @henrikkauppi @vhosouza @tfmoraes please review this new Pull request.