### PR TITLE
Quick fix for a bug in preferences.py

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -92,7 +92,10 @@ class Preferences(wx.Dialog):
 
     def OnOK(self, event):
         Publisher.sendMessage("Save Preferences")
-        self.EndModal(wx.ID_OK)
+        try:
+            self.EndModal(wx.ID_OK)
+        except wx._core.wxAssertionError:
+            self.Destroy()
 
     def OnCharHook(self, event):
         if event.GetKeyCode() == wx.WXK_ESCAPE:


### PR DESCRIPTION
The bug occurs when changing the tracker, after which preferences cannot be closed normally (pressing OK will cause a wx error and preferences won't close). 

You'll see preferences is re-opened (hidden and shown again) when the tracker is changed. This behavior is probably the cause of the bug... 

This commit is a quick fix that ignores the source of the bug