### PR TITLE
FIX: Coregistration UI fixes and improvements

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -435,7 +435,7 @@ class ImagePage(wx.Panel):
 
         sizer = wx.GridBagSizer(5, 5)
         sizer.Add(
-            self.btns_set_fiducial[0],  # Left Ear
+            self.btns_set_fiducial[1],  # Right Ear
             wx.GBPosition(1, 0),
             span=wx.GBSpan(1, 2),
             flag=wx.ALIGN_CENTER_VERTICAL,
@@ -447,7 +447,7 @@ class ImagePage(wx.Panel):
             flag=wx.ALIGN_CENTER_HORIZONTAL,
         )
         sizer.Add(
-            self.btns_set_fiducial[1],  # Right Ear
+            self.btns_set_fiducial[0],  # Left Ear
             wx.GBPosition(1, 3),
             span=wx.GBSpan(1, 2),
             flag=wx.ALIGN_CENTER_VERTICAL,
@@ -669,7 +669,7 @@ class TrackerPage(wx.Panel):
 
         sizer = wx.GridBagSizer(5, 5)
         sizer.Add(
-            self.fiducial_buttons[0],  # Left Ear
+            self.fiducial_buttons[1],  # Right Ear
             wx.GBPosition(1, 0),
             span=wx.GBSpan(1, 2),
             flag=wx.ALIGN_CENTER_VERTICAL,
@@ -681,7 +681,7 @@ class TrackerPage(wx.Panel):
             flag=wx.ALIGN_CENTER_HORIZONTAL,
         )
         sizer.Add(
-            self.fiducial_buttons[1],  # Right Ear
+            self.fiducial_buttons[0],  # Left Ear
             wx.GBPosition(1, 3),
             span=wx.GBSpan(1, 2),
             flag=wx.ALIGN_CENTER_VERTICAL,

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -431,7 +431,7 @@ class ImagePage(wx.Panel):
         top_sizer.AddMany([(start_button), (reset_button)])
 
         bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        bottom_sizer.Add(next_button)
+        bottom_sizer.Add(next_button, 0, wx.EXPAND | wx.TOP, 65)
 
         sizer = wx.GridBagSizer(5, 5)
         sizer.Add(
@@ -459,7 +459,7 @@ class ImagePage(wx.Panel):
             [
                 (top_sizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 10),
                 (sizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.LEFT | wx.RIGHT, 5),
-                (bottom_sizer, 0, wx.ALIGN_RIGHT | wx.RIGHT | wx.TOP, 30),
+                (bottom_sizer, 0, wx.ALIGN_RIGHT | wx.RIGHT, 30),
             ]
         )
         self.sizer = main_sizer
@@ -1039,7 +1039,6 @@ class StylusPage(wx.Panel):
                 (lbl, 1, wx.EXPAND | wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2),
                 (lbl_rec, 1, wx.EXPAND | wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2),
                 (self.help, 0, wx.EXPAND | wx.ALL | wx.ALIGN_CENTER_VERTICAL, 1),
-                (btn_rec, 0, wx.EXPAND | wx.ALL | wx.ALIGN_LEFT, 1),
             ]
         )
 
@@ -1049,14 +1048,15 @@ class StylusPage(wx.Panel):
         next_button.Bind(wx.EVT_BUTTON, partial(self.OnNext))
 
         bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        bottom_sizer.Add(back_button)
-        bottom_sizer.Add(next_button)
+        bottom_sizer.Add(back_button, 0, wx.EXPAND | wx.TOP, 10)
+        bottom_sizer.Add(btn_rec, 0, wx.EXPAND | wx.TOP, 10)
+        bottom_sizer.Add(next_button, 0, wx.EXPAND | wx.TOP, 10)
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         main_sizer.AddMany(
             [
-                (border, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 1),
-                (bottom_sizer, 0, wx.ALIGN_CENTER | wx.CENTER | wx.TOP, 1),
+                (border, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 10),
+                (bottom_sizer, 0, wx.ALIGN_CENTER | wx.CENTER | wx.TOP, 10),
             ]
         )
 
@@ -1110,33 +1110,42 @@ class StimulatorPage(wx.Panel):
             self,
             -1,
             _(
-                f"Ready for navigation with {self.navigation.n_coils} coil{'' if self.navigation.n_coils == 1 else 's'}!"
+                f"Ready for navigation with {self.navigation.n_coils} "
+                f"coil{'' if self.navigation.n_coils == 1 else 's'}!"
             ),
         )
-        # lbl.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD))
+        lbl.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD))
         self.lbl = lbl
 
-        btn_edit = wx.Button(self, -1, _("Edit coil registration in Preferences"))
+        btn_edit = wx.Button(self, -1, _("Edit coil registration"))
         btn_edit.SetToolTip("Open preferences menu")
         btn_edit.Bind(wx.EVT_BUTTON, self.OnEditPreferences)
 
-        next_button = wx.Button(self, label="Proceed to navigation")
+        back_button = wx.Button(self, label="Back")
+        back_button.Bind(wx.EVT_BUTTON, partial(self.OnBack))
+
+        next_button = wx.Button(self, label="Next")
         next_button.Bind(wx.EVT_BUTTON, partial(self.OnNext))
         if not self.navigation.CoilSelectionDone():
             self.lbl.SetLabel("Please select a coil registration")
             next_button.Enable(False)
         self.next_button = next_button
 
-        border.AddMany(
+        border.Add(lbl, 1, wx.EXPAND | wx.TOP, 10)
+
+        bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        bottom_sizer.AddMany(
             [
-                (lbl, 1, wx.EXPAND),
+                (back_button, 1, wx.EXPAND),
                 (btn_edit, 1, wx.EXPAND),
                 (next_button, 1, wx.EXPAND),
             ]
         )
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
-        main_sizer.Add(border, 0, wx.EXPAND, 5)
+        main_sizer.Add(border, 0, wx.CENTER | wx.ALL, 5)
+        main_sizer.AddSpacer(205)
+        main_sizer.Add(bottom_sizer, 0, wx.EXPAND | wx.ALL, 20)
 
         self.SetSizerAndFit(main_sizer)
         self.Layout()
@@ -1163,6 +1172,9 @@ class StimulatorPage(wx.Panel):
 
     def OnEditPreferences(self, evt):
         Publisher.sendMessage("Open preferences menu", page=3)
+
+    def OnBack(self, evt):
+        Publisher.sendMessage("Move to stylus page")
 
     def OnNext(self, evt):
         Publisher.sendMessage("Open navigation menu")


### PR DESCRIPTION
- Swapped the position of left and right fiducial registration button so that they now match the layout of the axial slice view.
- Improved the consistency of the button layout in the coregistration panel by moving all the buttons for navigating between different pages to the bottom of the screen and adding a missing "back" button to the TMS coil page. Labels of some buttons were also simplified and changed for consistency. 