### PR TITLE
FIX: Error when trying to open Preferences

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -163,7 +163,11 @@ class VisualizationTab(wx.Panel):
         self.number_colors = 4
         self.cluster_volume = None
 
-        self.conf = dict(self.session.GetConfig("mep_configuration"))
+        self.conf = self.session.GetConfig("mep_configuration")
+        if self.conf is None:
+            self.conf = {}
+        else:
+            self.conf = dict(self.conf)
         self.conf["mep_colormap"] = self.conf.get("mep_colormap", "Viridis")
 
         bsizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("3D Visualization"))

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -164,10 +164,10 @@ class VisualizationTab(wx.Panel):
         self.cluster_volume = None
 
         self.conf = self.session.GetConfig("mep_configuration")
-        if self.conf is None:
+        try:
+            self.conf = dict(self.session.GetConfig("mep_configuration"))
+        except TypeError:
             self.conf = {}
-        else:
-            self.conf = dict(self.conf)
         self.conf["mep_colormap"] = self.conf.get("mep_colormap", "Viridis")
 
         bsizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("3D Visualization"))

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -165,7 +165,7 @@ class VisualizationTab(wx.Panel):
 
         self.conf = self.session.GetConfig("mep_configuration")
         try:
-            self.conf = dict(self.session.GetConfig("mep_configuration"))
+            self.conf = dict(self.conf)
         except TypeError:
             self.conf = {}
         self.conf["mep_colormap"] = self.conf.get("mep_colormap", "Viridis")


### PR DESCRIPTION
This addresses issue #872 

## Updated ```VisualizationTab``` :
### -An error was occurring when using ```dict()``` in cases where ```self.session.GetConfig("mep_configuration")``` returned None.
### -Added a condition to check that.