### PR TITLE
FIX:The application terminates if you cancel the confirmation dialog box for exit.

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -173,7 +173,6 @@ class Frame(wx.Frame):
 
         # Close InVesalius main window, hence exit the software.
         self.Bind(wx.EVT_CLOSE, self.OnExit)
-        self.Bind(wx.EVT_ICONIZE, self.OnIconize)
 
         # Bind global key events.
         self.Bind(wx.EVT_CHAR_HOOK, self.OnGlobalKey)
@@ -515,7 +514,7 @@ class Frame(wx.Frame):
                 None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
             dialog.ShowCheckBox("Store session", True)
-
+        
         def on_close(event):
             dialog.EndModal(wx.ID_CANCEL)
             event.Skip()
@@ -549,17 +548,6 @@ class Frame(wx.Frame):
             Publisher.sendMessage("Exit")
             if status == 1:
                 Publisher.sendMessage("Exit session")
-
-    def OnIconize(self, evt):
-        print("Window minimized")
-        if self.IsIconized():
-            self.CloseAllMenus()
-        evt.Skip()
-
-    def CloseAllMenus(self):
-        simulator = wx.UIActionSimulator()
-        simulator.MouseMove(0, 0)
-        simulator.MouseClick()
 
     def OnMenuClick(self, evt):
         """

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -514,12 +514,20 @@ class Frame(wx.Frame):
                 None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
             dialog.ShowCheckBox("Store session", True)
+        
+        def on_close(event):
+            dialog.EndModal(wx.ID_CANCEL)
+            event.Skip()
+
+        dialog.Bind(wx.EVT_CLOSE, on_close)
 
         answer = dialog.ShowModal()
         save = dialog.IsCheckBoxChecked()
         dialog.Destroy()
 
         # logger = log.MyLogger()
+        if answer == wx.ID_CANCEL:
+            return 0
 
         if not save and answer == wx.ID_YES:
             log.invLogger.closeLogging()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -514,9 +514,9 @@ class Frame(wx.Frame):
                 None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
             dialog.ShowCheckBox("Store session", True)
-        
+
         def on_close(event):
-            dialog.EndModal(wx.ID_CANCEL)
+            dialog.EndModal(wx.ID_NO)
             event.Skip()
 
         dialog.Bind(wx.EVT_CLOSE, on_close)
@@ -526,8 +526,6 @@ class Frame(wx.Frame):
         dialog.Destroy()
 
         # logger = log.MyLogger()
-        if answer == wx.ID_CANCEL:
-            return 0
 
         if not save and answer == wx.ID_YES:
             log.invLogger.closeLogging()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -173,6 +173,7 @@ class Frame(wx.Frame):
 
         # Close InVesalius main window, hence exit the software.
         self.Bind(wx.EVT_CLOSE, self.OnExit)
+        self.Bind(wx.EVT_ICONIZE, self.OnIconize)
 
         # Bind global key events.
         self.Bind(wx.EVT_CHAR_HOOK, self.OnGlobalKey)
@@ -514,7 +515,7 @@ class Frame(wx.Frame):
                 None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
             dialog.ShowCheckBox("Store session", True)
-        
+
         def on_close(event):
             dialog.EndModal(wx.ID_CANCEL)
             event.Skip()
@@ -548,6 +549,17 @@ class Frame(wx.Frame):
             Publisher.sendMessage("Exit")
             if status == 1:
                 Publisher.sendMessage("Exit session")
+
+    def OnIconize(self, evt):
+        print("Window minimized")
+        if self.IsIconized():
+            self.CloseAllMenus()
+        evt.Skip()
+
+    def CloseAllMenus(self):
+        simulator = wx.UIActionSimulator()
+        simulator.MouseMove(0, 0)
+        simulator.MouseClick()
 
     def OnMenuClick(self, evt):
         """


### PR DESCRIPTION
This fixes the issue #874 .

## Changes in ExitDialog
### 1. Added a` on_close` function:
####    This function handles the close event of the dialog.
####    It calls `EndModal` with `wx.ID_CANCEL` to set the return code when the dialog is closed without selecting an option

### 2. Bound the `EVT_CLOSE` event:
####    The `EVT_CLOSE` event is bound to the `on_close` function.

### 3. Checked the return value of `wx.ID_CANCEL`:
####    The return value `wx.ID_CANCEL` is checked to determine if the dialog was closed without selecting an option.
####    If `wx.ID_CANCEL` is returned, the function returns 0 to prevent the application from exiting.
