### PR TITLE
FIX: Shortcuts not responding

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -192,6 +192,14 @@ class Frame(wx.Frame):
         Handle all key events at a global level.
         """
         keycode = event.GetKeyCode()
+        modifiers = event.GetModifiers()
+
+        # If it is CTRL+S, CTRL+Shift+S, or CTRL+Q, skip this event
+        if modifiers & wx.MOD_CONTROL:
+            unicode = event.GetUnicodeKey()
+            if unicode in (ord("s"), ord("S"), ord("q"), ord("Q")):
+                event.Skip()
+                return
 
         # If the key is a move marker key, publish a message to move the marker.
         if keycode in const.MOVEMENT_KEYCODES and not self.edit_data_notebook_label:


### PR DESCRIPTION
This fixes issue #893 

### The shortcuts for Save, Save As, and Exit were not working as they were being intercepted by the wrong handler.

To fix this:
- Explicitly skipped the events CTRL+S, CTRL+Shift+S, and CTRL+Q in ```OnGlobalKey``` function.

The shortcuts are now being properly being handled by ```OnMenuClick``` as intended.

Kindly review this PR @tfmoraes  @paulojamorim  @henrikkauppi  @rmatsuda