### PR TITLE
Type Annotations for default_viewers.py, frame.py,volume_widgets.py (Issue #497)

### DIFF
--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -40,10 +40,11 @@ from invesalius.gui.widgets.clut_raycasting import (
 )
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+from typing import Any, List, Tuple
 
 
 class Panel(wx.Panel):
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.Panel.__init__(self, parent, pos=wx.Point(0, 50), size=wx.Size(744, 656))
 
         self.__init_aui_manager()
@@ -52,7 +53,7 @@ class Panel(wx.Panel):
         # self.__init_four_way_splitter()
         # self.__init_mix()
 
-    def __init_aui_manager(self):
+    def __init_aui_manager(self) -> None:
         self.aui_manager = wx.aui.AuiManager()
         self.aui_manager.SetManagedWindow(self)
 
@@ -153,30 +154,30 @@ class Panel(wx.Panel):
         if session.GetConfig("mode") != const.MODE_NAVIGATOR:
             Publisher.sendMessage("Hide target button")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         self.aui_manager.Bind(wx.aui.EVT_AUI_PANE_MAXIMIZE, self.OnMaximize)
         self.aui_manager.Bind(wx.aui.EVT_AUI_PANE_RESTORE, self.OnRestore)
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         Publisher.subscribe(self.OnSetTargetMode, "Set target mode")
         Publisher.subscribe(self.OnStartNavigation, "Start navigation")
         Publisher.subscribe(self._Exit, "Exit")
 
-    def OnSetTargetMode(self, enabled=True):
+    def OnSetTargetMode(self, enabled: bool = True) -> None:
         if enabled:
             self.MaximizeViewerVolume()
         else:
             self.RestoreViewerVolume()
 
-    def OnStartNavigation(self):
+    def OnStartNavigation(self) -> None:
         self.MaximizeViewerVolume()
 
-    def RestoreViewerVolume(self):
+    def RestoreViewerVolume(self) -> None:
         self.aui_manager.RestoreMaximizedPane()
         Publisher.sendMessage("Hide raycasting widget")
         self.aui_manager.Update()
 
-    def MaximizeViewerVolume(self):
+    def MaximizeViewerVolume(self) -> None:
         # Restore volume viewer to make sure it is not already maximized before attempting to maximize it
         # to fix the issue with panes locking into the maximized state where they cannot be restored
         self.RestoreViewerVolume()
@@ -186,22 +187,22 @@ class Panel(wx.Panel):
         Publisher.sendMessage("Show raycasting widget")
         self.aui_manager.Update()
 
-    def OnMaximize(self, evt):
+    def OnMaximize(self, evt: wx.aui.AuiManagerEvent) -> None:
         if evt.GetPane().name == self.s4.name:
             Publisher.sendMessage("Show raycasting widget")
 
-    def OnRestore(self, evt):
+    def OnRestore(self, evt: wx.aui.AuiManagerEvent) -> None:
         if evt.GetPane().name == self.s4.name:
             Publisher.sendMessage("Hide raycasting widget")
 
-    def _Exit(self):
+    def _Exit(self) -> None:
         self.aui_manager.UnInit()
 
 
 class VolumeInteraction(wx.Panel):
-    def __init__(self, parent, id):
+    def __init__(self, parent: wx.Window, id: int):
         super().__init__(parent, id)
-        self.can_show_raycasting_widget = 0
+        self.can_show_raycasting_widget: int = 0
         self.__init_aui_manager()
         # sizer = wx.BoxSizer(wx.HORIZONTAL)
         # sizer.Add(volume_viewer.Viewer(self), 1, wx.EXPAND|wx.GROW)
@@ -210,7 +211,7 @@ class VolumeInteraction(wx.Panel):
         self.__bind_events_wx()
         # sizer.Fit(self)
 
-    def __init_aui_manager(self):
+    def __init_aui_manager(self) -> None:
         self.aui_manager = wx.aui.AuiManager()
         self.aui_manager.SetManagedWindow(self)
 
@@ -235,14 +236,14 @@ class VolumeInteraction(wx.Panel):
         self.aui_manager.AddPane(self.clut_raycasting, self.s2)
         self.aui_manager.Update()
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         self.clut_raycasting.Bind(EVT_CLUT_POINT_RELEASE, self.OnPointChanged)
         self.clut_raycasting.Bind(EVT_CLUT_CURVE_SELECT, self.OnCurveSelected)
         self.clut_raycasting.Bind(EVT_CLUT_CURVE_WL_CHANGE, self.OnChangeCurveWL)
         # self.Bind(wx.EVT_SIZE, self.OnSize)
         # self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         Publisher.subscribe(self.ShowRaycastingWidget, "Show raycasting widget")
         Publisher.subscribe(self.HideRaycastingWidget, "Hide raycasting widget")
         Publisher.subscribe(self.OnSetRaycastPreset, "Update raycasting preset")
@@ -250,38 +251,38 @@ class VolumeInteraction(wx.Panel):
         Publisher.subscribe(self.LoadHistogram, "Load histogram")
         Publisher.subscribe(self._Exit, "Exit")
 
-    def __update_curve_wwwl_text(self, curve):
+    def __update_curve_wwwl_text(self, curve: int) -> None:
         ww, wl = self.clut_raycasting.GetCurveWWWl(curve)
         Publisher.sendMessage("Set raycasting wwwl", ww=ww, wl=wl, curve=curve)
 
-    def ShowRaycastingWidget(self):
+    def ShowRaycastingWidget(self) -> None:
         self.can_show_raycasting_widget = 1
         if self.clut_raycasting.to_draw_points:
             p = self.aui_manager.GetPane(self.clut_raycasting)
             p.Show()
             self.aui_manager.Update()
 
-    def HideRaycastingWidget(self):
+    def HideRaycastingWidget(self) -> None:
         self.can_show_raycasting_widget = 0
         p = self.aui_manager.GetPane(self.clut_raycasting)
         p.Hide()
         self.aui_manager.Update()
 
-    def OnPointChanged(self, evt):
+    def OnPointChanged(self, evt: wx.CommandEvent) -> None:
         Publisher.sendMessage("Set raycasting refresh")
         Publisher.sendMessage("Set raycasting curve", curve=evt.GetCurve())
         Publisher.sendMessage("Render volume viewer")
 
-    def OnCurveSelected(self, evt):
+    def OnCurveSelected(self, evt: wx.CommandEvent) -> None:
         Publisher.sendMessage("Set raycasting curve", curve=evt.GetCurve())
         Publisher.sendMessage("Render volume viewer")
 
-    def OnChangeCurveWL(self, evt):
+    def OnChangeCurveWL(self, evt: wx.CommandEvent) -> None:
         curve = evt.GetCurve()
         self.__update_curve_wwwl_text(curve)
         Publisher.sendMessage("Render volume viewer")
 
-    def OnSetRaycastPreset(self):
+    def OnSetRaycastPreset(self) -> None:
         preset = project.Project().raycasting_preset
         p = self.aui_manager.GetPane(self.clut_raycasting)
         self.clut_raycasting.SetRaycastPreset(preset)
@@ -291,15 +292,15 @@ class VolumeInteraction(wx.Panel):
             p.Hide()
         self.aui_manager.Update()
 
-    def LoadHistogram(self, histogram, init, end):
+    def LoadHistogram(self, histogram: Any, init: float, end: float) -> None:
         self.clut_raycasting.SetRange((init, end))
         self.clut_raycasting.SetHistogramArray(histogram, (init, end))
 
-    def RefreshPoints(self):
+    def RefreshPoints(self) -> None:
         self.clut_raycasting.CalculatePixelPoints()
         self.clut_raycasting.Refresh()
 
-    def _Exit(self):
+    def _Exit(self) -> None:
         self.aui_manager.UnInit()
 
 
@@ -317,7 +318,7 @@ ICON_SIZE = (32, 32)
 
 
 class VolumeViewerCover(wx.Panel):
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.Panel.__init__(self, parent)
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -331,7 +332,7 @@ class VolumeViewerCover(wx.Panel):
 
 
 class VolumeToolPanel(wx.Panel):
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.Panel.__init__(self, parent)
 
         # VOLUME RAYCASTING BUTTON
@@ -370,8 +371,8 @@ class VolumeToolPanel(wx.Panel):
 
         # VOLUME COLOUR BUTTON
         if sys.platform.startswith("linux"):
-            size = (32, 32)
-            sp = 2
+            size: Tuple[int, int] = (32, 32)
+            sp: int = 2
         else:
             size = (24, 24)
             sp = 5
@@ -389,11 +390,11 @@ class VolumeToolPanel(wx.Panel):
         # sizer.Add(self.button_target, 0, wx.TOP | wx.BOTTOM, 1)
         #  sizer.Add(self.button_3d_mask, 0, wx.TOP | wx.BOTTOM, 1)
 
-        self.navigation_status = False
+        self.navigation_status: bool = False
 
         # Conditions for enabling Target button:
-        self.target_selected = False
-        self.track_obj = False
+        self.target_selected: bool = False
+        self.track_obj: bool = False
 
         sizer.Fit(self)
 
@@ -406,15 +407,15 @@ class VolumeToolPanel(wx.Panel):
         self.__bind_events()
         self.__bind_events_wx()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         Publisher.subscribe(self.ChangeButtonColour, "Change volume viewer gui colour")
         Publisher.subscribe(self.DisablePreset, "Close project data")
         Publisher.subscribe(self.Uncheck, "Uncheck image plane menu")
 
-    def DisablePreset(self):
+    def DisablePreset(self) -> None:
         self.off_item.Check(1)
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         self.button_slice_plane.Bind(wx.EVT_LEFT_DOWN, self.OnButtonSlicePlane)
         self.button_raycasting.Bind(wx.EVT_LEFT_DOWN, self.OnButtonRaycasting)
         self.button_view.Bind(wx.EVT_LEFT_DOWN, self.OnButtonView)
@@ -422,26 +423,26 @@ class VolumeToolPanel(wx.Panel):
         self.button_stereo.Bind(wx.EVT_LEFT_DOWN, self.OnButtonStereo)
         # self.button_target.Bind(wx.EVT_LEFT_DOWN, self.OnButtonTarget)
 
-    def OnButtonRaycasting(self, evt):
+    def OnButtonRaycasting(self, evt: wx.Event) -> None:
         # MENU RELATED TO RAYCASTING TYPES
         self.button_raycasting.PopupMenu(self.menu_raycasting)
 
-    def OnButtonStereo(self, evt):
+    def OnButtonStereo(self, evt: wx.Event) -> None:
         self.button_stereo.PopupMenu(self.stereo_menu)
 
-    def OnButtonView(self, evt):
+    def OnButtonView(self, evt: wx.Event) -> None:
         self.button_view.PopupMenu(self.menu_view)
 
-    def OnButtonSlicePlane(self, evt):
+    def OnButtonSlicePlane(self, evt: wx.Event) -> None:
         self.button_slice_plane.PopupMenu(self.slice_plane_menu)
 
-    def OnSavePreset(self, evt):
+    def OnSavePreset(self, evt: wx.CommandEvent) -> None:
         d = wx.TextEntryDialog(self, _("Preset name"))
         if d.ShowModal() == wx.ID_OK:
             preset_name = d.GetValue()
             Publisher.sendMessage("Save raycasting preset", preset_name=preset_name)
 
-    def __init_menus(self):
+    def __init_menus(self) -> None:
         # MENU RELATED TO RAYCASTING TYPES
         menu = self.menu = wx.Menu()
         # print "\n\n"
@@ -525,12 +526,12 @@ class VolumeToolPanel(wx.Panel):
         self.Fit()
         self.Update()
 
-    def DisableVolumeCutMenu(self):
+    def DisableVolumeCutMenu(self) -> None:
         self.menu.Enable(RAYCASTING_TOOLS, 0)
         item = ID_TO_TOOL_ITEM[self.id_cutplane]
         item.Check(0)
 
-    def BuildRaycastingMenu(self):
+    def BuildRaycastingMenu(self) -> None:
         presets = []
         for folder in const.RAYCASTING_PRESETS_FOLDERS:
             presets += [
@@ -539,7 +540,7 @@ class VolumeToolPanel(wx.Panel):
                 if os.path.isfile(os.path.join(folder, filename))
             ]
 
-    def OnMenuPlaneSlice(self, evt):
+    def OnMenuPlaneSlice(self, evt: wx.CommandEvent) -> None:
         id = evt.GetId()
         item = ID_TO_ITEMSLICEMENU[id]
         checked = item.IsChecked()
@@ -550,21 +551,21 @@ class VolumeToolPanel(wx.Panel):
         else:
             Publisher.sendMessage("Enable plane", plane_label=label)
 
-    def OnMenuStereo(self, evt):
+    def OnMenuStereo(self, evt: wx.CommandEvent) -> None:
         id = evt.GetId()
         mode = ID_TO_STEREO_NAME[id]
         Publisher.sendMessage("Set stereo mode", mode=mode)
 
-    def Uncheck(self):
+    def Uncheck(self) -> None:
         for item in self.slice_plane_menu.GetMenuItems():
             if item.IsChecked():
                 item.Check(0)
 
-    def ChangeButtonColour(self, colour):
+    def ChangeButtonColour(self, colour: List[float]) -> None:
         colour = [i * 255 for i in colour]
         self.button_colour.SetColour(colour)
 
-    def OnMenuRaycasting(self, evt):
+    def OnMenuRaycasting(self, evt: wx.CommandEvent) -> None:
         """Events from raycasting menu."""
         id = evt.GetId()
         if id in ID_TO_NAME.keys():
@@ -594,7 +595,7 @@ class VolumeToolPanel(wx.Panel):
                 TOOL_STATE[id] = False
                 item.Check(0)
 
-    def OnMenuView(self, evt):
+    def OnMenuView(self, evt: wx.CommandEvent) -> None:
         """Events from button menus."""
         bmp = wx.Bitmap(ID_TO_BMP[evt.GetId()][1], wx.BITMAP_TYPE_PNG)
         self.button_view.SetBitmapSelected(bmp)
@@ -602,6 +603,6 @@ class VolumeToolPanel(wx.Panel):
         Publisher.sendMessage("Set volume view angle", view=evt.GetId())
         self.Refresh()
 
-    def OnSelectColour(self, evt):
+    def OnSelectColour(self, evt: csel.ColourSelectEvent) -> None:
         colour = [i / 255.0 for i in evt.GetValue()]
         Publisher.sendMessage("Change volume viewer background colour", colour=colour)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------
 
+from typing import Any, List, Optional, Tuple, Dict
 import errno
 import os.path
 import platform
@@ -64,7 +65,7 @@ IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}
 
 
 class MessageWatershed(wx.PopupWindow):
-    def __init__(self, prnt, msg):
+    def __init__(self, prnt: wx.Window, msg: str):
         wx.PopupWindow.__init__(self, prnt, -1)
         self.txt = wx.StaticText(self, -1, msg)
 
@@ -83,7 +84,7 @@ class Frame(wx.Frame):
     Main frame of the whole software.
     """
 
-    def __init__(self, prnt):
+    def __init__(self, prnt: wx.Window):
         """
         Initialize frame, given its parent.
         """
@@ -101,20 +102,20 @@ class Frame(wx.Frame):
         icon_path = inv_paths.ICON_DIR.joinpath("invesalius.ico")
         self.SetIcon(wx.Icon(str(icon_path), wx.BITMAP_TYPE_ICO))
 
-        self.mw = None
-        self._last_viewer_orientation_focus = const.AXIAL_STR
+        self.mw: Optional[MessageWatershed] = None
+        self._last_viewer_orientation_focus: str = const.AXIAL_STR
 
         if sys.platform != "darwin":
             self.Maximize()
 
-        self.sizeChanged = True
+        self.sizeChanged: bool = True
         # Necessary update AUI (statusBar in special)
         # when maximized in the Win 7 and XP
         self.SetSize(self.GetSize())
         # self.SetSize(wx.Size(1024, 748))
 
-        self._show_navigator_message = True
-        self.edit_data_notebook_label = False
+        self._show_navigator_message: bool = True
+        self.edit_data_notebook_label: bool = False
 
         # to control check and unckeck of menu view -> interpolated_slices
         main_menu = MenuBar(self)
@@ -140,7 +141,7 @@ class Frame(wx.Frame):
 
         # log.initLogger()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -163,7 +164,7 @@ class Frame(wx.Frame):
         sub(self._UpdateViewerFocus, "Set viewer orientation focus")
         sub(self._Exit, "Exit")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         """
         Bind normal events from wx (except pubsub related).
         """
@@ -181,13 +182,13 @@ class Frame(wx.Frame):
         self.Bind(wx.EVT_LIST_BEGIN_LABEL_EDIT, self.OnEditLabel)
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.OnEditLabel)
 
-    def OnEditLabel(self, evt):
+    def OnEditLabel(self, evt: wx.ListEvent) -> None:
         if evt.GetEventType() == wx.wxEVT_LIST_BEGIN_LABEL_EDIT:
             self.edit_data_notebook_label = True
         if evt.GetEventType() == wx.wxEVT_LIST_END_LABEL_EDIT or evt.IsEditCancelled():
             self.edit_data_notebook_label = False
 
-    def OnGlobalKey(self, event):
+    def OnGlobalKey(self, event: wx.KeyEvent) -> None:
         """
         Handle all key events at a global level.
         """
@@ -206,7 +207,7 @@ class Frame(wx.Frame):
         # For all other keys, continue with the normal event handling (propagate the event).
         event.Skip()
 
-    def __init_aui(self):
+    def __init_aui(self) -> None:
         """
         Build AUI manager and all panels inside InVesalius frame.
         """
@@ -363,14 +364,14 @@ class Frame(wx.Frame):
 
         self.Layout()
 
-    def _BeginBusyCursor(self):
+    def _BeginBusyCursor(self) -> None:
         """
         Start busy cursor.
         Note: _EndBusyCursor should be called after.
         """
         wx.BeginBusyCursor()
 
-    def _EndBusyCursor(self):
+    def _EndBusyCursor(self) -> None:
         """
         End busy cursor.
         Note: _BeginBusyCursor should have been called previously.
@@ -381,7 +382,7 @@ class Frame(wx.Frame):
             # no matching wxBeginBusyCursor() for wxEndBusyCursor()
             pass
 
-    def _Exit(self):
+    def _Exit(self) -> None:
         """
         Exit InVesalius.
         """
@@ -392,7 +393,7 @@ class Frame(wx.Frame):
         if hasattr(sys, "frozen") and sys.platform == "darwin":
             sys.exit(0)
 
-    def _HideContentPanel(self):
+    def _HideContentPanel(self) -> None:
         """
         Hide data and tasks panels.
         """
@@ -401,7 +402,7 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Tasks").Show(1)
         aui_manager.Update()
 
-    def _HideImportPanel(self):
+    def _HideImportPanel(self) -> None:
         """
         Hide import panel and show tasks.
         """
@@ -411,14 +412,14 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Tasks").Show(1)
         aui_manager.Update()
 
-    def _HideTask(self):
+    def _HideTask(self) -> None:
         """
         Hide task panel.
         """
         self.aui_manager.GetPane("Tasks").Hide()
         self.aui_manager.Update()
 
-    def _SetProjectName(self, proj_name=""):
+    def _SetProjectName(self, proj_name: str = "") -> None:
         """
         Set project name into frame's title.
         """
@@ -427,7 +428,7 @@ class Frame(wx.Frame):
         else:
             self.SetTitle(f"{proj_name} - InVesalius 3")
 
-    def _ShowContentPanel(self):
+    def _ShowContentPanel(self) -> None:
         """
         Show viewers and task, hide import panel.
         """
@@ -441,7 +442,7 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Tasks").Show(1)
         aui_manager.Update()
 
-    def _ShowImportNetwork(self):
+    def _ShowImportNetwork(self) -> None:
         """
         Show viewers and task, hide import panel.
         """
@@ -453,7 +454,7 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Import").Show(0)
         aui_manager.Update()
 
-    def _ShowImportBitmap(self):
+    def _ShowImportBitmap(self) -> None:
         """
         Show viewers and task, hide import panel.
         """
@@ -465,14 +466,14 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Import").Show(0)
         aui_manager.Update()
 
-    def _ShowHelpMessage(self, message):
+    def _ShowHelpMessage(self, message: str) -> None:
         aui_manager = self.aui_manager
         pos = aui_manager.GetPane("Data").window.GetScreenPosition()
         self.mw = MessageWatershed(self, message)
         self.mw.SetPosition(pos)
         self.mw.Show()
 
-    def _ShowImportPanel(self):
+    def _ShowImportPanel(self) -> None:
         """
         Show only DICOM import panel. as dicom"""
         Publisher.sendMessage("Set layout button data only")
@@ -482,27 +483,27 @@ class Frame(wx.Frame):
         aui_manager.GetPane("Tasks").Show(0)
         aui_manager.Update()
 
-    def _ShowTask(self):
+    def _ShowTask(self) -> None:
         """
         Show task panel.
         """
         self.aui_manager.GetPane("Tasks").Show()
         self.aui_manager.Update()
 
-    def _UpdateAUI(self):
+    def _UpdateAUI(self) -> None:
         """
         Refresh AUI panels/data.
         """
         self.aui_manager.Update()
 
-    def _UpdateViewerFocus(self, orientation):
+    def _UpdateViewerFocus(self, orientation: str) -> None:
         if orientation in (const.AXIAL_STR, const.CORONAL_STR, const.SAGITAL_STR):
             self._last_viewer_orientation_focus = orientation
 
-    def CloseProject(self):
+    def CloseProject(self) -> None:
         Publisher.sendMessage("Close Project")
 
-    def ExitDialog(self):
+    def ExitDialog(self) -> Optional[int]:
         msg = _("Are you sure you want to exit?")
         if sys.platform == "darwin":
             dialog = wx.RichMessageDialog(
@@ -530,7 +531,7 @@ class Frame(wx.Frame):
         else:
             return 0  # Don't Exit
 
-    def OnExit(self, evt):
+    def OnExit(self, evt: Optional[wx.Event]) -> None:
         """
         Exit InVesalius: disconnect tracker and send 'Exit' message.
         """
@@ -541,7 +542,7 @@ class Frame(wx.Frame):
             if status == 1:
                 Publisher.sendMessage("Exit session")
 
-    def OnMenuClick(self, evt):
+    def OnMenuClick(self, evt: wx.CommandEvent) -> None:
         """
         Capture event from mouse click on menu / toolbar (as both use
         the same ID's)
@@ -701,7 +702,7 @@ class Frame(wx.Frame):
         elif id == const.ID_PLUGINS_SHOW_PATH:
             self.ShowPluginsFolder()
 
-    def OnDbsMode(self):
+    def OnDbsMode(self) -> None:
         st = self.actived_dbs_mode.IsChecked()
         Publisher.sendMessage("Hide target button")
         if st:
@@ -712,7 +713,7 @@ class Frame(wx.Frame):
             Publisher.sendMessage("Hide dbs folder")
         self.actived_navigation_mode.Check(const.ID_MODE_NAVIGATION, 0)
 
-    def OnNavigationMode(self, status):
+    def OnNavigationMode(self, status: bool) -> None:
         if status and self._show_navigator_message and sys.platform != "win32":
             wx.MessageBox(
                 _("Currently the Navigation mode is only working on Windows"),
@@ -724,7 +725,7 @@ class Frame(wx.Frame):
         if not status:
             Publisher.sendMessage("Remove sensors ID")
 
-    def OnSize(self, evt):
+    def OnSize(self, evt: wx.SizeEvent) -> None:
         """
         Refresh GUI when frame is resized.
         """
@@ -732,20 +733,21 @@ class Frame(wx.Frame):
         self.Reposition()
         self.sizeChanged = True
 
-    def OnIdle(self, evt):
+    def OnIdle(self, evt: wx.IdleEvent) -> None:
         if self.sizeChanged:
             self.Reposition()
 
-    def Reposition(self):
+    def Reposition(self) -> None:
         Publisher.sendMessage("ProgressBar Reposition")
         self.sizeChanged = False
 
-    def OnMove(self, evt):
+    def OnMove(self, evt: wx.MoveEvent) -> None:
         aui_manager = self.aui_manager
         pos = aui_manager.GetPane("Data").window.GetScreenPosition()
-        self.mw.SetPosition(pos)
+        if self.mw is not None:
+            self.mw.SetPosition(pos)
 
-    def ShowPreferences(self, page=0):
+    def ShowPreferences(self, page: int = 0) -> None:
         preferences_dialog = preferences.Preferences(self, page)
         preferences_dialog.LoadPreferences()
         preferences_dialog.Center()
@@ -794,51 +796,51 @@ class Frame(wx.Frame):
             Publisher.sendMessage("Update Navigation Mode MenuBar")
             Publisher.sendMessage("Update Surface Interpolation")
 
-    def ShowAbout(self):
+    def ShowAbout(self) -> None:
         """
         Shows about dialog.
         """
         dlg.ShowAboutDialog(self)
 
-    def SaveProject(self):
+    def SaveProject(self) -> None:
         """
         Save project.
         """
         Publisher.sendMessage("Show save dialog", save_as=False)
 
-    def ShowGettingStarted(self):
+    def ShowGettingStarted(self) -> None:
         """
         Show getting started window.
         """
         webbrowser.open("https://invesalius.github.io/docs/user_guide/user_guide.html")
 
-    def ShowImportDicomPanel(self):
+    def ShowImportDicomPanel(self) -> None:
         """
         Show import DICOM panel. as dicom"""
         Publisher.sendMessage("Show import directory dialog")
 
-    def ShowImportOtherFiles(self, id_file):
+    def ShowImportOtherFiles(self, id_file: int) -> None:
         """
         Show import Analyze, NiFTI1 or PAR/REC dialog.
         """
         Publisher.sendMessage("Show import other files dialog", id_type=id_file)
 
-    def ShowRetrieveDicomPanel(self):
+    def ShowRetrieveDicomPanel(self) -> None:
         Publisher.sendMessage("Show retrieve dicom panel")
 
-    def ShowOpenProject(self):
+    def ShowOpenProject(self) -> None:
         """
         Show open project dialog.
         """
         Publisher.sendMessage("Show open project dialog")
 
-    def ShowSaveAsProject(self):
+    def ShowSaveAsProject(self) -> None:
         """
         Show save as dialog.
         """
         Publisher.sendMessage("Show save dialog", save_as=True)
 
-    def ExportProject(self):
+    def ExportProject(self) -> None:
         """
         Show save dialog to export slice.
         """
@@ -874,7 +876,7 @@ class Frame(wx.Frame):
             else:
                 session.SetConfig("last_directory_export_prj", dirpath)
 
-    def ShowProjectProperties(self):
+    def ShowProjectProperties(self) -> None:
         window = project_properties.ProjectProperties(self)
         if window.ShowModal() == wx.ID_OK:
             p = prj.Project()
@@ -888,68 +890,68 @@ class Frame(wx.Frame):
 
         window.Destroy()
 
-    def ShowBitmapImporter(self):
+    def ShowBitmapImporter(self) -> None:
         """
         Tiff, BMP, JPEG and PNG
         """
         Publisher.sendMessage("Show bitmap dialog")
 
-    def FlipVolume(self, axis):
+    def FlipVolume(self, axis: int) -> None:
         Publisher.sendMessage("Flip volume", axis=axis)
         Publisher.sendMessage("Reload actual slice")
 
-    def SwapAxes(self, axes):
+    def SwapAxes(self, axes: Tuple[int, int]) -> None:
         Publisher.sendMessage("Swap volume axes", axes=axes)
         Publisher.sendMessage("Update scroll")
         Publisher.sendMessage("Reload actual slice")
 
-    def OnUndo(self):
+    def OnUndo(self) -> None:
         Publisher.sendMessage("Undo edition")
 
-    def OnRedo(self):
+    def OnRedo(self) -> None:
         Publisher.sendMessage("Redo edition")
 
-    def OnGotoSlice(self):
+    def OnGotoSlice(self) -> None:
         gt_dialog = dlg.GoToDialog(init_orientation=self._last_viewer_orientation_focus)
         gt_dialog.CenterOnParent()
         gt_dialog.ShowModal()
         self.Refresh()
 
-    def GoToDialogScannerCoord(self):
+    def GoToDialogScannerCoord(self) -> None:
         gts_dialog = dlg.GoToDialogScannerCoord()
         gts_dialog.CenterOnParent()
         gts_dialog.ShowModal()
         self.Refresh()
 
-    def OnMaskBoolean(self):
+    def OnMaskBoolean(self) -> None:
         Publisher.sendMessage("Show boolean dialog")
 
-    def OnCleanMask(self):
+    def OnCleanMask(self) -> None:
         Publisher.sendMessage("Clean current mask")
         Publisher.sendMessage("Reload actual slice")
 
-    def OnReorientImg(self):
+    def OnReorientImg(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_REORIENT)
         rdlg = dlg.ReorientImageDialog()
         rdlg.Show()
 
-    def OnFillHolesManually(self):
+    def OnFillHolesManually(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_MASK_FFILL)
 
-    def OnFillHolesAutomatically(self):
+    def OnFillHolesAutomatically(self) -> None:
         fdlg = dlg.FillHolesAutoDialog(_("Fill holes automatically"))
         fdlg.Show()
 
-    def OnRemoveMaskParts(self):
+    def OnRemoveMaskParts(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_REMOVE_MASK_PARTS)
 
-    def OnSelectMaskParts(self):
+    def OnSelectMaskParts(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_SELECT_MASK_PARTS)
 
-    def OnFFillSegmentation(self):
+    def OnFFillSegmentation(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_FFILL_SEGMENTATION)
 
-    def OnBrainSegmentation(self):
+    def OnBrainSegmentation(self) -> None:
         from invesalius.gui import deep_learning_seg_dialog
 
         if (
@@ -972,7 +974,7 @@ class Frame(wx.Frame):
             dlg.ShowModal()
             dlg.Destroy()
 
-    def OnTracheSegmentation(self):
+    def OnTracheSegmentation(self) -> None:
         from invesalius.gui import deep_learning_seg_dialog
 
         if deep_learning_seg_dialog.HAS_TORCH:
@@ -991,7 +993,7 @@ class Frame(wx.Frame):
             dlg.ShowModal()
             dlg.Destroy()
 
-    def OnImplantCTSegmentation(self):
+    def OnImplantCTSegmentation(self) -> None:
         from invesalius.gui import deep_learning_seg_dialog
 
         if deep_learning_seg_dialog.HAS_TORCH:
@@ -1010,7 +1012,7 @@ class Frame(wx.Frame):
             dlg.ShowModal()
             dlg.Destroy()
 
-    def OnMandibleCTSegmentation(self):
+    def OnMandibleCTSegmentation(self) -> None:
         from invesalius.gui import deep_learning_seg_dialog
 
         if deep_learning_seg_dialog.HAS_TORCH:
@@ -1029,22 +1031,22 @@ class Frame(wx.Frame):
             dlg.ShowModal()
             dlg.Destroy()
 
-    def OnInterpolatedSlices(self, status):
+    def OnInterpolatedSlices(self, status: bool) -> None:
         Publisher.sendMessage("Set interpolated slices", flag=status)
 
-    def OnCropMask(self):
+    def OnCropMask(self) -> None:
         Publisher.sendMessage("Enable style", style=const.SLICE_STATE_CROP_MASK)
 
-    def OnEnableMask3DPreview(self, value):
+    def OnEnableMask3DPreview(self, value: bool) -> None:
         if value:
             Publisher.sendMessage("Enable mask 3D preview")
         else:
             Publisher.sendMessage("Disable mask 3D preview")
 
-    def OnUpdateMaskPreview(self):
+    def OnUpdateMaskPreview(self) -> None:
         Publisher.sendMessage("Update mask 3D preview")
 
-    def ShowPluginsFolder(self):
+    def ShowPluginsFolder(self) -> None:
         """
         Show getting started window.
         """
@@ -1069,11 +1071,11 @@ class MenuBar(wx.MenuBar):
     help.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.MenuBar.__init__(self)
 
         self.parent = parent
-        self._plugins_menu_ids = {}
+        self._plugins_menu_ids: Dict[int, Dict[str, Any]] = {}
 
         # Used to enable/disable menu items if project is opened or
         # not. Eg. save should only be available if a project is open
@@ -1115,7 +1117,7 @@ class MenuBar(wx.MenuBar):
 
         self.SetStateProjectClose()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -1140,7 +1142,7 @@ class MenuBar(wx.MenuBar):
 
         self.num_masks = 0
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Create all menu and submenus, and add them to self.
         """
@@ -1417,7 +1419,7 @@ class MenuBar(wx.MenuBar):
 
         plugins_menu.Bind(wx.EVT_MENU, self.OnPluginMenu)
 
-    def OnPluginMenu(self, evt):
+    def OnPluginMenu(self, evt: wx.CommandEvent) -> None:
         id = evt.GetId()
         if id != const.ID_PLUGINS_SHOW_PATH:
             try:
@@ -1428,27 +1430,27 @@ class MenuBar(wx.MenuBar):
                 print("Invalid plugin")
         evt.Skip()
 
-    def SliceInterpolationStatus(self):
+    def SliceInterpolationStatus(self) -> bool:
         session = ses.Session()
         slice_interpolation = session.GetConfig("slice_interpolation")
 
-        return slice_interpolation != 0
+        return bool(slice_interpolation != 0)
 
-    def NavigationModeStatus(self):
+    def NavigationModeStatus(self) -> bool:
         session = ses.Session()
         mode = session.GetConfig("mode")
 
-        return mode == 1
+        return bool(mode == 1)
 
-    def OnUpdateSliceInterpolation(self):
+    def OnUpdateSliceInterpolation(self) -> None:
         v = self.SliceInterpolationStatus()
         self.view_menu.Check(const.ID_VIEW_INTERPOLATED, v)
 
-    def OnUpdateNavigationMode(self):
+    def OnUpdateNavigationMode(self) -> None:
         v = self.NavigationModeStatus()
         self.mode_menu.Check(const.ID_MODE_NAVIGATION, v)
 
-    def AddPluginsItems(self, items):
+    def AddPluginsItems(self, items: Dict[str, Dict[str, Any]]) -> None:
         for menu_item in self.plugins_menu.GetMenuItems():
             if menu_item.GetId() != const.ID_PLUGINS_SHOW_PATH:
                 self.plugins_menu.DestroyItem(menu_item)
@@ -1459,7 +1461,7 @@ class MenuBar(wx.MenuBar):
             menu_item = self.plugins_menu.Append(_new_id, item, items[item]["description"])
             menu_item.Enable(items[item]["enable_startup"])
 
-    def OnEnableState(self, state):
+    def OnEnableState(self, state: bool) -> None:
         """
         Based on given state, enables or disables menu items which
         depend if project is open or not.
@@ -1469,7 +1471,7 @@ class MenuBar(wx.MenuBar):
         else:
             self.SetStateProjectClose()
 
-    def SetStateProjectClose(self):
+    def SetStateProjectClose(self) -> None:
         """
         Disable menu items (e.g. save) when project is closed.
         """
@@ -1481,7 +1483,7 @@ class MenuBar(wx.MenuBar):
             if not self._plugins_menu_ids[item]["enable_startup"]:
                 self.Enable(item, False)
 
-    def SetStateProjectOpen(self):
+    def SetStateProjectOpen(self) -> None:
         """
         Enable menu items (e.g. save) when project is opened.
         """
@@ -1493,19 +1495,19 @@ class MenuBar(wx.MenuBar):
             if not self._plugins_menu_ids[item]["enable_startup"]:
                 self.Enable(item, True)
 
-    def OnEnableUndo(self, value):
+    def OnEnableUndo(self, value: bool) -> None:
         if value:
             self.FindItemById(wx.ID_UNDO).Enable(True)
         else:
             self.FindItemById(wx.ID_UNDO).Enable(False)
 
-    def OnEnableRedo(self, value):
+    def OnEnableRedo(self, value: bool) -> None:
         if value:
             self.FindItemById(wx.ID_REDO).Enable(True)
         else:
             self.FindItemById(wx.ID_REDO).Enable(False)
 
-    def OnEnableGotoCoord(self, status=True):
+    def OnEnableGotoCoord(self, status: bool = True) -> None:
         """
         Enable or disable goto coord depending on the imported affine matrix.
         :param status: True for enabling and False for disabling the Go-To-Coord
@@ -1513,7 +1515,7 @@ class MenuBar(wx.MenuBar):
 
         self.FindItemById(const.ID_GOTO_COORD).Enable(status)
 
-    def OnEnableNavigation(self, nav_status, vis_status):
+    def OnEnableNavigation(self, nav_status: bool, vis_status: bool) -> None:
         """
         Disable mode menu when navigation is on.
         :param nav_status: Navigation status
@@ -1525,18 +1527,18 @@ class MenuBar(wx.MenuBar):
         else:
             self.FindItemById(const.ID_MODE_NAVIGATION).Enable(True)
 
-    def OnAddMask(self, mask):
+    def OnAddMask(self, mask: Any) -> None:
         self.num_masks += 1
         self.bool_op_menu.Enable(self.num_masks >= 2)
         self.mask_preview.Enable(True)
         self.mask_auto_reload.Enable(True)
         self.mask_preview_reload.Enable(True)
 
-    def OnRemoveMasks(self, mask_indexes):
+    def OnRemoveMasks(self, mask_indexes: List[int]) -> None:
         self.num_masks -= len(mask_indexes)
         self.bool_op_menu.Enable(self.num_masks >= 2)
 
-    def OnShowMask(self, index, value):
+    def OnShowMask(self, index: int, value: bool) -> None:
         self.clean_mask_menu.Enable(value)
         self.crop_mask_menu.Enable(value)
         self.mask_preview.Enable(value)
@@ -1554,21 +1556,21 @@ class ProgressBar(wx.Gauge):
     Progress bar / gauge.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.Gauge.__init__(self, parent, -1, 100)
         self.parent = parent
         self._Layout()
 
         self.__bind_events()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
         sub = Publisher.subscribe
         sub(self._Layout, "ProgressBar Reposition")
 
-    def _Layout(self):
+    def _Layout(self) -> None:
         """
         Compute new size and position, according to parent resize
         """
@@ -1577,7 +1579,7 @@ class ProgressBar(wx.Gauge):
         self.SetSize((rect.width - 4, rect.height - 4))
         self.Show()
 
-    def SetPercentage(self, value):
+    def SetPercentage(self, value: int) -> None:
         """
         Set value [0;100] into gauge, moving "status" percentage.
         """
@@ -1598,7 +1600,7 @@ class StatusBar(wx.StatusBar):
     Control general status (both text and gauge)
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         wx.StatusBar.__init__(self, parent, -1)
 
         # General status configurations
@@ -1613,7 +1615,7 @@ class StatusBar(wx.StatusBar):
 
         self.__bind_events()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -1621,7 +1623,7 @@ class StatusBar(wx.StatusBar):
         sub(self._SetProgressValue, "Update status in GUI")
         sub(self._SetProgressLabel, "Update status text in GUI")
 
-    def _SetProgressValue(self, value, label):
+    def _SetProgressValue(self, value: int, label: str) -> None:
         """
         Set both percentage value in gauge and text progress label in
         status.
@@ -1639,7 +1641,7 @@ class StatusBar(wx.StatusBar):
             except wx.PyAssertionError:
                 utils.debug("wx._core.PyAssertionError")
 
-    def _SetProgressLabel(self, label):
+    def _SetProgressLabel(self, label: str) -> None:
         """
         Set text progress label.
         """
@@ -1659,7 +1661,7 @@ class TaskBarIcon(wx_TaskBarIcon):
         - linux2: Show icon on "Notification Area" (near clock)
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[wx.Window] = None):
         wx_TaskBarIcon.__init__(self)
         self.frame = parent
 
@@ -1670,7 +1672,7 @@ class TaskBarIcon(wx_TaskBarIcon):
         # bind some events
         self.Bind(wx.EVT_TASKBAR_LEFT_DCLICK, self.OnTaskBarActivate)
 
-    def OnTaskBarActivate(self, evt):
+    def OnTaskBarActivate(self, evt: wx.Event) -> None:
         pass
 
 
@@ -1684,7 +1686,7 @@ class ProjectToolBar(AuiToolBar):
     Toolbar related to general invesalius.project operations, including: import, as project    open, save and saveas, among others.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         style = AUI_TB_PLAIN_BACKGROUND
         AuiToolBar.__init__(self, parent, -1, wx.DefaultPosition, wx.DefaultSize, agwStyle=style)
         self.SetToolBitmapSize(wx.Size(32, 32))
@@ -1701,14 +1703,14 @@ class ProjectToolBar(AuiToolBar):
         self.Realize()
         self.SetStateProjectClose()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
         sub = Publisher.subscribe
         sub(self._EnableState, "Enable state project")
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Add tools into toolbar.
         """
@@ -1776,7 +1778,7 @@ class ProjectToolBar(AuiToolBar):
         #                   "Print medical image...",
         #                   BMP_PRINT)
 
-    def _EnableState(self, state):
+    def _EnableState(self, state: bool) -> None:
         """
         Based on given state, enable or disable menu items which
         depend if project is open or not.
@@ -1787,7 +1789,7 @@ class ProjectToolBar(AuiToolBar):
             self.SetStateProjectClose()
         self.Refresh()
 
-    def SetStateProjectClose(self):
+    def SetStateProjectClose(self) -> None:
         """
         Disable menu items (e.g. save) when project is closed.
         """
@@ -1795,7 +1797,7 @@ class ProjectToolBar(AuiToolBar):
             self.EnableTool(tool, False)
         self.Refresh()
 
-    def SetStateProjectOpen(self):
+    def SetStateProjectOpen(self) -> None:
         """
         Enable menu items (e.g. save) when project is opened.
         """
@@ -1815,7 +1817,7 @@ class ObjectToolBar(AuiToolBar):
     move, rotate, brightness/contrast, etc.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         style = AUI_TB_PLAIN_BACKGROUND
         AuiToolBar.__init__(self, parent, -1, wx.DefaultPosition, wx.DefaultSize, agwStyle=style)
 
@@ -1843,7 +1845,7 @@ class ObjectToolBar(AuiToolBar):
         self.Realize()
         self.SetStateProjectClose()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -1854,13 +1856,13 @@ class ObjectToolBar(AuiToolBar):
         sub(self._ToggleAngularMeasure, "Set tool angular measure")
         sub(self.ToggleItem, "Toggle toolbar item")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         """
         Bind normal events from wx (except pubsub related).
         """
         self.Bind(wx.EVT_TOOL, self.OnToggle)
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Add tools into toolbar.
         """
@@ -1974,7 +1976,7 @@ class ObjectToolBar(AuiToolBar):
         #                bitmap = BMP_ANNOTATE,
         #                kind = wx.ITEM_CHECK)
 
-    def _EnableState(self, state):
+    def _EnableState(self, state: bool) -> None:
         """
         Based on given state, enable or disable menu items which
         depend if project is open or not.
@@ -1985,7 +1987,7 @@ class ObjectToolBar(AuiToolBar):
             self.SetStateProjectClose()
         self.Refresh()
 
-    def _UntoggleAllItems(self):
+    def _UntoggleAllItems(self) -> None:
         """
         Untoggle all items on toolbar.
         """
@@ -1995,7 +1997,7 @@ class ObjectToolBar(AuiToolBar):
                 self.ToggleTool(id, False)
         self.Refresh()
 
-    def _ToggleLinearMeasure(self):
+    def _ToggleLinearMeasure(self) -> None:
         """
         Force measure distance tool to be toggled and bind pubsub
         events to other classes whici are interested on this.
@@ -2009,7 +2011,7 @@ class ObjectToolBar(AuiToolBar):
             if state and (item != id):
                 self.ToggleTool(item, False)
 
-    def _ToggleAngularMeasure(self):
+    def _ToggleAngularMeasure(self) -> None:
         """
         Force measure angle tool to be toggled and bind pubsub
         events to other classes which are interested on this.
@@ -2023,7 +2025,7 @@ class ObjectToolBar(AuiToolBar):
             if state and (item != id):
                 self.ToggleTool(item, False)
 
-    def OnToggle(self, evt):
+    def OnToggle(self, evt: wx.CommandEvent) -> None:
         """
         Update status of other items on toolbar (only one item
         should be toggle each time).
@@ -2045,12 +2047,12 @@ class ObjectToolBar(AuiToolBar):
                 self.ToggleTool(item, False)
         evt.Skip()
 
-    def ToggleItem(self, _id, value):
+    def ToggleItem(self, _id: int, value: bool) -> None:
         if _id in self.enable_items:
             self.ToggleTool(_id, value)
             self.Refresh()
 
-    def SetStateProjectClose(self):
+    def SetStateProjectClose(self) -> None:
         """
         Disable menu items (e.g. zoom) when project is closed.
         """
@@ -2058,7 +2060,7 @@ class ObjectToolBar(AuiToolBar):
             self.EnableTool(tool, False)
             self._UntoggleAllItems()
 
-    def SetStateProjectOpen(self):
+    def SetStateProjectOpen(self) -> None:
         """
         Enable menu items (e.g. zoom) when project is opened.
         """
@@ -2077,7 +2079,7 @@ class SliceToolBar(AuiToolBar):
     intersection reference and scroll slices.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         style = AUI_TB_PLAIN_BACKGROUND
         AuiToolBar.__init__(self, parent, -1, wx.DefaultPosition, wx.DefaultSize, agwStyle=style)
 
@@ -2095,7 +2097,7 @@ class SliceToolBar(AuiToolBar):
         self.Realize()
         self.SetStateProjectClose()
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Add tools into toolbar.
         """
@@ -2123,7 +2125,7 @@ class SliceToolBar(AuiToolBar):
             short_help_string=_("Slices' cross intersection"),
         )
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -2133,13 +2135,13 @@ class SliceToolBar(AuiToolBar):
         sub(self.OnToggle, "Toggle toolbar button")
         sub(self.ToggleItem, "Toggle toolbar item")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         """
         Bind normal events from wx (except pubsub related).
         """
         self.Bind(wx.EVT_TOOL, self.OnToggle)
 
-    def _EnableState(self, state):
+    def _EnableState(self, state: bool) -> None:
         """
         Based on given state, enable or disable menu items which
         depend if project is open or not.
@@ -2151,7 +2153,7 @@ class SliceToolBar(AuiToolBar):
             self._UntoggleAllItems()
         self.Refresh()
 
-    def _UntoggleAllItems(self):
+    def _UntoggleAllItems(self) -> None:
         """
         Untoggle all items on toolbar.
         """
@@ -2164,7 +2166,7 @@ class SliceToolBar(AuiToolBar):
                     Publisher.sendMessage(msg, style=const.SLICE_STATE_CROSS)
         self.Refresh()
 
-    def OnToggle(self, evt=None, id=None):
+    def OnToggle(self, evt: Optional[wx.CommandEvent] = None, id: Optional[int] = None) -> None:
         """
         Update status of other items on toolbar (only one item
         should be toggle each time).
@@ -2174,8 +2176,9 @@ class SliceToolBar(AuiToolBar):
                 self.ToggleTool(id, True)
                 self.Refresh()
         else:
-            id = evt.GetId()
-            evt.Skip()
+            if evt is not None:
+                id = evt.GetId()
+                evt.Skip()
 
         state = self.GetToolToggled(id)
 
@@ -2199,12 +2202,12 @@ class SliceToolBar(AuiToolBar):
         ##print ">>>", self.sst.IsToggled()
         # print ">>>", self.sst.GetState()
 
-    def ToggleItem(self, _id, value):
+    def ToggleItem(self, _id: int, value: bool) -> None:
         if _id in self.enable_items:
             self.ToggleTool(_id, value)
             self.Refresh()
 
-    def SetStateProjectClose(self):
+    def SetStateProjectClose(self) -> None:
         """
         Disable menu items (e.g. cross) when project is closed.
         """
@@ -2212,7 +2215,7 @@ class SliceToolBar(AuiToolBar):
             self.EnableTool(tool, False)
         self.Refresh()
 
-    def SetStateProjectOpen(self):
+    def SetStateProjectOpen(self) -> None:
         """
         Enable menu items (e.g. cross) when project is opened.
         """
@@ -2230,7 +2233,7 @@ class LayoutToolBar(AuiToolBar):
     - show/hide rulers (= the rulers showing the scale on each viewer)
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         style = AUI_TB_PLAIN_BACKGROUND
         AuiToolBar.__init__(self, parent, -1, wx.DefaultPosition, wx.DefaultSize, agwStyle=style)
 
@@ -2249,7 +2252,7 @@ class LayoutToolBar(AuiToolBar):
         self.Realize()
         self.SetStateProjectClose()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -2259,13 +2262,13 @@ class LayoutToolBar(AuiToolBar):
         sub(self._SetLayoutWithoutTask, "Set layout button full")
         sub(self._SendRulerVisibilityStatus, "Send ruler visibility status")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         """
         Bind normal events from wx (except pubsub related).
         """
         self.Bind(wx.EVT_TOOL, self.OnToggle)
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Add tools into toolbar.
         """
@@ -2317,7 +2320,7 @@ class LayoutToolBar(AuiToolBar):
             short_help_string=_("Hide ruler"),
         )
 
-    def _EnableState(self, state):
+    def _EnableState(self, state: bool) -> None:
         """
         Based on given state, enable or disable menu items which
         depend if project is open or not.
@@ -2328,22 +2331,22 @@ class LayoutToolBar(AuiToolBar):
             self.SetStateProjectClose()
         self.Refresh()
 
-    def _SendRulerVisibilityStatus(self):
+    def _SendRulerVisibilityStatus(self) -> None:
         Publisher.sendMessage("Receive ruler visibility status", status=self.ontool_ruler)
 
-    def _SetLayoutWithoutTask(self):
+    def _SetLayoutWithoutTask(self) -> None:
         """
         Set item bitmap to task panel hiden.
         """
         self.SetToolNormalBitmap(ID_LAYOUT, self.BMP_WITHOUT_MENU)
 
-    def _SetLayoutWithTask(self):
+    def _SetLayoutWithTask(self) -> None:
         """
         Set item bitmap to task panel shown.
         """
         self.SetToolNormalBitmap(ID_LAYOUT, self.BMP_WITH_MENU)
 
-    def OnToggle(self, event):
+    def OnToggle(self, event: wx.CommandEvent) -> None:
         """
         Update status of toolbar item (bitmap and help)
         """
@@ -2360,7 +2363,7 @@ class LayoutToolBar(AuiToolBar):
             if state and (item != id):
                 self.ToggleTool(item, False)
 
-    def SetStateProjectClose(self):
+    def SetStateProjectClose(self) -> None:
         """
         Disable menu items (e.g. text) when project is closed.
         """
@@ -2371,7 +2374,7 @@ class LayoutToolBar(AuiToolBar):
         for tool in self.enable_items:
             self.EnableTool(tool, False)
 
-    def SetStateProjectOpen(self):
+    def SetStateProjectOpen(self) -> None:
         """
         Disable menu items (e.g. text) when project is closed.
         """
@@ -2382,7 +2385,7 @@ class LayoutToolBar(AuiToolBar):
         for tool in self.enable_items:
             self.EnableTool(tool, True)
 
-    def ToggleLayout(self):
+    def ToggleLayout(self) -> None:
         """
         Based on previous layout item state, toggle it.
         """
@@ -2398,7 +2401,7 @@ class LayoutToolBar(AuiToolBar):
             self.SetToolShortHelp(ID_LAYOUT, _("Show task panel"))
             self.ontool_layout = True
 
-    def ToggleText(self):
+    def ToggleText(self) -> None:
         """
         Based on previous text item state, toggle it.
         """
@@ -2415,7 +2418,7 @@ class LayoutToolBar(AuiToolBar):
             Publisher.sendMessage("Update AUI")
             self.ontool_text = True
 
-    def ShowRulers(self):
+    def ShowRulers(self) -> None:
         """
         Show the rulers on the viewers.
         """
@@ -2425,7 +2428,7 @@ class LayoutToolBar(AuiToolBar):
         Publisher.sendMessage("Update AUI")
         self.ontool_ruler = True
 
-    def HideRulers(self):
+    def HideRulers(self) -> None:
         """
         Hide the rulers on the viewers.
         """
@@ -2435,7 +2438,7 @@ class LayoutToolBar(AuiToolBar):
         Publisher.sendMessage("Update AUI")
         self.ontool_ruler = False
 
-    def ToggleRulers(self):
+    def ToggleRulers(self) -> None:
         """
         Based on the current ruler state, either show or hide the rulers.
         """
@@ -2450,7 +2453,7 @@ class HistoryToolBar(AuiToolBar):
     Toolbar related to project history. Contains undo and redo buttons.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: wx.Window):
         style = AUI_TB_PLAIN_BACKGROUND
         AuiToolBar.__init__(self, parent, -1, wx.DefaultPosition, wx.DefaultSize, agwStyle=style)
 
@@ -2463,7 +2466,7 @@ class HistoryToolBar(AuiToolBar):
 
         self.Realize()
 
-    def __bind_events(self):
+    def __bind_events(self) -> None:
         """
         Bind events related to pubsub.
         """
@@ -2471,14 +2474,14 @@ class HistoryToolBar(AuiToolBar):
         sub(self.OnEnableUndo, "Enable undo")
         sub(self.OnEnableRedo, "Enable redo")
 
-    def __bind_events_wx(self):
+    def __bind_events_wx(self) -> None:
         """
         Bind normal events from wx (except pubsub related).
         """
         self.Bind(wx.EVT_TOOL, self.OnUndo, id=wx.ID_UNDO)
         self.Bind(wx.EVT_TOOL, self.OnRedo, id=wx.ID_REDO)
 
-    def __init_items(self):
+    def __init_items(self) -> None:
         """
         Add tools into toolbar.
         """
@@ -2512,20 +2515,20 @@ class HistoryToolBar(AuiToolBar):
         self.EnableTool(wx.ID_UNDO, False)
         self.EnableTool(wx.ID_REDO, False)
 
-    def OnUndo(self, event):
+    def OnUndo(self, event: wx.CommandEvent) -> None:
         Publisher.sendMessage("Undo edition")
 
-    def OnRedo(self, event):
+    def OnRedo(self, event: wx.CommandEvent) -> None:
         Publisher.sendMessage("Redo edition")
 
-    def OnEnableUndo(self, value):
+    def OnEnableUndo(self, value: bool) -> None:
         if value:
             self.EnableTool(wx.ID_UNDO, True)
         else:
             self.EnableTool(wx.ID_UNDO, False)
         self.Refresh()
 
-    def OnEnableRedo(self, value):
+    def OnEnableRedo(self, value: bool) -> None:
         if value:
             self.EnableTool(wx.ID_REDO, True)
         else:


### PR DESCRIPTION
### Added type annotations to:
- invesalius/gui/default_viewers.py
- invesalius/gui/frame.py
- invesalius/data/volume_widgets.py

### Key changes implemented:

*   Added type annotations to function and method signatures, including argument and return types.
*   Specified types for class attributes, providing clarity on the expected data they hold.
*   Utilized `Optional[]` where variables can be `None`, enforcing explicit handling of potentially missing values.

To ensure the correctness and validity of the added type annotations, I ran Mypy with the following command using strict settings:

validated using:
```bash
mypy .\invesalius\gui\frame.py  .\invesalius\gui\default_viewers.py .\invesalius\data\volume_widgets.py --follow-imports=skip --disallow-untyped-defs --disallow-any-generics --disallow-incomplete-defs --warn-redundant-casts --warn-unused-ignores --no-implicit-optional --strict-equality --warn-return-any --warn-unused-config
```
Result:
```bash
Success: no issues found in 3 source files
```