### PR TITLE
Migrate `bundles.yml` GitHub Action to Use `uv` instead of  `pip`

### DIFF
--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        architecture: ['x64']
+        architecture: ["x64"]
         ai_ready: [0, 1]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-        
+
       - name: Put current date into a variable
         run: |
           $DATE=& Get-Date -format yyyy-MM-dd
@@ -24,36 +24,44 @@ jobs:
         run: |
           $COMMIT=$(git rev-parse HEAD)
           echo "COMMIT=$COMMIT" >> $env:GITHUB_ENV
-            
-      - name: Setup VC++ 2022 (17.0)
-        uses: ilammy/msvc-dev-cmd@v1.13.0
-        with:
-          vsversion: '17.0'
-          arch: ${{ matrix.architecture }}
-    
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.2'
-          cache: 'pip'
 
-      - name: Upgrade pip and enable wheel support
-        run: python -m pip install --upgrade pip setuptools wheel 
+      - name: install uv
+        run: |
+          powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.6.5/install.ps1 | iex"
+          $env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"
 
-      - name: Install InVesalius requirements
-        run: pip install -r requirements.txt
+      - name: install venv and sync dependencies
+        run: |
+          uv venv --python 3.12
+          uv sync
+
+      # - name: Check inside inv_cy/release
+      #   run: |
+      #     .venv\Scripts\activate
+      #     dir invesalius_cy\Release
+
+      # - name: Check current dir
+      #   run: |
+      #     dir
+
+      # - name: site packages data
+      #   run: |
+      #     dir .venv\Lib\site-packages
+
+      # - name: Inside inv_cy
+      #   run: |
+      #     uv pip list
+      #     dir .\invesalius_cy\
 
       - name: Install Pytorch + Cuda 11.8 (only ai-ready build)
         if: ${{ matrix.ai_ready == 1}}
-        run: pip install torch==2.3.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
-
-      - name: Compile InVesalius Cython parts
         run: |
-              python3 setup.py build_ext --inplace
-              python3 setup.py build_plugins
+          uv pip install  torch==2.3.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
 
       - name: Insert version and commit hash into dialog.py
-        run: python3 bundle_tools/win/insert_version_date.py ./invesalius/gui/dialogs.py ${{ env.DATE }} ${{ env.COMMIT }} nightly
+        run: |
+          .venv\Scripts\activate
+          uv run bundle_tools/win/insert_version_date.py ./invesalius/gui/dialogs.py ${{ env.DATE }} ${{ env.COMMIT }} nightly
 
       - uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         id: pyinstaller
@@ -70,35 +78,36 @@ jobs:
 
       - name: Compile pyinstaller bootloader
         run: |
-              cd ./pyinstaller/pyinstaller-6.9.0/bootloader/
-              python3 ./waf distclean all
-              cd ..
-              pip install .
+          .venv\Scripts\activate
+          cd ./pyinstaller/pyinstaller-6.9.0/bootloader/
+          python3 ./waf distclean all
+          cd ..
+          uv pip install .
 
       - name: Download mandible ai weight
         if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 
+        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         with:
           url: "https://raw.githubusercontent.com/invesalius/weights/main/mandible_ct/mandible_jit_ct.pt"
           target: ./ai/mandible_jit_ct/
 
       - name: Download cranioplasty binary ai weight
         if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 
+        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         with:
           url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt"
           target: ./ai/cranioplasty_jit_ct_binary/
 
       - name: Download cranioplasty gray ai weight
         if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 
+        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         with:
           url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt"
           target: ./ai/cranioplasty_jit_ct_gray/
 
       - name: Download trachea ai weight
         if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 
+        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         with:
           url: "https://github.com/tfmoraes/deep_trachea_torch/releases/download/v1.0/weights.pt"
           target: ./ai/trachea_ct/
@@ -106,11 +115,11 @@ jobs:
       - name: Fix trachea name ai weight
         if: ${{ matrix.ai_ready == 1 }}
         run: |
-              move ./ai/trachea_ct/weights.pt ./ai/trachea_ct/trachea_ct.pt
+          move ./ai/trachea_ct/weights.pt ./ai/trachea_ct/trachea_ct.pt
 
       - name: Download brain ai weight
         if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 
+        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
         with:
           url: "https://github.com/tfmoraes/deepbrain_torch/releases/download/v1.1.0/weights.pt"
           target: ./ai/brain_mri_t1/
@@ -118,14 +127,13 @@ jobs:
       - name: Fix brain name ai weight
         if: ${{ matrix.ai_ready == 1 }}
         run: |
-              move ./ai/brain_mri_t1/weights.pt ./ai/brain_mri_t1/brain_mri_t1.pt
-
+          move ./ai/brain_mri_t1/weights.pt ./ai/brain_mri_t1/brain_mri_t1.pt
       - name: Generate InVesalius .exe file
         run: |
-              cp ./bundle_tools/win/app.spec ./  
-              pyinstaller app.spec --clean --noconfirm
-              mkdir installer
-
+          .venv\Scripts\activate
+          cp ./bundle_tools/win/app.spec ./  
+          pyinstaller app.spec --clean --noconfirm
+          mkdir installer
       - name: Generate InVesalius installer - win64 ai-ready build
         if: ${{ matrix.ai_ready == 1 }}
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
@@ -144,7 +152,6 @@ jobs:
         run: |
           cd ./installer
           dir
-
       - name: Upload artifact of package normal file
         if: ${{ matrix.ai_ready == 0}}
         uses: actions/upload-artifact@v4
@@ -181,19 +188,18 @@ jobs:
       - name: Message
         run: |
           dir
-
       - name: Update Nightly Release
         uses: andelf/nightly-release@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly
-          name: 'Nightly'
+          name: "Nightly"
           draft: false
           prerelease: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.is-pre-release) || (github.event_name == 'schedule')}}
           body: |
             This is a nightly release InVesalius.
             It's unstable compared to the official releases, **use it with caution**!
           files: |
-                  ./invesalius-3.1_nightly_ai-ready_win64.exe
-                  ./invesalius-3.1_nightly_win64.exe
+            ./invesalius-3.1_nightly_ai-ready_win64.exe
+            ./invesalius-3.1_nightly_win64.exe

--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -56,12 +56,13 @@ jobs:
         with:
           file_path: ./pyinstaller/v6.9.0.zip
           extract_dir: ./pyinstaller/
-          
+
       - name: copy .pyd files to invesalius_cy
         run: |
-          Copy-Item -Recurse invesalius_cy\Release -Destination invesalius_cy
+          Copy-Item -Path invesalius_cy\Release\* -Destination invesalius_cy -Recurse -Force
+
           dir
-         
+
       - name: Compile pyinstaller bootloader
         run: |
           .venv\Scripts\activate
@@ -69,8 +70,6 @@ jobs:
           python3 ./waf distclean all
           cd ..
           uv pip install .
-
-       
 
       - name: Download mandible ai weight
         if: ${{ matrix.ai_ready == 1 }}

--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: install venv and sync dependencies
         run: |
-          uv venv --python 3.12
           uv sync
 
       - name: Install Pytorch + Cuda 11.8 (only ai-ready build)

--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -61,8 +61,6 @@ jobs:
         run: |
           Copy-Item -Path invesalius_cy\Release\* -Destination invesalius_cy -Recurse -Force
 
-          dir
-
       - name: Compile pyinstaller bootloader
         run: |
           .venv\Scripts\activate

--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -35,24 +35,6 @@ jobs:
           uv venv --python 3.12
           uv sync
 
-      # - name: Check inside inv_cy/release
-      #   run: |
-      #     .venv\Scripts\activate
-      #     dir invesalius_cy\Release
-
-      # - name: Check current dir
-      #   run: |
-      #     dir
-
-      # - name: site packages data
-      #   run: |
-      #     dir .venv\Lib\site-packages
-
-      # - name: Inside inv_cy
-      #   run: |
-      #     uv pip list
-      #     dir .\invesalius_cy\
-
       - name: Install Pytorch + Cuda 11.8 (only ai-ready build)
         if: ${{ matrix.ai_ready == 1}}
         run: |

--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -56,7 +56,12 @@ jobs:
         with:
           file_path: ./pyinstaller/v6.9.0.zip
           extract_dir: ./pyinstaller/
-
+          
+      - name: copy .pyd files to invesalius_cy
+        run: |
+          Copy-Item -Recurse invesalius_cy\Release -Destination invesalius_cy
+          dir
+         
       - name: Compile pyinstaller bootloader
         run: |
           .venv\Scripts\activate
@@ -64,6 +69,8 @@ jobs:
           python3 ./waf distclean all
           cd ..
           uv pip install .
+
+       
 
       - name: Download mandible ai weight
         if: ${{ matrix.ai_ready == 1 }}

--- a/bundle_tools/win/app.spec
+++ b/bundle_tools/win/app.spec
@@ -15,7 +15,8 @@ from PyInstaller.utils.hooks import get_module_file_attribute, collect_dynamic_l
 from PyInstaller.compat import is_win
 
 python_dir = os.path.dirname(sys.executable)
-site_packages = os.path.join(python_dir,'Lib','site-packages')
+venv_path = os.path.dirname(python_dir)
+site_packages = os.path.join(venv_path,'Lib','site-packages')
 
 
 def check_extension(item): 
@@ -60,18 +61,18 @@ for v in vtk_files:
         libraries.append((v, dest_dir))
 
 #add interpolation module (pyinstaller not take automatically)
-libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy',\
+libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy\Release',\
     'interpolation.*.pyd'))[0],'invesalius_cy'))
 
 #add plaidml modules and files
-#libraries.append((os.path.join(python_dir,'library','bin','plaidml.dll'),'library\\bin'))
+#libraries.append((os.path.join(venv_path,'library','bin','plaidml.dll'),'library\\bin'))
 #
-#plaidml_files = get_all_files(os.path.join(python_dir,'share','plaidml'))
+#plaidml_files = get_all_files(os.path.join(venv_path,'share','plaidml'))
 #
 #for v in plaidml_files:
 #    if not(check_extension(v)):
 #        #take only folder name and remove first '\\'
-#        dest_dir = os.path.dirname(v.replace(python_dir,''))[1:]
+#        dest_dir = os.path.dirname(v.replace(venv_path,''))[1:]
 #        libraries.append((v, dest_dir))
 #
 #

--- a/bundle_tools/win/app.spec
+++ b/bundle_tools/win/app.spec
@@ -15,8 +15,8 @@ from PyInstaller.utils.hooks import get_module_file_attribute, collect_dynamic_l
 from PyInstaller.compat import is_win
 
 python_dir = os.path.dirname(sys.executable)
-venv_path = os.path.dirname(python_dir)
-site_packages = os.path.join(venv_path,'Lib','site-packages')
+venv_dir = os.path.dirname(python_dir) 
+site_packages = os.path.join(venv_dir,'Lib','site-packages') #because Lib is inside .venv directory
 
 
 def check_extension(item): 
@@ -61,18 +61,18 @@ for v in vtk_files:
         libraries.append((v, dest_dir))
 
 #add interpolation module (pyinstaller not take automatically)
-libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy\Release',\
-    'interpolation.*.pyd'))[0],'invesalius_cy'))
+libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy\Release',\ 
+    'interpolation.*.pyd'))[0],'invesalius_cy')) #.pyd files are inside of invesalius_cy\Release
 
 #add plaidml modules and files
-#libraries.append((os.path.join(venv_path,'library','bin','plaidml.dll'),'library\\bin'))
+#libraries.append((os.path.join(venv_dir,'library','bin','plaidml.dll'),'library\\bin'))
 #
-#plaidml_files = get_all_files(os.path.join(venv_path,'share','plaidml'))
+#plaidml_files = get_all_files(os.path.join(venv_dir,'share','plaidml'))
 #
 #for v in plaidml_files:
 #    if not(check_extension(v)):
 #        #take only folder name and remove first '\\'
-#        dest_dir = os.path.dirname(v.replace(venv_path,''))[1:]
+#        dest_dir = os.path.dirname(v.replace(venv_dir,''))[1:]
 #        libraries.append((v, dest_dir))
 #
 #

--- a/bundle_tools/win/app.spec
+++ b/bundle_tools/win/app.spec
@@ -61,7 +61,7 @@ for v in vtk_files:
         libraries.append((v, dest_dir))
 
 #add interpolation module (pyinstaller not take automatically)
-libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy\Release',\ 
+libraries.append((glob.glob(os.path.join(SOURCE_DIR,'invesalius_cy\Release', 
     'interpolation.*.pyd'))[0],'invesalius_cy')) #.pyd files are inside of invesalius_cy\Release
 
 #add plaidml modules and files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 license = { file = "LICENSE.txt" }
 readme = "README.md"
-requires-python = ">=3.12.*"
+requires-python = "==3.12.*"
 
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 license = { file = "LICENSE.txt" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12.*"
 
 
 [dependency-groups]


### PR DESCRIPTION
This PR updates the `bundles.yml` workflow file to use `uv` instead of `pip` for building windows executables. 

The key changes include:

- Replacing `setup.py` -based installation with `uv sync`
- Ensuring dependencies are installed from `pyproject.toml`
- Updating the build process to align with uv and scikit-build-core
- Updates Python version to 3.12
    - Reason :In Python versions below 3.12, `pip install -e .` does not function properly, causing installation issues. 
    - Python versions above 3.12 do not have support for `pyacvd` yet.

@tfmoraes @paulojamorim Could you please review this PR. Thanks!