### PR TITLE
Persistent Affine Refactor

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -273,15 +273,17 @@ class Slice(metaclass=utils.Singleton):
         for buffer_ in self.buffer_slices.values():
             buffer_.discard_vtk_mask()
             buffer_.discard_mask()
-        
-    def get_world_to_invesalius_vtk_affine(self, inverse : bool = False) -> Tuple[np.ndarray, "vtkMatrix4x4", float]:
+
+    def get_world_to_invesalius_vtk_affine(
+        self, inverse: bool = False
+    ) -> Tuple[np.ndarray, "vtkMatrix4x4", float]:
         """
         Creates an affine matrix with img_shift adjustment and returns both the NumPy
         and VTK versions of the matrix, along with the img_shift value.
-        
+
         Args:
             inverse (bool): If True, returns the inverse transformation matrix
-            
+
         Returns:
             tuple: (adjusted_affine_numpy, adjusted_affine_vtk, img_shift)
                 - adjusted_affine_numpy (np.ndarray): The 4x4 transformation matrix as NumPy array
@@ -295,19 +297,19 @@ class Slice(metaclass=utils.Singleton):
             prj_data = Project()
             matrix_shape = tuple(prj_data.matrix_shape)
             spacing = tuple(prj_data.spacing)
-        except (AttributeError):
+        except AttributeError:
             matrix_shape = self.matrix.shape
             spacing = self.spacing
-        
+
         img_shift = spacing[1] * (matrix_shape[1] - 1)
         adjusted_affine = self.affine.copy()
         adjusted_affine[1, -1] -= img_shift
         if inverse:
             adjusted_affine = np.linalg.inv(adjusted_affine)
         affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(adjusted_affine)
-        
+
         return adjusted_affine, affine_vtk, img_shift
-    
+
     def OnRemoveMasks(self, mask_indexes):
         proj = Project()
         for item in mask_indexes:

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -273,7 +273,41 @@ class Slice(metaclass=utils.Singleton):
         for buffer_ in self.buffer_slices.values():
             buffer_.discard_vtk_mask()
             buffer_.discard_mask()
+        
+    def get_world_to_invesalius_vtk_affine(self, inverse : bool = False) -> Tuple[np.ndarray, "vtkMatrix4x4", float]:
+        """
+        Creates an affine matrix with img_shift adjustment and returns both the NumPy
+        and VTK versions of the matrix, along with the img_shift value.
+        
+        Args:
+            inverse (bool): If True, returns the inverse transformation matrix
+            
+        Returns:
+            tuple: (adjusted_affine_numpy, adjusted_affine_vtk, img_shift)
+                - adjusted_affine_numpy (np.ndarray): The 4x4 transformation matrix as NumPy array
+                - adjusted_affine_vtk (vtkMatrix4x4): The same matrix in VTK format
+                - img_shift (float): The calculated image shift value
+        """
+        from invesalius.data import vtk_utils
 
+        # Try to get matrix shape from Project, or fallback to Slice's own matrix
+        try:
+            prj_data = Project()
+            matrix_shape = tuple(prj_data.matrix_shape)
+            spacing = tuple(prj_data.spacing)
+        except (AttributeError):
+            matrix_shape = self.matrix.shape
+            spacing = self.spacing
+        
+        img_shift = spacing[1] * (matrix_shape[1] - 1)
+        adjusted_affine = self.affine.copy()
+        adjusted_affine[1, -1] -= img_shift
+        if inverse:
+            adjusted_affine = np.linalg.inv(adjusted_affine)
+        affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(adjusted_affine)
+        
+        return adjusted_affine, affine_vtk, img_shift
+    
     def OnRemoveMasks(self, mask_indexes):
         proj = Project()
         for item in mask_indexes:

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -599,14 +599,8 @@ class SurfaceManager:
         :return: transformed polydata
         :rtype: vtkPolydata
         """
-        matrix_shape = sl.Slice().matrix.shape
-        spacing = sl.Slice().spacing
-        img_shift = spacing[1] * (matrix_shape[1] - 1)
-        affine = sl.Slice().affine.copy()
-        affine[1, -1] -= img_shift
-        if inverse:
-            affine = np.linalg.inv(affine)
-        affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(affine)
+        slic = sl.Slice()
+        affine, affine_vtk, _ = slic.get_world_to_invesalius_vtk_affine(inverse=inverse)
 
         polydata_transform = vtkTransform()
         polydata_transform.PostMultiply()

--- a/invesalius/gui/task_tractography.py
+++ b/invesalius/gui/task_tractography.py
@@ -453,13 +453,7 @@ class InnerTaskPanel(wx.Panel):
 
         if not self.affine_vtk:
             slic = sl.Slice()
-            prj_data = prj.Project()
-            matrix_shape = tuple(prj_data.matrix_shape)
-            spacing = tuple(prj_data.spacing)
-            img_shift = spacing[1] * (matrix_shape[1] - 1)
-            self.affine = slic.affine.copy()
-            self.affine[1, -1] -= img_shift
-            self.affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(self.affine)
+            self.affine, self.affine_vtk, img_shift = slic.get_world_to_invesalius_vtk_affine()
 
         if filename:
             Publisher.sendMessage("Update status text in GUI", label=_("Busy"))
@@ -524,13 +518,7 @@ class InnerTaskPanel(wx.Panel):
 
             if not self.affine_vtk:
                 slic = sl.Slice()
-                prj_data = prj.Project()
-                matrix_shape = tuple(prj_data.matrix_shape)
-                spacing = tuple(prj_data.spacing)
-                img_shift = spacing[1] * (matrix_shape[1] - 1)
-                self.affine = slic.affine.copy()
-                self.affine[1, -1] -= img_shift
-                self.affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(self.affine)
+                self.affine, self.affine_vtk, img_shift = slic.get_world_to_invesalius_vtk_affine()
 
             try:
                 t_init = time.time()

--- a/invesalius/navigation/iterativeclosestpoint.py
+++ b/invesalius/navigation/iterativeclosestpoint.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from invesalius.navigation.navigation import Navigation
     from invesalius.navigation.tracker import Tracker
 
+
 class IterativeClosestPoint(metaclass=Singleton):
     def __init__(self) -> None:
         self.use_icp = False

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -618,17 +618,8 @@ class Navigation(metaclass=Singleton):
 
             if self.view_tracts:
                 # initialize Trekker parameters
-                # TODO: This affine and affine_vtk are created 4 times. To improve, create a new affine object inside
-                #  Slice() that contains the transformation with the img_shift. Rename it to avoid confusion to the
-                #  affine, for instance it can be: affine_world_to_invesalius_vtk
                 slic = sl.Slice()
-                prj_data = prj.Project()
-                matrix_shape = tuple(prj_data.matrix_shape)
-                spacing = tuple(prj_data.spacing)
-                img_shift = spacing[1] * (matrix_shape[1] - 1)
-                affine = slic.affine.copy()
-                affine[1, -1] -= img_shift
-                affine_vtk = vtk_utils.numpy_to_vtkMatrix4x4(affine)
+                affine, affine_vtk, img_shift = slic.get_world_to_invesalius_vtk_affine()
 
                 Publisher.sendMessage("Update marker offset state", create=True)
 

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -84,11 +84,16 @@ class Tracker(metaclass=Singleton):
             return
 
         from typing import cast
-        tracker_id: int = cast(int, state["tracker_id"])  
+
+        tracker_id: int = cast(int, state["tracker_id"])
         tracker_fiducials: NDArray[np.float64] = np.array(state["tracker_fiducials"])
         tracker_fiducials_raw: NDArray[np.float64] = np.array(state["tracker_fiducials_raw"])
-        m_tracker_fiducials_raw: NDArray[np.float64] = np.array(state["marker_tracker_fiducials_raw"])
-        configuration: Optional[Dict[str, object]] = cast(Optional[Dict[str, object]], state["configuration"])  # Modified: cast configuration
+        m_tracker_fiducials_raw: NDArray[np.float64] = np.array(
+            state["marker_tracker_fiducials_raw"]
+        )
+        configuration: Optional[Dict[str, object]] = cast(
+            Optional[Dict[str, object]], state["configuration"]
+        )  # Modified: cast configuration
 
         self.tracker_id = tracker_id
         self.tracker_fiducials = tracker_fiducials
@@ -97,7 +102,9 @@ class Tracker(metaclass=Singleton):
 
         self.SetTracker(tracker_id=self.tracker_id, configuration=configuration)
 
-    def SetTracker(self, tracker_id: int, n_coils: int = 1, configuration: Optional[Dict[str, object]] = None) -> None:
+    def SetTracker(
+        self, tracker_id: int, n_coils: int = 1, configuration: Optional[Dict[str, object]] = None
+    ) -> None:
         if tracker_id:
             self.tracker_connection = tc.CreateTrackerConnection(tracker_id, n_coils)
 
@@ -178,7 +185,9 @@ class Tracker(metaclass=Singleton):
     def AreTrackerFiducialsSet(self) -> bool:
         return not np.isnan(self.tracker_fiducials).any()
 
-    def GetTrackerCoordinates(self, ref_mode_id: int, n_samples: int = 1) -> Tuple[Tuple[bool, ...], NDArray[np.float64], NDArray[np.float64]]:
+    def GetTrackerCoordinates(
+        self, ref_mode_id: int, n_samples: int = 1
+    ) -> Tuple[Tuple[bool, ...], NDArray[np.float64], NDArray[np.float64]]:
         coord_raw_samples: Dict[int, NDArray[np.float64]] = {}
         coord_samples: Dict[int, NDArray[np.float64]] = {}
 


### PR DESCRIPTION
I found the same affine transformation code duplicated in 4 different places across the codebase and decided to clean it up. This PR addresses the TODO comment in `navigation.py` that highlighted this issue:

> "TODO: This affine and affine_vtk are created 4 times. To improve, create a new affine object inside Slice() that contains the transformation with the img_shift."

I created a new method `get_world_to_invesalius_vtk_affine()` in the `Slice` class that centralizes this functionality and replaced all the duplicate code with calls to this method. The duplicated code was in:
- `surface.py`
- `task_tractography.py` (twice)
- `navigation.py`

The new method:
- Works with both regular and inverse transformations
- Falls back to different data sources if needed
- Has proper type annotations and documentation

This refactoring makes the code more maintainable and ensures consistent behavior when handling coordinate transformations throughout the codebase.