### PR TITLE
Updated test_set_and_get_config in test_session.py

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,7 +12,9 @@ from invesalius.session import CONFIG_PATH, STATE_PATH, Session
 session = Session()
 
 
-def test_set_and_get_config():
+def test_set_and_get_config(mocker):
+    mocker.patch.object(session, "_write_to_json")
+    
     session.SetConfig("debug", True)
     assert session.GetConfig("debug") == True
 


### PR DESCRIPTION
When running the test suite, test_set_and_get_config fails with a FileNotFoundError because it's trying to write to a config file at a path where the directory structure doesn't exist

![{5B4379B8-2D8B-46D5-A014-C6D2B052D99C}](https://github.com/user-attachments/assets/5b3f7c36-b6bc-43de-88ee-3708e7a57dfc)

Proposed Solution
Update the tests to properly mock file operations. This will prevent the test from depending on the actual filesystem state.



