### PR TITLE
fix: 3D slice widgets now are enabled in the correct position

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -18,7 +18,7 @@
 # --------------------------------------------------------------------------
 import os
 import tempfile
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
 import numpy as np
 from vtkmodules.vtkCommonCore import vtkLookupTable
@@ -29,6 +29,7 @@ from vtkmodules.vtkImagingCore import (
     vtkImageFlip,
     vtkImageMapToColors,
 )
+from vtkmodules.vtkInteractionWidgets import vtkImagePlaneWidget
 from vtkmodules.vtkRenderingCore import (
     vtkColorTransferFunction,
     vtkWindowLevelLookupTable,
@@ -1331,7 +1332,9 @@ class Slice(metaclass=utils.Singleton):
 
         Publisher.sendMessage("Reload actual slice")
 
-    def UpdateSlice3D(self, widget, orientation):
+    def UpdateSlice3D(
+        self, widget: vtkImagePlaneWidget, orientation: Literal["AXIAL", "CORONAL", "SAGITAL"]
+    ):
         img = self.buffer_slices[orientation].vtk_image
         # original_orientation = Project().original_orientation
         cast = vtkImageCast()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2990,20 +2990,33 @@ class SlicePlane:
 
         Publisher.sendMessage("Render volume viewer")
 
-    def Enable(self, plane_label=None):
+    def Enable(self, plane_label: str | None = None):
+        """
+        Enable slice widgets (axial, coronal, sagittal) in the volume viewer.
+
+        Parameters
+        ----------
+        plane_label : str or None, optional
+            The label of the plane to enable. Accepted values are "Axial",
+            "Coronal", "Sagital". If ``None``, all planes are enabled.
+        """
         if plane_label:
             if plane_label == "Axial":
                 self.plane_z.On()
+                Publisher.sendMessage("Update slice 3D", widget=self.plane_z, orientation="AXIAL")
             elif plane_label == "Coronal":
                 self.plane_y.On()
+                Publisher.sendMessage("Update slice 3D", widget=self.plane_y, orientation="CORONAL")
             elif plane_label == "Sagital":
                 self.plane_x.On()
+                Publisher.sendMessage("Update slice 3D", widget=self.plane_x, orientation="SAGITAL")
             Publisher.sendMessage("Reposition 3D Plane", plane_label=plane_label)
         else:
             self.plane_z.On()
             self.plane_x.On()
             self.plane_y.On()
             Publisher.sendMessage("Set volume view angle", view=const.VOL_ISO)
+            Publisher.sendMessage("Update all slice")
 
         Publisher.sendMessage("Render volume viewer")
 


### PR DESCRIPTION
- Fixes #936 

### Before

![image](https://github.com/user-attachments/assets/a0df9a9e-c568-4a27-b79e-5b82a4deac47)

### After
3D slice widgets start at the correct position

![image](https://github.com/user-attachments/assets/4af75a9d-ff39-4054-8285-650142af9403)
