### PR TITLE
FIX: pre-commit.yml in response to up coming github changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,8 +5,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - id: file_changes
@@ -14,7 +14,7 @@ jobs:
       with:
         prNumber: ${{ github.event.number }}
         output: ' '
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.0
       name: ruff-pre-commit-run
       with: 
         extra_args: --files ${{ steps.file_changes.outputs.files }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for pre-commit checks. The main changes involve upgrading the versions of the actions used.

This PR is in response to https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts


Workflow configuration updates:

* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L8-R17): Updated `actions/checkout` from version 2 to version 4.
* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L8-R17): Updated `actions/setup-python` from version 2 to version 5.
* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L8-R17): Updated `pre-commit/action` from version 2.0.3 to version 3.0.0.


