### PR TITLE
OPTIMIZE: session tests

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,6 +10,7 @@ import invesalius.constants as const
 from invesalius import inv_paths
 from invesalius.session import CONFIG_PATH, STATE_PATH, Session
 
+
 @pytest.fixture
 def isolated_session():
     return Session()
@@ -45,7 +46,9 @@ def test_create_config(mocker, isolated_session):
     assert isolated_session._config["rendering"] == 0
     assert isolated_session._config["slice_interpolation"] == 0
     assert isolated_session._config["auto_reload_preview"] is False
-    assert isolated_session._config["recent_projects"] == [(str(inv_paths.SAMPLE_DIR), "Cranium.inv3")]
+    assert isolated_session._config["recent_projects"] == [
+        (str(inv_paths.SAMPLE_DIR), "Cranium.inv3")
+    ]
     assert isolated_session._config["last_dicom_folder"] == ""
     assert isolated_session._config["file_logging"] == 0
     assert isolated_session._config["file_logging_level"] == 0
@@ -115,9 +118,7 @@ def test_close_project(mocker, isolated_session):
 def test_save_project(mocker, isolated_session):
     mock_set_state = mocker.patch.object(isolated_session, "SetState")
     mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
-    mocker.patch.object(
-        isolated_session, "GetConfig", return_value=[["/dummy/path", "dummy.inv"]]
-    )
+    mocker.patch.object(isolated_session, "GetConfig", return_value=[["/dummy/path", "dummy.inv"]])
     project_path = ("path", "project.inv")
     isolated_session.SaveProject(project_path)
     mock_set_state.assert_called_once_with("project_path", project_path)
@@ -148,7 +149,9 @@ def test_create_project(mocker, isolated_session):
 def test_open_project(mocker, isolated_session):
     mock_set_state = mocker.patch.object(isolated_session, "SetState")
     mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
-    mocker.patch.object(isolated_session, "GetConfig", return_value=[["/existing/path", "existing.inv"]])
+    mocker.patch.object(
+        isolated_session, "GetConfig", return_value=[["/existing/path", "existing.inv"]]
+    )
     project_path = "/path/dummy.inv"
     isolated_session.OpenProject(project_path)
     mock_set_state.assert_called_once_with("project_path", ("/path", "dummy.inv"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,119 +10,120 @@ import invesalius.constants as const
 from invesalius import inv_paths
 from invesalius.session import CONFIG_PATH, STATE_PATH, Session
 
-session = Session()
+@pytest.fixture
+def isolated_session():
+    return Session()
 
 
-def test_set_and_get_config():
-    session.SetConfig("debug", True)
-    assert session.GetConfig("debug") == True
+def test_set_and_get_config(isolated_session):
+    isolated_session.SetConfig("debug", True)
+    assert isolated_session.GetConfig("debug") is True
 
 
-def test_write_config_file(mocker):
+def test_write_config_file(mocker, isolated_session):
     mock_file = mock_open()
     mocker.patch("builtins.open", mock_file)
     mocker.patch("pathlib.Path.mkdir")
     mock_json_dump = mocker.patch("json.dump")
-    session._config = {"debug": True, "language": "en", "file_logging": 1}
-    session.WriteConfigFile()
+    isolated_session._config = {"debug": True, "language": "en", "file_logging": 1}
+    isolated_session.WriteConfigFile()
     mock_file.assert_called_once_with(Path(CONFIG_PATH), "w")
     expected_data = {"debug": True, "language": "en", "file_logging": 1}
     mock_json_dump.assert_called_once_with(expected_data, mock_file(), sort_keys=True, indent=4)
 
 
-def test_create_config(mocker):
-    mock_write_config = mocker.patch.object(session, "WriteConfigFile")
-    session.CreateConfig()
-    assert session._config["mode"] == const.MODE_RP
-    assert session._config["project_status"] == const.PROJECT_STATUS_CLOSED
-    assert session._config["debug"] is False
-    assert session._config["debug_efield"] is False
-    assert session._config["language"] == ""
-    assert isinstance(session._config["random_id"], int)
-    assert session._config["surface_interpolation"] == 1
-    assert session._config["rendering"] == 0
-    assert session._config["slice_interpolation"] == 0
-    assert session._config["auto_reload_preview"] is False
-    assert session._config["recent_projects"] == [(str(inv_paths.SAMPLE_DIR), "Cranium.inv3")]
-    assert session._config["last_dicom_folder"] == ""
-    assert session._config["file_logging"] == 0
-    assert session._config["file_logging_level"] == 0
-    assert session._config["append_log_file"] == 0
-    assert session._config["logging_file"] == ""
-    assert session._config["console_logging"] == 0
-    assert session._config["console_logging_level"] == 0
+def test_create_config(mocker, isolated_session):
+    mock_write_config = mocker.patch.object(isolated_session, "WriteConfigFile")
+    isolated_session.CreateConfig()
+    assert isolated_session._config["mode"] == const.MODE_RP
+    assert isolated_session._config["project_status"] == const.PROJECT_STATUS_CLOSED
+    assert isolated_session._config["debug"] is False
+    assert isolated_session._config["debug_efield"] is False
+    assert isolated_session._config["language"] == ""
+    assert isinstance(isolated_session._config["random_id"], int)
+    assert isolated_session._config["surface_interpolation"] == 1
+    assert isolated_session._config["rendering"] == 0
+    assert isolated_session._config["slice_interpolation"] == 0
+    assert isolated_session._config["auto_reload_preview"] is False
+    assert isolated_session._config["recent_projects"] == [(str(inv_paths.SAMPLE_DIR), "Cranium.inv3")]
+    assert isolated_session._config["last_dicom_folder"] == ""
+    assert isolated_session._config["file_logging"] == 0
+    assert isolated_session._config["file_logging_level"] == 0
+    assert isolated_session._config["append_log_file"] == 0
+    assert isolated_session._config["logging_file"] == ""
+    assert isolated_session._config["console_logging"] == 0
+    assert isolated_session._config["console_logging_level"] == 0
     mock_write_config.assert_called_once()
 
 
-def test_read_state(mocker):
+def test_read_state(mocker, isolated_session):
     test_data = {"dummykey": "dummyValue"}
     mock_file = mock_open(read_data=json.dumps(test_data))
     mocker.patch("builtins.open", mock_file)
     mocker.patch("json.load", return_value=test_data)
     mocker.patch("os.path.exists", return_value=True)
-    success = session._ReadState()
-    session._state = test_data
-    assert session.GetState("dummykey") == "dummyValue"
+    success = isolated_session._ReadState()
+    isolated_session._state = test_data
+    assert isolated_session.GetState("dummykey") == "dummyValue"
     assert success is True
 
 
-def test_create_state(mocker):
+def test_create_state(mocker, isolated_session):
     mock_state_json = mock_open()
     mocker.patch("builtins.open", mock_state_json)
     mocker.patch("pathlib.Path.mkdir")
     mock_json_dump = mocker.patch("json.dump")
-    session.CreateState()
+    isolated_session.CreateState()
     mock_state_json.assert_called_once_with(Path(STATE_PATH), "w")
     mock_json_dump.assert_called_once_with({}, mock_state_json(), sort_keys=True, indent=4)
 
 
-def test_set_and_get_state(mocker):
+def test_set_and_get_state(mocker, isolated_session):
     mock_file = mock_open()
     mocker.patch("builtins.open", mock_file)
     mocker.patch("pathlib.Path.mkdir")
     mock_json = mocker.patch("json.dump")
-    session.SetState("test_key", "test_value")
+    isolated_session.SetState("test_key", "test_value")
     mock_file.assert_called_once_with(Path(STATE_PATH), "w")
     mock_json.assert_called_once_with(
         {"test_key": "test_value"}, mock_file(), sort_keys=True, indent=4
     )
 
 
-def test_delete_state_file(mocker):
+def test_delete_state_file(mocker, isolated_session):
     mocker.patch("os.path.exists", return_value=True)
     mock_remove = mocker.patch("os.remove")
-    session.DeleteStateFile()
+    isolated_session.DeleteStateFile()
     mock_remove.assert_called_once_with(STATE_PATH)
 
 
-def test_delete_state_file_not_exist(mocker):
+def test_delete_state_file_not_exist(mocker, isolated_session):
     mocker.patch("os.path.exists", return_value=False)
     mock_remove = mocker.patch("os.remove")
-    session.DeleteStateFile()
+    isolated_session.DeleteStateFile()
     mock_remove.assert_not_called()
 
 
-def test_close_project(mocker):
-    mock_set_state = mocker.patch.object(session, "SetState")
-    mock_set_config = mocker.patch.object(session, "SetConfig")
-    session.CloseProject()
+def test_close_project(mocker, isolated_session):
+    mock_set_state = mocker.patch.object(isolated_session, "SetState")
+    mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
+    isolated_session.CloseProject()
     mock_set_state.assert_called_once_with("project_path", None)
     mock_set_config.assert_called_once_with("project_status", const.PROJECT_STATUS_CLOSED)
 
 
-def test_save_project(mocker):
-    """Ensure SaveProject sets the project state and updates the config."""
-    mock_set_state = mocker.patch.object(session, "SetState")
-    mock_set_config = mocker.patch.object(session, "SetConfig")
+def test_save_project(mocker, isolated_session):
+    mock_set_state = mocker.patch.object(isolated_session, "SetState")
+    mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
     mocker.patch.object(
-        session, "GetConfig", return_value=[["/dummy/path", "dummy.inv"]]
-    )  # Ensures its not None
+        isolated_session, "GetConfig", return_value=[["/dummy/path", "dummy.inv"]]
+    )
     project_path = ("path", "project.inv")
-    session.SaveProject(project_path)
+    isolated_session.SaveProject(project_path)
     mock_set_state.assert_called_once_with("project_path", project_path)
     mock_set_config.assert_has_calls(
         [
-            call("recent_projects", mocker.ANY),  # Ensures recent projects were updated
+            call("recent_projects", mocker.ANY),
             call("project_status", const.PROJECT_STATUS_OPENED),
         ],
         any_order=True,
@@ -130,45 +131,43 @@ def test_save_project(mocker):
     assert mock_set_config.call_count == 2
 
 
-def test_change_project(mocker):
-    mock_set_config = mocker.patch.object(session, "SetConfig")
-    session.ChangeProject()
+def test_change_project(mocker, isolated_session):
+    mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
+    isolated_session.ChangeProject()
     mock_set_config.assert_called_once_with("project_status", const.PROJECT_STATUS_CHANGED)
 
 
-def test_create_project(mocker):
-    mock_set_state = mocker.patch.object(session, "SetState")
-    mock_set_config = mocker.patch.object(session, "SetConfig")
-    session.CreateProject("new_project.inv")
+def test_create_project(mocker, isolated_session):
+    mock_set_state = mocker.patch.object(isolated_session, "SetState")
+    mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
+    isolated_session.CreateProject("new_project.inv")
     mock_set_state.assert_called_once()
     mock_set_config.assert_called_once_with("project_status", const.PROJECT_STATUS_NEW)
 
 
-def test_open_project(mocker):
-    mock_set_state = mocker.patch.object(session, "SetState")
-    mock_set_config = mocker.patch.object(session, "SetConfig")
-    mocker.patch.object(session, "GetConfig", return_value=[["/existing/path", "existing.inv"]])
+def test_open_project(mocker, isolated_session):
+    mock_set_state = mocker.patch.object(isolated_session, "SetState")
+    mock_set_config = mocker.patch.object(isolated_session, "SetConfig")
+    mocker.patch.object(isolated_session, "GetConfig", return_value=[["/existing/path", "existing.inv"]])
     project_path = "/path/dummy.inv"
-    session.OpenProject(project_path)
+    isolated_session.OpenProject(project_path)
     mock_set_state.assert_called_once_with("project_path", ("/path", "dummy.inv"))
-
     mock_set_config.assert_has_calls(
         [
             call("recent_projects", mocker.ANY),
-            call("project_status", const.PROJECT_STATUS_OPENED),  # Ensures project was opened
+            call("project_status", const.PROJECT_STATUS_OPENED),
         ],
         any_order=True,
     )
-
     assert mock_set_config.call_count == 2
 
 
-def test_read_state_with_corrupted_json(mocker):
+def test_read_state_with_corrupted_json(mocker, isolated_session):
     mocker.patch("os.path.exists", return_value=True)
     mock_file = mock_open(read_data="corrupted data")
     mocker.patch("builtins.open", mock_file)
     mocker.patch("json.load", side_effect=json.JSONDecodeError("Expecting value", "", 0))
-    mock_delete = mocker.patch.object(session, "DeleteStateFile")
-    success = session._ReadState()
+    mock_delete = mocker.patch.object(isolated_session, "DeleteStateFile")
+    success = isolated_session._ReadState()
     assert success is False
     mock_delete.assert_called_once()


### PR DESCRIPTION
This pull request focuses on improving the test isolation in `tests/test_session.py` by introducing a `pytest` fixture to create isolated `Session` instances for each test. This change ensures that tests do not interfere with each other by sharing the same session state.

I discovered this by accident while trying to parallelize the tests to speed them up — one test kept failing because the session object was shared globally instead of being isolated.

Key changes include:

* **Test Isolation:**
  - Added a `pytest` fixture named `isolated_session` to provide a fresh `Session` instance for each test.

* **Refactoring Tests:**
  - Updated all test functions to use the `isolated_session` fixture instead of a shared `session` instance. This change affects functions such as `test_set_and_get_config`, `test_write_config_file`, `test_create_config`, `test_read_state`, `test_create_state`, `test_set_and_get_state`, `test_delete_state_file`, `test_delete_state_file_not_exist`, `test_close_project`, `test_save_project`, `test_change_project`, `test_create_project`, `test_open_project`, and `test_read_state_with_corrupted_json`.