### PR TITLE
Updated test_tracker.py

### DIFF
--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -107,6 +107,9 @@ def test_set_tracker(mocker, tracker):
     mocker.patch(
         "invesalius.data.tracker_connection.CreateTrackerConnection", return_value=mock_tracker_conn
     )
+    
+    mocker.patch.object(tracker, "SaveState")
+    
     with patch.object(threading.Thread, "start"):
         tracker.SetTracker(tracker_id=const.DEBUGTRACKAPPROACH)
 


### PR DESCRIPTION
when running the unit test test_set_tracker in test_tracker.py it fails with a FileNotFoundError because the test attempts to write to a state file in a directory that doesn't exist during test execution
![{3AA6CFEB-818A-4EAF-A0E1-57BCB183821F}](https://github.com/user-attachments/assets/84c1b7cc-5e2c-420f-adb6-ad64a29c0626)
