### PR TITLE
fix: handle missing surface index in OnLargestSurface()

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -335,10 +335,13 @@ class SurfaceManager:
         Create a new surface, based on largest part of the last
         selected surface.
         """
+        proj = prj.Project()
+        index = self.last_surface_index
+        if index not in proj.surface_dict:
+            print(f"[Error] Surface index {index} not found in surface_dict.")
+            return
         progress_dialog = dialogs.SelectLargestSurfaceProgressWindow()
         progress_dialog.Update()
-        index = self.last_surface_index
-        proj = prj.Project()
         surface = proj.surface_dict[index]
 
         new_polydata = pu.SelectLargestPart(surface.polydata)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3383,6 +3383,10 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             return
         marker = self.__get_marker(list_index)
 
+        proj = prj.Project()
+        if not proj.surface_dict:
+            wx.MessageBox(_("No 3D surface was created."), _("InVesalius 3"))
+            return
         self.markers.CreateCoilTargetFromLandmark(marker)
 
     def OnCreateCoilTargetFromBrainTargets(self, evt):


### PR DESCRIPTION
This pull request includes a change to the `OnLargestSurface` method in the `invesalius/data/surface.py` file. The change improves error handling by checking if the surface index exists in the `surface_dict` before proceeding. Currently, the system hangs if this problem is encountered.

Recreate error:
1. Start app
2. Import DICOM image... ie. [`Chest`](https://invesalius.github.io/download.html#:~:text=Download-,Chest,-Download)
3. Configure 3D surface -> Advanced options -> Select largest surface

Error handling improvement:

* [`invesalius/data/surface.py`](diffhunk://#diff-ac4948ccf9066c0269d0546990162180fcdf44aeaa22abe91501b20eaae1ae69R338-L341): Added a check to ensure the `last_surface_index` exists in `proj.surface_dict` before attempting to access it, and prints an error message if the index is not found.

