### PR TITLE
unsubscribe function doesn't handle None arguments correctly

### DIFF
--- a/invesalius/pubsub/pub.py
+++ b/invesalius/pubsub/pub.py
@@ -62,7 +62,8 @@ def subscribe(listener: UserListener, topicName: str, **curriedArgs) -> Tuple[Li
 
 def unsubscribe(*args, **kwargs) -> None:
     """Unsubscribe from a topic."""
-    Publisher.unsubscribe(*args, **kwargs)
+    if args and args[0] is not None: 
+        Publisher.unsubscribe(*args, **kwargs)
 
 
 def sendMessage(topicName: str, **msgdata) -> None:


### PR DESCRIPTION
the unsubscribe function currently doesn't check if the topic name is none before forwarding the call to Publisher.unsubscribe()
this PR fixes that issue