### PR TITLE
refactor: simplify ExitDialog implementation 

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -512,16 +512,10 @@ class Frame(wx.Frame):
 
     def ExitDialog(self):
         msg = _("Are you sure you want to exit?")
-        if sys.platform == "darwin":
-            dialog = wx.RichMessageDialog(
-                None, "", msg, wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
-            )
-            dialog.ShowCheckBox("Store session", True)
-        else:
-            dialog = wx.RichMessageDialog(
-                None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
-            )
-            dialog.ShowCheckBox("Store session", True)
+        dialog = wx.RichMessageDialog(
+            None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
+        )
+        dialog.ShowCheckBox("Store session", True)
 
         def on_close(event):
             dialog.EndModal(wx.ID_NO)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -515,7 +515,7 @@ class Frame(wx.Frame):
         dialog = wx.RichMessageDialog(
             None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
         )
-        dialog.ShowCheckBox("Store session", True)
+        dialog.ShowCheckBox("Store session", False)
 
         def on_close(event):
             dialog.EndModal(wx.ID_NO)


### PR DESCRIPTION
This pull request includes changes to the `invesalius/gui/frame.py` file to simplify the `ExitDialog` method by removing platform-specific code for macOS.

Simplification of `ExitDialog` method:

* [`invesalius/gui/frame.py`](diffhunk://#diff-010bd7ee7abcf4486d91a94c10b30ecd5f38a414f2bff3ec760f0829551717eeL515-L520): Removed the conditional logic that handled macOS-specific dialog creation, simplifying the method to use a single dialog creation process for all platforms.

before:
<img width="240" alt="before" src="https://github.com/user-attachments/assets/346e4dea-743e-42a5-8b34-46b9a26326ce" />

after:
<img width="248" alt="after" src="https://github.com/user-attachments/assets/6ae702b4-4c44-4fd9-9757-898b74a0e37c" />
