### PR TITLE
bug fix related to preference option (https://github.com/invesalius/invesalius3/issues/957)

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -57,7 +57,7 @@ except ImportError:
 VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range(3)]
 
 WILDCARD_EXPORT_SLICE = (
-    "HDF5 (*.hdf5)|*.hdf5|" "NIfTI 1 (*.nii)|*.nii|" "Compressed NIfTI (*.nii.gz)|*.nii.gz"
+    "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
 )
 
 IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}
@@ -512,16 +512,16 @@ class Frame(wx.Frame):
 
     def ExitDialog(self):
         msg = _("Are you sure you want to exit?")
-        if sys.platform == "darwin":
-            dialog = wx.RichMessageDialog(
-                None, "", msg, wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
-            )
-            dialog.ShowCheckBox("Store session", False)
-        else:
-            dialog = wx.RichMessageDialog(
-                None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
-            )
-            dialog.ShowCheckBox("Store session", False)
+        dialog = wx.RichMessageDialog(
+            None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
+        )
+        dialog.ShowCheckBox("Store session", False)
+
+        def on_close(event):
+            dialog.EndModal(wx.ID_NO)
+            event.Skip()
+
+        dialog.Bind(wx.EVT_CLOSE, on_close)
 
         answer = dialog.ShowModal()
         save = dialog.IsCheckBoxChecked()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -57,7 +57,7 @@ except ImportError:
 VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range(3)]
 
 WILDCARD_EXPORT_SLICE = (
-    "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
+    "HDF5 (*.hdf5)|*.hdf5|" "NIfTI 1 (*.nii)|*.nii|" "Compressed NIfTI (*.nii.gz)|*.nii.gz"
 )
 
 IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}
@@ -516,12 +516,12 @@ class Frame(wx.Frame):
             dialog = wx.RichMessageDialog(
                 None, "", msg, wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
-            dialog.ShowCheckBox("Store session", True)
+            dialog.ShowCheckBox("Store session", False)
         else:
             dialog = wx.RichMessageDialog(
                 None, msg, "Invesalius 3", wx.ICON_QUESTION | wx.YES_NO | wx.NO_DEFAULT
             )
-            dialog.ShowCheckBox("Store session", True)
+            dialog.ShowCheckBox("Store session", False)
 
         answer = dialog.ShowModal()
         save = dialog.IsCheckBoxChecked()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -769,31 +769,49 @@ class Frame(wx.Frame):
             surface_interpolation = values[const.SURFACE_INTERPOLATION]
             language = values[const.LANGUAGE]
             slice_interpolation = values[const.SLICE_INTERPOLATION]
-            file_logging = values[const.FILE_LOGGING]
-            file_logging_level = values[const.FILE_LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
-            console_logging = values[const.CONSOLE_LOGGING]
-            console_logging_level = values[const.CONSOLE_LOGGING_LEVEL]
-            logging = values[const.LOGGING]
-            logging_level = values[const.LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
+            
+            # Handle logging settings with safe access to avoid KeyError
+            try:
+                file_logging = values.get(const.FILE_LOGGING)
+                file_logging_level = values.get(const.FILE_LOGGING_LEVEL)
+                append_log_file = values.get(const.APPEND_LOG_FILE)
+                logging_file = values.get(const.LOGFILE)
+                console_logging = values.get(const.CONSOLE_LOGGING)
+                console_logging_level = values.get(const.CONSOLE_LOGGING_LEVEL)
+                
+                # Set config only if values are not None
+                if file_logging is not None:
+                    session.SetConfig("file_logging", file_logging)
+                if file_logging_level is not None:
+                    session.SetConfig("file_logging_level", file_logging_level)
+                if append_log_file is not None:
+                    session.SetConfig("append_log_file", append_log_file)
+                if logging_file is not None:
+                    session.SetConfig("logging_file", logging_file)
+                if console_logging is not None:
+                    session.SetConfig("console_logging", console_logging)
+                if console_logging_level is not None:
+                    session.SetConfig("console_logging_level", console_logging_level)
+            except Exception as e:
+                print(f"Error handling logging settings: {e}")
+                
+            # Handle legacy logging settings
+            try:
+                logging = values.get(const.LOGGING)
+                logging_level = values.get(const.LOGGING_LEVEL)
+                
+                # Set config only if values are not None
+                if logging is not None:
+                    session.SetConfig("do_logging", logging)
+                if logging_level is not None:
+                    session.SetConfig("logging_level", logging_level)
+            except Exception as e:
+                print(f"Error handling legacy logging settings: {e}")
 
             session.SetConfig("rendering", rendering)
             session.SetConfig("surface_interpolation", surface_interpolation)
             session.SetConfig("language", language)
             session.SetConfig("slice_interpolation", slice_interpolation)
-            session.SetConfig("file_logging", file_logging)
-            session.SetConfig("file_logging_level", file_logging_level)
-            session.SetConfig("append_log_file", append_log_file)
-            session.SetConfig("logging_file", logging_file)
-            session.SetConfig("console_logging", console_logging)
-            session.SetConfig("console_logging_level", console_logging_level)
-            session.SetConfig("do_logging", logging)
-            session.SetConfig("logging_level", logging_level)
-            session.SetConfig("append_log_file", append_log_file)
-            session.SetConfig("logging_file", logging_file)
 
             Publisher.sendMessage("Remove Volume")
             Publisher.sendMessage("Reset Raycasting")

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -57,7 +57,7 @@ except ImportError:
 VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range(3)]
 
 WILDCARD_EXPORT_SLICE = (
-    "HDF5 (*.hdf5)|*.hdf5|" "NIfTI 1 (*.nii)|*.nii|" "Compressed NIfTI (*.nii.gz)|*.nii.gz"
+    "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
 )
 
 IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}
@@ -769,7 +769,7 @@ class Frame(wx.Frame):
             surface_interpolation = values[const.SURFACE_INTERPOLATION]
             language = values[const.LANGUAGE]
             slice_interpolation = values[const.SLICE_INTERPOLATION]
-            
+
             # Handle logging settings with safe access to avoid KeyError
             try:
                 file_logging = values.get(const.FILE_LOGGING)
@@ -778,7 +778,7 @@ class Frame(wx.Frame):
                 logging_file = values.get(const.LOGFILE)
                 console_logging = values.get(const.CONSOLE_LOGGING)
                 console_logging_level = values.get(const.CONSOLE_LOGGING_LEVEL)
-                
+
                 # Set config only if values are not None
                 if file_logging is not None:
                     session.SetConfig("file_logging", file_logging)
@@ -794,12 +794,12 @@ class Frame(wx.Frame):
                     session.SetConfig("console_logging_level", console_logging_level)
             except Exception as e:
                 print(f"Error handling logging settings: {e}")
-                
+
             # Handle legacy logging settings
             try:
                 logging = values.get(const.LOGGING)
                 logging_level = values.get(const.LOGGING_LEVEL)
-                
+
                 # Set config only if values are not None
                 if logging is not None:
                     session.SetConfig("do_logging", logging)


### PR DESCRIPTION
Sir, @rmatsuda @paulojamorim , please review this pr regarding preference bug fix : https://github.com/invesalius/invesalius3/issues/957 (✔️)


I modified the code in frame.py to safely access the logging configuration values using the .get() method instead of direct dictionary access with values[const.FILE_LOGGING].

The fix ensures that even when the logging tab is disabled (self.have_log_tab = 0), the preferences dialog can still function correctly without throwing the KeyError: 4 exception.