### PR TITLE
fix: ensure proper splash screen behavior during startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,7 +99,6 @@ class InVesalius(wx.App):
         self.SetAppName("InVesalius 3")
         self.splash = Inv3SplashScreen()
         self.splash.Show()
-        wx.CallLater(1000, self.Startup2)
 
         return True
 
@@ -267,6 +266,7 @@ class Inv3SplashScreen(SplashScreen):
             self.main.Raise()
         # Destroy the splash screen
         self.Destroy()
+        wx.CallAfter(wx.GetApp().Startup2)
 
 
 def non_gui_startup(args):


### PR DESCRIPTION
This PR updates the GUI initialization flow by moving the call to Startup2() from OnInit() to ShowMain(), using wx.CallAfter.

Previously, Startup2() was triggered with wx.CallLater(1000, ...) in OnInit(), relying on a fixed delay before proceeding to show the main window and initialize logging. This led to timing issues, especially if the splash screen or image loading took longer than expected.

By moving the call to ShowMain() and using wx.CallAfter, we ensure that Startup2() is executed only after the splash screen has been closed and the event loop is idle. This results in a more stable and predictable startup sequence.
