### PR TITLE
Improve file export options formatting and fix preferences dialog error

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -61,7 +61,9 @@ VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range
 [ID_SHOW_LOG_VIEWER] = [wx.NewIdRef() for number in range(1)]
 
 WILDCARD_EXPORT_SLICE = (
-    "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
+    "HDF5 (*.hdf5)|*.hdf5|"
+    "NIfTI 1 (*.nii)|*.nii|"
+    "Compressed NIfTI (*.nii.gz)|*.nii.gz"
 )
 
 IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -23,7 +23,6 @@ import platform
 import subprocess
 import sys
 import webbrowser
-from datetime import datetime
 
 import wx
 import wx.aui
@@ -61,9 +60,7 @@ VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range
 [ID_SHOW_LOG_VIEWER] = [wx.NewIdRef() for number in range(1)]
 
 WILDCARD_EXPORT_SLICE = (
-    "HDF5 (*.hdf5)|*.hdf5|"
-    "NIfTI 1 (*.nii)|*.nii|"
-    "Compressed NIfTI (*.nii.gz)|*.nii.gz"
+    "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
 )
 
 IDX_EXT = {0: ".hdf5", 1: ".nii", 2: ".nii.gz"}
@@ -211,7 +208,7 @@ class Frame(wx.Frame):
         # Check if the focus is on a text entry field
         focused = wx.Window.FindFocus()
         is_search_field = False
-        if focused and isinstance(focused, (wx.TextCtrl, wx.ComboBox)):
+        if focused and isinstance(focused, wx.TextCtrl | wx.ComboBox):
             is_search_field = True
 
         # If it is CTRL+S, CTRL+Shift+S, or CTRL+Q, skip this event
@@ -845,7 +842,7 @@ class Frame(wx.Frame):
             surface_interpolation = values[const.SURFACE_INTERPOLATION]
             language = values[const.LANGUAGE]
             slice_interpolation = values[const.SLICE_INTERPOLATION]
-            
+
             # Handle logging settings only if they exist in the values dictionary
             if const.FILE_LOGGING in values:
                 file_logging = values[const.FILE_LOGGING]
@@ -856,7 +853,7 @@ class Frame(wx.Frame):
                 console_logging_level = values[const.CONSOLE_LOGGING_LEVEL]
                 logging = values.get(const.LOGGING, 0)  # Default to 0 if not present
                 logging_level = values.get(const.LOGGING_LEVEL, 0)  # Default to 0 if not present
-                
+
                 session.SetConfig("file_logging", file_logging)
                 session.SetConfig("file_logging_level", file_logging_level)
                 session.SetConfig("append_log_file", append_log_file)
@@ -1416,9 +1413,7 @@ class MenuBar(wx.MenuBar):
         planning_menu.Append(const.ID_PLANNING_CRANIOPLASTY, _("Cranioplasty"))
 
         analysis_menu = wx.Menu()
-        mask_density_menu = analysis_menu.Append(
-            const.ID_MASK_DENSITY_MEASURE, _("Mask density measure")
-        )
+        analysis_menu.Append(const.ID_MASK_DENSITY_MEASURE, _("Mask density measure"))
 
         reorient_menu.Enable(False)
         tools_menu.Append(-1, _("Analysis"), analysis_menu)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -845,31 +845,31 @@ class Frame(wx.Frame):
             surface_interpolation = values[const.SURFACE_INTERPOLATION]
             language = values[const.LANGUAGE]
             slice_interpolation = values[const.SLICE_INTERPOLATION]
-            file_logging = values[const.FILE_LOGGING]
-            file_logging_level = values[const.FILE_LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
-            console_logging = values[const.CONSOLE_LOGGING]
-            console_logging_level = values[const.CONSOLE_LOGGING_LEVEL]
-            logging = values[const.LOGGING]
-            logging_level = values[const.LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
+            
+            # Handle logging settings only if they exist in the values dictionary
+            if const.FILE_LOGGING in values:
+                file_logging = values[const.FILE_LOGGING]
+                file_logging_level = values[const.FILE_LOGGING_LEVEL]
+                append_log_file = values[const.APPEND_LOG_FILE]
+                logging_file = values[const.LOGFILE]
+                console_logging = values[const.CONSOLE_LOGGING]
+                console_logging_level = values[const.CONSOLE_LOGGING_LEVEL]
+                logging = values.get(const.LOGGING, 0)  # Default to 0 if not present
+                logging_level = values.get(const.LOGGING_LEVEL, 0)  # Default to 0 if not present
+                
+                session.SetConfig("file_logging", file_logging)
+                session.SetConfig("file_logging_level", file_logging_level)
+                session.SetConfig("append_log_file", append_log_file)
+                session.SetConfig("logging_file", logging_file)
+                session.SetConfig("console_logging", console_logging)
+                session.SetConfig("console_logging_level", console_logging_level)
+                session.SetConfig("do_logging", logging)
+                session.SetConfig("logging_level", logging_level)
 
             session.SetConfig("rendering", rendering)
             session.SetConfig("surface_interpolation", surface_interpolation)
             session.SetConfig("language", language)
             session.SetConfig("slice_interpolation", slice_interpolation)
-            session.SetConfig("file_logging", file_logging)
-            session.SetConfig("file_logging_level", file_logging_level)
-            session.SetConfig("append_log_file", append_log_file)
-            session.SetConfig("logging_file", logging_file)
-            session.SetConfig("console_logging", console_logging)
-            session.SetConfig("console_logging_level", console_logging_level)
-            session.SetConfig("do_logging", logging)
-            session.SetConfig("logging_level", logging_level)
-            session.SetConfig("append_log_file", append_log_file)
-            session.SetConfig("logging_file", logging_file)
 
             Publisher.sendMessage("Remove Volume")
             Publisher.sendMessage("Reset Raycasting")


### PR DESCRIPTION
This PR includes 4 fixes:

1. Improves code readability by reformatting the WILDCARD_EXPORT_SLICE constant to have each file type on its own line for better maintainability.

2. Fixes a KeyError that occurs when pressing OK in the Preferences dialog. This issue was introduced in PR #913 when the logging tab was disabled (self.have_log_tab = 0). The fix adds proper checking for the existence of logging-related keys before accessing them.

3. Fixed the UP038 error by updating the isinstance() call on line 211 to use the modern syntax with pipe operator ( | ) instead of a tuple:

Changed isinstance(focused, (wx.TextCtrl, wx.ComboBox)) to isinstance(focused, wx.TextCtrl | wx.ComboBox)

4. Fixed the F841 error by removing the unused variable assignment on line 1416:

Changed mask_density_menu = analysis_menu.Append(...) to just analysis_menu.Append(...)