### PR TITLE
Fix KeyError in preferences dialog for logging settings (issue fix #957)

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -842,17 +842,15 @@ class Frame(wx.Frame):
             rendering = values[const.RENDERING]
             surface_interpolation = values[const.SURFACE_INTERPOLATION]
             language = values[const.LANGUAGE]
-            slice_interpolation = values[const.SLICE_INTERPOLATION]
-            file_logging = values[const.FILE_LOGGING]
-            file_logging_level = values[const.FILE_LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
-            console_logging = values[const.CONSOLE_LOGGING]
-            console_logging_level = values[const.CONSOLE_LOGGING_LEVEL]
-            logging = values[const.LOGGING]
-            logging_level = values[const.LOGGING_LEVEL]
-            append_log_file = values[const.APPEND_LOG_FILE]
-            logging_file = values[const.LOGFILE]
+            slice_interpolation = values.get(const.SLICE_INTERPOLATION, 0)
+            file_logging = values.get(const.FILE_LOGGING, 0)
+            file_logging_level = values.get(const.FILE_LOGGING_LEVEL, 0)
+            append_log_file = values.get(const.APPEND_LOG_FILE, 0)
+            logging_file = values.get(const.LOGFILE, "")
+            console_logging = values.get(const.CONSOLE_LOGGING, 0)
+            console_logging_level = values.get(const.CONSOLE_LOGGING_LEVEL, 0)
+            logging = values.get(const.LOGGING, 0)
+            logging_level = values.get(const.LOGGING_LEVEL, 0)
 
             session.SetConfig("rendering", rendering)
             session.SetConfig("surface_interpolation", surface_interpolation)


### PR DESCRIPTION

Please review sir @paulojamorim @rmatsuda and let me know about further changes

This PR addresses issue:
-  #957 

by fixing a KeyError that occurs when accessing the preferences dialog. The error was caused by missing keys in the values dictionary returned from the preferences dialog.

The fix uses the `.get()` method with default values for all logging-related parameters, preventing the KeyError when a key is not present in the dictionary.

The changes are focused solely on fixing this specific issue, with no additional modifications to other functionality.


Thank you sir for the constant support.
