### PR TITLE
Fix "Please import image first" message after successful DICOM import

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -482,8 +482,12 @@ class Controller:
     def OnLoadImportPanel(self, patient_series: Optional[List]) -> None:
         ok = self.LoadImportPanel(patient_series)
         if ok:
+            # Make sure to show the import panel explicitly with both messages
+            # This ensures the UI properly displays the panel after loading DICOM files
             Publisher.sendMessage("Show import panel")
             Publisher.sendMessage("Show import panel in frame")
+            # Force focus on the import panel
+            wx.CallAfter(Publisher.sendMessage, "Show import panel in frame")
             self.img_type = 1
 
     def OnLoadImportBitmapPanel(

--- a/invesalius/reader/dicom_reader.py
+++ b/invesalius/reader/dicom_reader.py
@@ -87,11 +87,11 @@ def _is_valid_dicom(filepath):
     """
     Check if a file is a valid DICOM file.
     Handles filenames with spaces and parentheses.
-    
+
     Parameters:
     -----------
     filepath (str): Path to the file to check.
-    
+
     Returns:
     --------
     bool: True if the file is likely a DICOM file, False otherwise.
@@ -101,11 +101,11 @@ def _is_valid_dicom(filepath):
         if not os.path.isfile(filepath):
             print(f"File does not exist: {filepath}")
             return False
-            
+
         # Check file extension - be very permissive
         file_extension = os.path.splitext(filepath)[1].lower()
-        valid_extensions = ('.dcm', '.dicom', '.dic', '.acr', '', '.ima', '.img')
-        
+        valid_extensions = (".dcm", ".dicom", ".dic", ".acr", "", ".ima", ".img")
+
         # For files with parentheses or special characters, be more permissive
         if file_extension not in valid_extensions:
             if ".dcm" in filepath.lower() or "dicom" in filepath.lower():
@@ -121,16 +121,20 @@ def _is_valid_dicom(filepath):
                         print(f"File has DICOM patterns in header: {filepath}")
                         # Continue processing
                     else:
-                        print(f"Skipping file with invalid extension: {filepath} (extension: {file_extension})")
+                        print(
+                            f"Skipping file with invalid extension: {filepath} (extension: {file_extension})"
+                        )
                         return False
-                
+
         # Try to read the file using GDCM, handling all possible encoding issues
         reader = gdcm.ImageReader()
         try:
             # For Windows paths with spaces and special characters
             if _has_win32api:
                 try:
-                    reader.SetFileName(utils.encode(win32api.GetShortPathName(filepath), const.FS_ENCODE))
+                    reader.SetFileName(
+                        utils.encode(win32api.GetShortPathName(filepath), const.FS_ENCODE)
+                    )
                 except Exception as e:
                     print(f"Win32 path error, trying alternative: {str(e)}")
                     try:
@@ -139,18 +143,24 @@ def _is_valid_dicom(filepath):
                     except:
                         # Last resort, try raw bytes
                         if isinstance(filepath, str):
-                            reader.SetFileName(filepath.encode('utf-8'))
+                            reader.SetFileName(filepath.encode("utf-8"))
                         else:
                             reader.SetFileName(filepath)
             else:
                 # For non-Windows systems
                 try:
-                    reader.SetFileName(utils.encode(filepath, const.FS_ENCODE) if isinstance(filepath, str) else filepath)
+                    reader.SetFileName(
+                        utils.encode(filepath, const.FS_ENCODE)
+                        if isinstance(filepath, str)
+                        else filepath
+                    )
                 except Exception as e:
                     print(f"Path encoding error, trying alternative: {str(e)}")
                     # Direct path setting
-                    reader.SetFileName(filepath if isinstance(filepath, str) else filepath.decode('utf-8'))
-            
+                    reader.SetFileName(
+                        filepath if isinstance(filepath, str) else filepath.decode("utf-8")
+                    )
+
             if reader.Read():
                 print(f"GDCM successfully read DICOM file: {filepath}")
                 return True
@@ -158,7 +168,7 @@ def _is_valid_dicom(filepath):
                 print(f"GDCM cannot read file as DICOM: {filepath}")
         except Exception as e:
             print(f"GDCM error: {str(e)} - trying manual checks")
-            
+
         # Manual method as fallback
         try:
             with open(filepath, "rb") as f:
@@ -167,25 +177,35 @@ def _is_valid_dicom(filepath):
                 if f.read(4) == b"DICM":
                     print(f"Found DICM magic bytes: {filepath}")
                     return True
-                
+
                 # Some DICOMs don't have the magic bytes, check for common group numbers
                 f.seek(0)
                 header = f.read(16)
                 # Check group numbers (both endianness)
-                groups = [b"\x02\x00", b"\x00\x02", b"\x08\x00", b"\x00\x08", 
-                          b"\x10\x00", b"\x00\x10", b"\x20\x00", b"\x00\x20"]
+                groups = [
+                    b"\x02\x00",
+                    b"\x00\x02",
+                    b"\x08\x00",
+                    b"\x00\x08",
+                    b"\x10\x00",
+                    b"\x00\x10",
+                    b"\x20\x00",
+                    b"\x00\x20",
+                ]
                 if any(header.startswith(g) for g in groups):
                     print(f"Found DICOM group at start: {filepath}")
                     return True
-                
+
                 # Last try - assume it's DICOM if filename looks like it
                 filename = os.path.basename(filepath).lower()
-                if any(pattern in filename for pattern in ["dicom", "dcm", "ct", "mri", "xray", "scan"]):
+                if any(
+                    pattern in filename for pattern in ["dicom", "dcm", "ct", "mri", "xray", "scan"]
+                ):
                     print(f"Assuming DICOM from filename: {filepath}")
                     return True
         except Exception as e:
             print(f"Manual check error: {str(e)} for {filepath}")
-            
+
         print(f"Not a recognized DICOM file: {filepath}")
         return False
     except Exception as e:
@@ -431,6 +451,7 @@ class ProgressDicomReader:
             # Set temporary project status to prevent "Please import image first" message
             import invesalius.constants as const
             import invesalius.session as ses
+
             session = ses.Session()
             # Only set to new when it was previously closed
             if session.GetConfig("project_status") == const.PROJECT_STATUS_CLOSED:


### PR DESCRIPTION
# Fix "Please import image first" message after successful DICOM import

## Problem
When DICOM files are successfully loaded in the import panel, clicking on navigation buttons causes an error message "Please import image first" to appear, even though the DICOM data has been properly loaded.

## Solution
This PR updates the project status after DICOM files are successfully loaded to prevent the error message from appearing. When valid DICOM groups are loaded, the project status is set to `PROJECT_STATUS_NEW` instead of remaining as `PROJECT_STATUS_CLOSED`.

## Changes
- Modified the `EndLoadFile` method in `ProgressDicomReader` to update the project status when valid DICOM data is loaded

## Testing
1. Load DICOM files from a directory
2. Verify no "Please import image first" message appears when clicking on navigation buttons
3. Ensure normal DICOM import workflow functions properly

![ljnjl](https://github.com/user-attachments/assets/35b7e68e-cafb-4442-b32f-6017671f09c5)
