### PR TITLE
Fix: UI glitch before progress bar starts in Brain Segmentation dialog 

### DIFF
--- a/invesalius/gui/deep_learning_seg_dialog.py
+++ b/invesalius/gui/deep_learning_seg_dialog.py
@@ -377,6 +377,7 @@ class DeepLearningSegmenterDialog(wx.Dialog):
         self.lbl_time.Show()
         self.main_sizer.Fit(self)
         self.main_sizer.SetSizeHints(self)
+        self.Update()
 
 
 class BrainSegmenterDialog(DeepLearningSegmenterDialog):


### PR DESCRIPTION
Fixes #975 

Made a small fix to properly update and show the progress bar after `Segment` is clicked by adding `self.Update()` at the end of `ShowProgress()`