### PR TITLE
[ Fix ]  AttributeError in GoToDialogScannerCoord scanner coordinate navigation

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6346,6 +6346,9 @@ class GoToDialogScannerCoord(wx.Dialog):
         self.goto_sagital = wx.TextCtrl(self, size=(50, -1))
         self.goto_coronal = wx.TextCtrl(self, size=(50, -1))
         self.goto_axial = wx.TextCtrl(self, size=(50, -1))
+        
+        # Initialize result attribute
+        self.result = None
 
         btn_ok = wx.Button(self, wx.ID_OK)
         btn_ok.SetHelpText("")
@@ -6392,7 +6395,8 @@ class GoToDialogScannerCoord(wx.Dialog):
         Publisher.subscribe(self.SetNewFocalPoint, "Cross focal point")
 
     def SetNewFocalPoint(self, coord, spacing):
-        Publisher.sendMessage("Update cross pos", coord=self.result * spacing)
+        if self.result is not None:
+            Publisher.sendMessage("Update cross pos", coord=self.result * spacing)
 
     def OnOk(self, evt: wx.CommandEvent) -> None:
         import invesalius.data.slice_ as slc

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6346,7 +6346,7 @@ class GoToDialogScannerCoord(wx.Dialog):
         self.goto_sagital = wx.TextCtrl(self, size=(50, -1))
         self.goto_coronal = wx.TextCtrl(self, size=(50, -1))
         self.goto_axial = wx.TextCtrl(self, size=(50, -1))
-        
+
         # Initialize result attribute
         self.result = None
 


### PR DESCRIPTION
Fixes an AttributeError that occurs when using the scanner coordinate navigation dialog. The error happens because the `result` attribute is accessed in SetNewFocalPoint `(edit > go to slice / go to scanner coord..)` before it's initialized.✅


![dfffff](https://github.com/user-attachments/assets/194a5131-ccc8-4eb2-9c06-4c8376d29cd0)



⛑️Changes:
- Initialize `result` attribute to None in _init_gui method
- Add null check before using result in SetNewFocalPoint

This prevents the "AttributeError: 'GoToDialogScannerCoord' object has no attribute 'result'" error while maintaining the existing functionality.

