### PR TITLE
FIX: verify project status before "Move to head model page"

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -556,7 +556,7 @@ class ImportsPage(wx.Panel):
             Publisher.sendMessage("Open recent project", filepath=path)
         else:
             Publisher.sendMessage("Show open project dialog")
-        Publisher.sendMessage("Move to head model page")
+        self.OnMoveToHeadModelPage()
 
     def OnLinkImport(self, event):
         self.ImportDicom()
@@ -564,7 +564,7 @@ class ImportsPage(wx.Panel):
 
     def ImportDicom(self):
         Publisher.sendMessage("Show import directory dialog")
-        Publisher.sendMessage("Move to head model page")
+        self.OnMoveToHeadModelPage()
 
     def OnLinkImportNifti(self, event):
         self.ImportNifti()
@@ -572,7 +572,13 @@ class ImportsPage(wx.Panel):
 
     def ImportNifti(self):
         Publisher.sendMessage("Show import other files dialog", id_type=const.ID_NIFTI_IMPORT)
-        Publisher.sendMessage("Move to head model page")
+        self.OnMoveToHeadModelPage()
+
+    def OnMoveToHeadModelPage(self):
+        session = ses.Session()
+        project_status = session.GetConfig("project_status")
+        if project_status != const.PROJECT_STATUS_CLOSED:
+            Publisher.sendMessage("Move to head model page")
 
     def OnButton(self, evt):
         id = evt.GetId()


### PR DESCRIPTION
Fix issue #986. When importing a NIfTI file or loading a project, the view automatically switches to the head model page. Fix the issue when the import is canceled.

- Pending: The automatic switch is not yet implemented for DICOM imports.
- TODO: Apply the same automatic page switch for DICOM imports.
- Note: Not urgent, as NIfTI is the primary format used in NeuroNav.