### PR TITLE
Fix GoToDialogScannerCoord: World-to-Voxel Conversion and Coil Target Creation

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6081,7 +6081,7 @@ class BrainSurfaceLoadingProgressWindow:
 
 class SurfaceSmoothingProgressWindow:
     def __init__(self):
-        title = "InVesalius 3"
+        title = "InVesalius 3 – Creating TMS Coil Target"
         message = _("Smoothing the surface...")
         style = wx.PD_APP_MODAL | wx.PD_CAN_ABORT
         parent = wx.GetApp().GetTopWindow()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2845,6 +2845,8 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         Publisher.subscribe(self.CreateMarkerEfield, "Create Marker from tangential")
         Publisher.subscribe(self.UpdateCortexMarker, "Update Cortex Marker")
 
+        Publisher.subscribe(self.CreateCoilTargetFromLandmark, "Create coil target from landmark")
+
         # Update main_coil combobox
         Publisher.subscribe(self.UpdateMainCoilCombobox, "Coil selection done")
 
@@ -3379,7 +3381,12 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         marker = self.__get_marker(idx)
         Publisher.sendMessage("Set camera to focus on marker", marker=marker)
 
-    def OnCreateCoilTargetFromLandmark(self, evt):
+    def CreateCoilTargetFromLandmark(self, index=None):
+        if index:
+            self.FocusOnMarker(index)
+        self.OnCreateCoilTargetFromLandmark()
+
+    def OnCreateCoilTargetFromLandmark(self, evt=None):
         list_index = self.marker_list_ctrl.GetFocusedItem()
         if list_index == -1:
             wx.MessageBox(_("No data selected."), _("InVesalius 3"))


### PR DESCRIPTION
- Fixes coordinate transformation using img_utils.convert_world_to_voxel, ensuring correct conversion from scanner/world coordinates to voxel space.

- Adds support for coil target creation by publishing a "Create coil target from landmark" message via pubsub, allowing integration with targeting workflows.