### PR TITLE
fix: add missing imports to `volume_mask.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,24 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+# files in which the hooks will be applied
+files: |
+    (?x)^(
+        invesalius/.*/.*py
+        | setup.py
+        | app.py
+        | typings/.*/.*pyi
+    )$
+
 repos:
--   repo: https://github.com/astral-sh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.5
+    rev: v0.11.9
     hooks:
-        # Run the linter.
-        - id: ruff
-          name: sort-imports
-          args: ["check", "--select", "I", "--fix"]
-        # Run the formatter.
-        - id: ruff-format
+      - id: ruff
+        args: [ --fix ]
+        types_or: [python, pyi, jupyter]
+      - id: ruff-format
+        types_or: [ python, pyi, jupyter ]
+
+

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -20,9 +20,7 @@ import os
 import plistlib
 import weakref
 
-from packaging.version import Version
 from vtkmodules.util import numpy_support
-from vtkmodules.vtkCommonCore import vtkVersion
 from vtkmodules.vtkCommonDataModel import vtkPiecewiseFunction, vtkPlane
 from vtkmodules.vtkFiltersSources import vtkPlaneSource
 from vtkmodules.vtkImagingCore import vtkImageFlip, vtkImageShiftScale
@@ -38,7 +36,6 @@ from vtkmodules.vtkRenderingCore import (
 )
 from vtkmodules.vtkRenderingVolume import (
     vtkFixedPointVolumeRayCastMapper,
-    vtkGPUVolumeRayCastMapper,
 )
 from vtkmodules.vtkRenderingVolumeOpenGL2 import vtkOpenGLGPUVolumeRayCastMapper
 

--- a/invesalius/data/volume_mask.py
+++ b/invesalius/data/volume_mask.py
@@ -16,6 +16,8 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+from packaging.version import Version
+from vtkmodules.vtkCommonCore import vtkVersion
 from vtkmodules.vtkCommonDataModel import vtkPiecewiseFunction
 from vtkmodules.vtkImagingCore import vtkImageFlip
 from vtkmodules.vtkRenderingCore import (


### PR DESCRIPTION
- Closes #1017 

Fast fix adding the missing imports.

I went looking in the pre-commit because of this bug and it seems quite out-dated (and only capturing import order or formatting). I think linting errors are more important and should be there as well.