### PR TITLE
Fix: 3D surface name change in data panel.

### DIFF
--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1586,7 +1586,7 @@ class SurfacesListCtrlPanel(InvListCtrl):
     def OnEditLabel(self, evt):
         if not evt.IsEditCancelled():
             index = evt.GetIndex()
-            self.SetItem(index, 1, evt.GetLabel())
+            self.SetItem(index, 2, evt.GetLabel())
             Publisher.sendMessage("Change surface name", index=evt.GetIndex(), name=evt.GetLabel())
         evt.Skip()
 


### PR DESCRIPTION
Fixes #1039

Previously `SetItem` method was targeting column=1 ( which is color picker). 
Now it targets column =2 ( where the surface name actually is present)