### PR TITLE
Fix: bare except clause in navigation/image.py LoadState error handling

### DIFF
--- a/invesalius/navigation/image.py
+++ b/invesalius/navigation/image.py
@@ -136,7 +136,7 @@ class Image:
                 self.load_from_state = False
                 try:
                     self.LoadState()
-                except:
+                except (IOError, OSError, ValueError, KeyError) as e:
                     ses.Session.DeleteStateFile()
                     self.LoadProject()  # Load project if failed to load from state
             else:


### PR DESCRIPTION
### Summary
Replaces bare `except:` clause with specific exception types in `invesalius/navigation/image.py` to improve error handling and follow Python best practices.

### Changes
- Changed bare `except:` to `except (IOError, OSError, ValueError, KeyError) as e:` at line 139
- This prevents catching system-level exceptions like `KeyboardInterrupt` and `SystemExit`

### Why This Change?
The bare except clause can accidentally suppress critical system signals and make debugging harder. By specifying exact exception types, we ensure only expected file/state loading errors are caught, while allowing important exceptions to propagate correctly.

### Related Issue
Fixes #1052