### PR TITLE
Refactor nightly build workflow: add release cleanup

### DIFF
--- a/.github/workflows/bundles.yml
+++ b/.github/workflows/bundles.yml
@@ -4,121 +4,137 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - release  # For testing workflow changes
 
 jobs:
+  # Delete existing nightly release first to avoid conflicts
+  cleanup-nightly:
+    name: cleanup previous nightly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete previous nightly release
+        run: |
+          gh release view nightly >/dev/null 2>&1 && \
+          gh release delete nightly --yes --cleanup-tag || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-win:
-      name: build windows packages
-      runs-on: windows-2022
-      strategy:
-        matrix:
-          architecture: ["x64"]
-          ai_ready: [1]
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            submodules: true
-  
-        - name: Put current date into a variable
-          run: |
-            $DATE=& Get-Date -format yyyy-MM-dd
-            echo "DATE=$DATE" >> $env:GITHUB_ENV
-  
-        - name: Put current commit hash in a variable
-          run: |
-            $COMMIT=$(git rev-parse HEAD)
-            echo "COMMIT=$COMMIT" >> $env:GITHUB_ENV
-  
-        - uses: astral-sh/setup-uv@v5
-          with:
-            python-version: 3.12
-            enable-cache: true
-            cache-dependency-glob: "uv.lock"
-  
-        - name: install venv and sync dependencies
-          run: |
-            uv sync --all-extras
-  
-        - name: Get InVesalius version
-          run: |
-            $INVESALIUS_VERSION=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('invesalius'))")
-            echo "INVESALIUS_VERSION=$INVESALIUS_VERSION" >> $env:GITHUB_ENV
-  
-        - name: copy .pyd files to invesalius_cy
-          run: Copy-Item -Path invesalius_cy\Release\* -Destination invesalius_cy -Recurse -Force
-  
-        - name: Download mandible ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-          with:
-            url: "https://raw.githubusercontent.com/invesalius/weights/main/mandible_ct/mandible_jit_ct.pt"
-            target: ./ai/mandible_jit_ct/
-        - name: Download cranioplasty binary ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-          with:
-            url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt"
-            target: ./ai/cranioplasty_jit_ct_binary/
-        - name: Download cranioplasty gray ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-          with:
-            url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt"
-            target: ./ai/cranioplasty_jit_ct_gray/
-        - name: Download trachea ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-          with:
-            url: "https://github.com/tfmoraes/deep_trachea_torch/releases/download/v1.0/weights.pt"
-            target: ./ai/trachea_ct/
-        - name: Fix trachea name ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          run: move ./ai/trachea_ct/weights.pt ./ai/trachea_ct/trachea_ct.pt
-        - name: Download brain ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-          with:
-            url: "https://github.com/tfmoraes/deepbrain_torch/releases/download/v1.1.0/weights.pt"
-            target: ./ai/brain_mri_t1/
-        - name: Fix brain name ai weight
-          if: ${{ matrix.ai_ready == 1 }}
-          run: move ./ai/brain_mri_t1/weights.pt ./ai/brain_mri_t1/brain_mri_t1.pt
-  
-        - name: Generate InVesalius .exe file
-          run: |
-            cp ./bundle_tools/win/app.spec ./  
-            uv run pyinstaller app.spec --clean --noconfirm
-            mkdir installer
-  
-        - name: Generate InVesalius installer - win64 ai-ready build
-          run: ISCC.exe /Oinstaller /F"invesalius-3.1_nightly_ai-ready_win64" /DMyAppVersion=${{ env.INVESALIUS_VERSION }} ./bundle_tools/win/generate_installer.iss
-  
-        - name: Upload artifact of package ai-ready file
-          if: ${{ matrix.ai_ready == 1 }}
-          uses: actions/upload-artifact@v4
-          with:
-            overwrite: true
-            name: invesalius_package_exe_ai-ready
-            retention-days: 2
-            path: ./installer/*.exe
-            
-        - name: Delete previous nightly release
-          run: |
-            gh release view nightly *> $null
-            if ($LASTEXITCODE -eq 0) {
-              gh release delete nightly --yes --cleanup-tag
-            } else {
-              echo "There is no nightly release, nothing to delete."
-              $global:LASTEXITCODE = 0
-            }
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    name: build windows packages
+    needs: [cleanup-nightly]
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: ["x64"]
+        ai_ready: [1]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Put current date into a variable
+        run: |
+          $DATE=& Get-Date -format yyyy-MM-dd
+          echo "DATE=$DATE" >> $env:GITHUB_ENV
+
+      - name: Put current commit hash in a variable
+        run: |
+          $COMMIT=$(git rev-parse HEAD)
+          echo "COMMIT=$COMMIT" >> $env:GITHUB_ENV
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: 3.12
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: install venv and sync dependencies
+        run: |
+          uv sync --all-extras
+
+      - name: Get InVesalius version
+        run: |
+          $INVESALIUS_VERSION=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('invesalius'))")
+          echo "INVESALIUS_VERSION=$INVESALIUS_VERSION" >> $env:GITHUB_ENV
+
+      - name: copy .pyd files to invesalius_cy
+        run: Copy-Item -Path invesalius_cy\Release\* -Destination invesalius_cy -Recurse -Force
+
+      # Cache AI weights to speed up builds
+      - name: Cache AI weights
+        if: ${{ matrix.ai_ready == 1 }}
+        id: cache-ai-weights
+        uses: actions/cache@v4
+        with:
+          path: ./ai/
+          key: ai-weights-v1
+
+      - name: Download mandible ai weight
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/mandible_jit_ct/
+          curl -L -o ./ai/mandible_jit_ct/mandible_jit_ct.pt "https://raw.githubusercontent.com/invesalius/weights/main/mandible_ct/mandible_jit_ct.pt"
+
+      - name: Download cranioplasty binary ai weight
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/cranioplasty_jit_ct_binary/
+          curl -L -o ./ai/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt"
+
+      - name: Download cranioplasty gray ai weight
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/cranioplasty_jit_ct_gray/
+          curl -L -o ./ai/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt"
+
+      - name: Download trachea ai weight
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/trachea_ct/
+          curl -L -o ./ai/trachea_ct/trachea_ct.pt "https://github.com/tfmoraes/deep_trachea_torch/releases/download/v1.0/weights.pt"
+
+      - name: Download brain ai weight
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/brain_mri_t1/
+          curl -L -o ./ai/brain_mri_t1/brain_mri_t1.pt "https://github.com/tfmoraes/deepbrain_torch/releases/download/v1.1.0/weights.pt"
+
+      - name: Generate InVesalius .exe file
+        run: |
+          cp ./bundle_tools/win/app.spec ./  
+          uv run pyinstaller app.spec --clean --noconfirm
+          mkdir installer
+
+      - name: Generate InVesalius installer - win64 ai-ready build
+        run: ISCC.exe /Oinstaller /F"invesalius-${{ env.INVESALIUS_VERSION }}_nightly_ai-ready_win64" /DMyAppVersion=${{ env.INVESALIUS_VERSION }} ./bundle_tools/win/generate_installer.iss
+
+      - name: Upload artifact of package ai-ready file
+        if: ${{ matrix.ai_ready == 1 }}
+        uses: actions/upload-artifact@v4
+        with:
+          overwrite: true
+          name: invesalius_package_exe_ai-ready
+          retention-days: 2
+          path: ./installer/*.exe
+
   build-mac:
     name: build mac packages
-    runs-on: macos-14
+    needs: [cleanup-nightly]
     strategy:
+      fail-fast: false
       matrix:
-        architecture: ["arm64", "x86_64"]
+        include:
+          - os: macos-14
+            architecture: arm64
+          - os: macos-13
+            architecture: x86_64
         ai_ready: [1]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,45 +166,49 @@ jobs:
           echo "INVESALIUS_VERSION=$INVESALIUS_VERSION" >> $GITHUB_ENV
 
       - name: copy .so files to invesalius_cy
-        run: cp invesalius_cy/Release/* invesalius_cy/ || true
+        run: |
+          if [ -d "invesalius_cy/Release" ]; then
+            cp invesalius_cy/Release/* invesalius_cy/
+          fi
 
-      # AI weights download steps (same as before)
+      # Cache AI weights to speed up builds
+      - name: Cache AI weights
+        if: ${{ matrix.ai_ready == 1 }}
+        id: cache-ai-weights
+        uses: actions/cache@v4
+        with:
+          path: ./ai/
+          key: ai-weights-v1
+
       - name: Download mandible ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-        with:
-          url: "https://raw.githubusercontent.com/invesalius/weights/main/mandible_ct/mandible_jit_ct.pt"
-          target: ./ai/mandible_jit_ct/
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/mandible_jit_ct/
+          curl -L -o ./ai/mandible_jit_ct/mandible_jit_ct.pt "https://raw.githubusercontent.com/invesalius/weights/main/mandible_ct/mandible_jit_ct.pt"
+
       - name: Download cranioplasty binary ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-        with:
-          url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt"
-          target: ./ai/cranioplasty_jit_ct_binary/
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/cranioplasty_jit_ct_binary/
+          curl -L -o ./ai/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_binary/cranioplasty_jit_ct_binary.pt"
+
       - name: Download cranioplasty gray ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-        with:
-          url: "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt"
-          target: ./ai/cranioplasty_jit_ct_gray/
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/cranioplasty_jit_ct_gray/
+          curl -L -o ./ai/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt "https://raw.githubusercontent.com/invesalius/weights/main/cranioplasty_jit_ct_gray/cranioplasty_jit_ct_gray.pt"
+
       - name: Download trachea ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-        with:
-          url: "https://github.com/tfmoraes/deep_trachea_torch/releases/download/v1.0/weights.pt"
-          target: ./ai/trachea_ct/
-      - name: Fix trachea name ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        run: mv ./ai/trachea_ct/weights.pt ./ai/trachea_ct/trachea_ct.pt
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/trachea_ct/
+          curl -L -o ./ai/trachea_ct/trachea_ct.pt "https://github.com/tfmoraes/deep_trachea_torch/releases/download/v1.0/weights.pt"
+
       - name: Download brain ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9
-        with:
-          url: "https://github.com/tfmoraes/deepbrain_torch/releases/download/v1.1.0/weights.pt"
-          target: ./ai/brain_mri_t1/
-      - name: Fix brain name ai weight
-        if: ${{ matrix.ai_ready == 1 }}
-        run: mv ./ai/brain_mri_t1/weights.pt ./ai/brain_mri_t1/brain_mri_t1.pt
+        if: ${{ matrix.ai_ready == 1 && steps.cache-ai-weights.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ./ai/brain_mri_t1/
+          curl -L -o ./ai/brain_mri_t1/brain_mri_t1.pt "https://github.com/tfmoraes/deepbrain_torch/releases/download/v1.1.0/weights.pt"
 
       - name: Generate InVesalius .app bundle
         run: |
@@ -203,10 +223,14 @@ jobs:
       - name: Create DMG
         run: |
           npm install --global create-dmg
-          create-dmg "dist/InVesalius 3.1.app"  || true
-          ls
-          mv InVesalius\ 3.1\ 3.1.dmg InVesalius_${{matrix.architecture}}.dmg
-          
+          create-dmg "dist/InVesalius 3.1.app" || true
+          # Verify DMG was created
+          DMG_FILE=$(ls -1 *.dmg 2>/dev/null | head -n1)
+          if [ -z "$DMG_FILE" ]; then
+            echo "Error: DMG file was not created!"
+            exit 1
+          fi
+          mv "$DMG_FILE" "InVesalius_${{ env.INVESALIUS_VERSION }}_${{ matrix.architecture }}.dmg"
 
       - name: Upload artifact of package ai-ready file
         if: ${{ matrix.ai_ready == 1 }}
@@ -216,8 +240,6 @@ jobs:
           name: invesalius_package_app_ai-ready_${{ matrix.architecture }}
           retention-days: 2
           path: ./*.dmg
-
-  
 
   publish_packages:
     name: publish packages
@@ -232,7 +254,6 @@ jobs:
 
       - name: Show collected files
         run: ls -lh
-        
 
       - name: Update Nightly Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

resolves #1059 

This PR refactors the nightly build GitHub Actions workflow to make it more reliable, faster, and safer across platforms. The changes focus on improving CI robustness, eliminating race conditions, and standardizing AI weight handling for nightly releases.

---

## Key Changes

- Added a dedicated **cleanup job** to safely remove the previous `nightly` release before new builds start
- Introduced **concurrency control** to prevent overlapping nightly runs
- Fixed **macOS runner selection** by correctly splitting Apple Silicon (`macos-14`) and Intel (`macos-13`) builds
- Added **AI weight caching** using `actions/cache` to significantly reduce build time
- Replaced third-party download actions with native `curl` for improved security and transparency
- Improved DMG creation robustness with explicit verification and safer file handling
- Standardized versioned artifact naming using the detected InVesalius package version

---

## Motivation

The previous workflow was functional but had several reliability and maintainability issues:

- Nightly builds could overlap and conflict
- macOS Intel builds were running on unsupported runners
- AI weights were downloaded repeatedly, slowing down CI
- Release deletion logic was platform-specific and coupled to build steps
- External download actions increased supply-chain risk

This refactor addresses these issues while keeping the build logic unchanged.

---

## Impact

-  Faster nightly builds (cached AI weights)
-  Correct macOS ARM/Intel binaries
-  Deterministic, race-free nightly releases
-  Cleaner CI logs and simpler maintenance
-  Improved security posture (fewer third-party actions)

---

## Notes

No application runtime behavior is changed.  
This PR only affects CI/CD infrastructure for nightly builds.

