### PR TITLE
Fix: Prevent crash when cancelling language dialog on first run

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,7 +171,8 @@ class Inv3SplashScreen(SplashScreen):
                 else:
                     homedir = os.path.expanduser("~")
                     config_dir = os.path.join(homedir, ".invesalius")
-                    shutil.rmtree(config_dir)
+                    if os.path.exists(config_dir):
+                        shutil.rmtree(config_dir)
 
                     sys.exit()
 


### PR DESCRIPTION
## Description
Fixes #1064 
This PR addresses a crash that occurs when users cancel the Language Selection dialog during the first run of InVesalius.
## Problem
When running InVesalius for the first time (no existing configuration), a Language Selection dialog is displayed. If the user cancels this dialog or closes the window, the application crashes with:
The crash occurred because the code attempted to remove the `.invesalius` configuration directory that was never created.
## Solution
Added an existence check (`os.path.exists()`) before attempting to remove the configuration directory in [app.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/app.py:0:0-0:0) .
## Changes
- **File Modified:** [app.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/app.py:0:0-0:0)
- **Lines Changed:** 174-175
- **Change:** Added `if os.path.exists(config_dir):` before `shutil.rmtree(config_dir)`
