### PR TITLE
Fix #878: Close menu bar when window loses focus on macOS

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -217,12 +217,12 @@ class Frame(wx.Frame):
                 # This ensures menus don't hang on screen when switching windows
                 try:
                     # Attempt to close any popup menus
-                    if hasattr(menu_bar, 'Dismiss'):
+                    if hasattr(menu_bar, "Dismiss"):
                         menu_bar.Dismiss()
                 except AttributeError:
                     # Dismiss method may not be available on all platforms
                     pass
-        
+
         # Always propagate the event
         event.Skip()
 


### PR DESCRIPTION
## Description
Fixes #878 - Menu opened from menu bar doesn't close when minimising/switching tabs

## Problem
On macOS, when a user opens a menu from the menu bar and then switches to another application or minimizes the window, the menu would stay visible as a "hanging" or "ghost" menu on screen.

## Solution
- Added `wx.EVT_ACTIVATE` event handler to detect window activation changes
- Implemented [OnWindowActivate()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/frame.py:207:4-231:20) method to dismiss open menus when window is deactivated
- Platform-safe implementation with graceful fallback

## Changes
- Modified: [invesalius/gui/frame.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/frame.py:0:0-0:0)
  - Added event binding for `EVT_ACTIVATE`.
  - Implemented [OnWindowActivate()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/frame.py:207:4-231:20) handler.