### PR TITLE
Fix: Language-related crashes in startup and DICOM import

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -185,13 +185,13 @@ CROP_PAN = 13
 SLICE_COLOR_TABLE: Dict[
     str, Tuple[Optional[int], Tuple[int, int], Tuple[float, float], Tuple[int, int]]
 ] = {
-    _("Default "): (None, (0, 0), (0, 0), (0, 1)),
-    _("Hue"): (None, (1, 1), (0, 1), (1, 1)),
-    _("Saturation"): (None, (0, 1), (0.6, 0.6), (1, 1)),
-    _("Desert"): (256, (1, 1), (0, 0.1), (1, 1)),
-    _("Rainbow"): (256, (1, 1), (0, 0.8), (1, 1)),
-    _("Ocean"): (256, (1, 1), (0.667, 0.5), (1, 1)),
-    _("Inverse Gray"): (256, (0, 0), (0, 0), (1, 0)),
+    "Default ": (None, (0, 0), (0, 0), (0, 1)),
+    "Hue": (None, (1, 1), (0, 1), (1, 1)),
+    "Saturation": (None, (0, 1), (0.6, 0.6), (1, 1)),
+    "Desert": (256, (1, 1), (0, 0.1), (1, 1)),
+    "Rainbow": (256, (1, 1), (0, 0.8), (1, 1)),
+    "Ocean": (256, (1, 1), (0.667, 0.5), (1, 1)),
+    "Inverse Gray": (256, (0, 0), (0, 0), (1, 0)),
 }
 
 # Colors for errors and positives
@@ -281,7 +281,7 @@ VOLUME_POSITION = {
 # proj = Project()
 # THRESHOLD_RANGE = proj.threshold_modes[_("Bone")]
 THRESHOLD_RANGE = [0, 3033]
-THRESHOLD_PRESETS_INDEX = _("Bone")
+THRESHOLD_PRESETS_INDEX = "Bone"
 THRESHOLD_HUE_RANGE = (0, 0.6667)
 THRESHOLD_INVALUE = 5000
 THRESHOLD_OUTVALUE = 0
@@ -355,10 +355,10 @@ BRUSH_MAX_SIZE = 100
 # 2: smooth_relaxation_factor
 # 3: decimate_reduction
 SURFACE_QUALITY = {
-    _("Low"): (3, 2, 0.3000, 0.4),
-    _("Medium"): (2, 2, 0.3000, 0.4),
-    _("High"): (0, 1, 0.3000, 0.1),
-    _("Optimal *"): (0, 2, 0.3000, 0.4),
+    "Low": (3, 2, 0.3000, 0.4),
+    "Medium": (2, 2, 0.3000, 0.4),
+    "High": (0, 1, 0.3000, 0.1),
+    "Optimal *": (0, 2, 0.3000, 0.4),
 }
 DEFAULT_SURFACE_QUALITY = _("Optimal *")
 SURFACE_QUALITY_LIST = [_("Low"), _("Medium"), _("High"), _("Optimal *")]
@@ -375,25 +375,25 @@ SURFACE_SPACE_CHOICES = [_("world/scanner space"), _("InVesalius space")]
 
 # Imagedata - window and level presets
 WINDOW_LEVEL: Dict[str, Union[Tuple[int, int], Tuple[None, None]]] = {
-    _("Abdomen"): (350, 50),
-    _("Bone"): (2000, 300),
-    _("Brain posterior fossa"): (120, 40),
-    _("Brain"): (80, 40),
-    _("Default"): (None, None),  # Control class set window and level from DICOM
-    _("Emphysema"): (500, -850),
-    _("Ischemia - Hard, non contrast"): (15, 32),
-    _("Ischemia - Soft, non contrast"): (80, 20),
-    _("Larynx"): (180, 80),
-    _("Liver"): (2000, -500),
-    _("Lung - Soft"): (1600, -600),
-    _("Lung - Hard"): (1000, -600),
-    _("Mediastinum"): (350, 25),
-    _("Manual"): (None, None),  # Case the user change window and level
-    _("Pelvis"): (450, 50),
-    _("Sinus"): (4000, 400),
-    _("Vasculature - Hard"): (240, 80),
-    _("Vasculature - Soft"): (650, 160),
-    _("Contour"): (255, 127),
+    "Abdomen": (350, 50),
+    "Bone": (2000, 300),
+    "Brain posterior fossa": (120, 40),
+    "Brain": (80, 40),
+    "Default": (None, None),  # Control class set window and level from DICOM
+    "Emphysema": (500, -850),
+    "Ischemia - Hard, non contrast": (15, 32),
+    "Ischemia - Soft, non contrast": (80, 20),
+    "Larynx": (180, 80),
+    "Liver": (2000, -500),
+    "Lung - Soft": (1600, -600),
+    "Lung - Hard": (1000, -600),
+    "Mediastinum": (350, 25),
+    "Manual": (None, None),  # Case the user change window and level
+    "Pelvis": (450, 50),
+    "Sinus": (4000, 400),
+    "Vasculature - Hard": (240, 80),
+    "Vasculature - Soft": (650, 160),
+    "Contour": (255, 127),
 }
 
 REDUCE_IMAGEDATA_QUALITY = 0

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -604,10 +604,10 @@ class Controller:
 
         const.THRESHOLD_OUTVALUE = proj.threshold_range[0]
         const.THRESHOLD_INVALUE = proj.threshold_range[1]
-        const.THRESHOLD_RANGE = proj.threshold_modes[_("Bone")]
+        const.THRESHOLD_RANGE = proj.threshold_modes["Bone"]
 
-        const.WINDOW_LEVEL[_("Default")] = (proj.window, proj.level)
-        const.WINDOW_LEVEL[_("Manual")] = (proj.window, proj.level)
+        const.WINDOW_LEVEL["Default"] = (proj.window, proj.level)
+        const.WINDOW_LEVEL["Manual"] = (proj.window, proj.level)
 
         self.Slice = sl.Slice()
         self.Slice.spacing = proj.spacing

--- a/invesalius/gui/bitmap_preview_panel.py
+++ b/invesalius/gui/bitmap_preview_panel.py
@@ -439,8 +439,8 @@ class SingleImagePreview(wx.Panel):
         self.dicom_list = []
         self.nimages = 1
         self.current_index = 0
-        self.window_width = const.WINDOW_LEVEL[_("Bone")][0]
-        self.window_level = const.WINDOW_LEVEL[_("Bone")][1]
+        self.window_width = const.WINDOW_LEVEL["Bone"][0]
+        self.window_level = const.WINDOW_LEVEL["Bone"][1]
 
     def __init_vtk(self):
         text_image_size = vtku.TextZero()

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -715,8 +715,8 @@ class SingleImagePreview(wx.Panel):
         self.dicom_list = []
         self.nimages = 1
         self.current_index = 0
-        self.window_width = const.WINDOW_LEVEL[_("Bone")][0]
-        self.window_level = const.WINDOW_LEVEL[_("Bone")][1]
+        self.window_width = const.WINDOW_LEVEL["Bone"][0]
+        self.window_level = const.WINDOW_LEVEL["Bone"][1]
 
     def __init_vtk(self):
         text_image_size = vtku.TextZero()

--- a/invesalius/gui/widgets/slice_menu.py
+++ b/invesalius/gui/widgets/slice_menu.py
@@ -50,6 +50,8 @@ class SliceMenu(wx.Menu):
         self.ID_TO_TOOL_ITEM: Dict[Union[wx.WindowIDRef, int], wx.MenuItem] = {}
         self.cdialog: Optional[ClutImagedataDialog] = None
 
+        self.ID_TO_CONST_KEY: Dict[Union[wx.WindowIDRef, int], str] = {}
+
         # ------------ Sub menu of the window and level ----------
         submenu_wl = wx.Menu()
 
@@ -59,17 +61,20 @@ class SliceMenu(wx.Menu):
         new_id = self.id_wl_first = wx.NewIdRef()
         wl_item = submenu_wl.Append(new_id, _("Default"), kind=wx.ITEM_RADIO)
         self.ID_TO_TOOL_ITEM[new_id] = wl_item
+        self.ID_TO_CONST_KEY[new_id] = "Default"
 
         # Case the user change window and level
         new_id = self.other_wl_id = wx.NewIdRef()
         wl_item = submenu_wl.Append(new_id, _("Manual"), kind=wx.ITEM_RADIO)
         self.ID_TO_TOOL_ITEM[new_id] = wl_item
+        self.ID_TO_CONST_KEY[new_id] = "Manual"
 
         for name in const.WINDOW_LEVEL:
-            if not (name == _("Default") or name == _("Manual")):
+            if not (name == "Default" or name == "Manual"):
                 new_id = wx.NewIdRef()
-                wl_item = submenu_wl.Append(new_id, name, kind=wx.ITEM_RADIO)
+                wl_item = submenu_wl.Append(new_id, _(name), kind=wx.ITEM_RADIO)
                 self.ID_TO_TOOL_ITEM[new_id] = wl_item
+                self.ID_TO_CONST_KEY[new_id] = name
 
         # ----------- Sub menu of the save and load options ---------
         # submenu_wl.AppendSeparator()
@@ -96,18 +101,20 @@ class SliceMenu(wx.Menu):
         color_item.Check(True)
         self.ID_TO_TOOL_ITEM[new_id] = color_item
         self.pseudo_color_items[new_id] = color_item
+        self.ID_TO_CONST_KEY[new_id] = "Default "
 
         for name in sorted(const.SLICE_COLOR_TABLE):
-            if not (name == _("Default ")):
+            if not (name == "Default "):
                 new_id = wx.NewIdRef()
-                color_item = submenu_pseudo_colours.Append(new_id, name, kind=mkind)
+                color_item = submenu_pseudo_colours.Append(new_id, _(name), kind=mkind)
                 self.ID_TO_TOOL_ITEM[new_id] = color_item
                 self.pseudo_color_items[new_id] = color_item
+                self.ID_TO_CONST_KEY[new_id] = name
 
         self.plist_presets = presets.get_wwwl_presets()
         for name in sorted(self.plist_presets):
             new_id = wx.NewIdRef()
-            color_item = submenu_pseudo_colours.Append(new_id, name, kind=mkind)
+            color_item = submenu_pseudo_colours.Append(new_id, _(name), kind=mkind)
             self.ID_TO_TOOL_ITEM[new_id] = color_item
             self.pseudo_color_items[new_id] = color_item
 
@@ -115,6 +122,7 @@ class SliceMenu(wx.Menu):
         color_item = submenu_pseudo_colours.Append(new_id, _("Custom"), kind=mkind)
         self.ID_TO_TOOL_ITEM[new_id] = color_item
         self.pseudo_color_items[new_id] = color_item
+        self.ID_TO_CONST_KEY[new_id] = "Custom"
 
         # --------------- Sub menu of the projection type ---------------------
         self.projection_items: Dict[Union[wx.WindowIDRef, int], wx.MenuItem] = {}
@@ -188,6 +196,9 @@ class SliceMenu(wx.Menu):
         # id = evt.GetId()
         item = self.ID_TO_TOOL_ITEM[evt.GetId()]
         key = item.GetItemLabelText()
+        if evt.GetId() in self.ID_TO_CONST_KEY:
+            key = self.ID_TO_CONST_KEY[evt.GetId()]
+
         if key in const.WINDOW_LEVEL.keys():
             window, level = const.WINDOW_LEVEL[key]
             Publisher.sendMessage(
@@ -241,7 +252,7 @@ class SliceMenu(wx.Menu):
             Publisher.sendMessage("Set projection type", projection_id=pid)
             Publisher.sendMessage("Reload actual slice")
 
-        elif key == _("Custom"):
+        elif key == "Custom":
             if self.cdialog is None:
                 slc = sl.Slice()
                 histogram = slc.histogram

--- a/invesalius/presets.py
+++ b/invesalius/presets.py
@@ -34,41 +34,41 @@ class Presets:
     def __init__(self):
         self.thresh_ct = TwoWaysDictionary(
             {
-                _("Bone"): (226, 3071),
-                _("Soft Tissue"): (-700, 225),
-                _("Enamel (Adult)"): (1553, 2850),
-                _("Enamel (Child)"): (2042, 3071),
-                _("Compact Bone (Adult)"): (662, 1988),
-                _("Compact Bone (Child)"): (586, 2198),
-                _("Spongial Bone (Adult)"): (148, 661),
-                _("Spongial Bone (Child)"): (156, 585),
-                _("Muscle Tissue (Adult)"): (-5, 135),
-                _("Muscle Tissue (Child)"): (-25, 139),
-                _("Fat Tissue (Adult)"): (-205, -51),
-                _("Fat Tissue (Child)"): (-212, -72),
-                _("Skin Tissue (Adult)"): (-718, -177),
-                _("Skin Tissue (Child)"): (-766, -202),
-                _("Custom"): (0, 0),
+                "Bone": (226, 3071),
+                "Soft Tissue": (-700, 225),
+                "Enamel (Adult)": (1553, 2850),
+                "Enamel (Child)": (2042, 3071),
+                "Compact Bone (Adult)": (662, 1988),
+                "Compact Bone (Child)": (586, 2198),
+                "Spongial Bone (Adult)": (148, 661),
+                "Spongial Bone (Child)": (156, 585),
+                "Muscle Tissue (Adult)": (-5, 135),
+                "Muscle Tissue (Child)": (-25, 139),
+                "Fat Tissue (Adult)": (-205, -51),
+                "Fat Tissue (Child)": (-212, -72),
+                "Skin Tissue (Adult)": (-718, -177),
+                "Skin Tissue (Child)": (-766, -202),
+                "Custom": (0, 0),
             }
         )
 
         self.thresh_mri = TwoWaysDictionary(
             {
-                _("Bone"): (1250, 4095),
-                _("Soft Tissue"): (324, 1249),
-                _("Enamel (Adult)"): (2577, 3874),
-                _("Enamel (Child)"): (3066, 4095),
-                _("Compact Bone (Adult)"): (1686, 3012),
-                _("Compact Bone (Child)"): (1610, 3222),
-                _("Spongial Bone (Adult)"): (1172, 1685),
-                _("Spongial Bone (Child)"): (1180, 1609),
-                _("Muscle Tissue (Adult)"): (1019, 1159),
-                _("Muscle Tissue (Child)"): (999, 1163),
-                _("Fat Tissue (Adult)"): (819, 973),
-                _("Fat Tissue (Child)"): (812, 952),
-                _("Skin Tissue (Adult)"): (306, 847),
-                _("Skin Tissue (Child)"): (258, 822),
-                _("Custom"): (0, 0),
+                "Bone": (1250, 4095),
+                "Soft Tissue": (324, 1249),
+                "Enamel (Adult)": (2577, 3874),
+                "Enamel (Child)": (3066, 4095),
+                "Compact Bone (Adult)": (1686, 3012),
+                "Compact Bone (Child)": (1610, 3222),
+                "Spongial Bone (Adult)": (1172, 1685),
+                "Spongial Bone (Child)": (1180, 1609),
+                "Muscle Tissue (Adult)": (1019, 1159),
+                "Muscle Tissue (Child)": (999, 1163),
+                "Fat Tissue (Adult)": (819, 973),
+                "Fat Tissue (Child)": (812, 952),
+                "Skin Tissue (Adult)": (306, 847),
+                "Skin Tissue (Child)": (258, 822),
+                "Custom": (0, 0),
             }
         )
         self.__bind_events()
@@ -105,31 +105,13 @@ class Presets:
         filename = "{}${}".format(filename, "presets.plist")
         preset = {}
 
-        translate_to_en = {
-            _("Bone"): "Bone",
-            _("Soft Tissue"): "Soft Tissue",
-            _("Enamel (Adult)"): "Enamel (Adult)",
-            _("Enamel (Child)"): "Enamel (Child)",
-            _("Compact Bone (Adult)"): "Compact Bone (Adult)",
-            _("Compact Bone (Child)"): "Compact Bone (Child)",
-            _("Spongial Bone (Adult)"): "Spongial Bone (Adult)",
-            _("Spongial Bone (Child)"): "Spongial Bone (Child)",
-            _("Muscle Tissue (Adult)"): "Muscle Tissue (Adult)",
-            _("Muscle Tissue (Child)"): "Muscle Tissue (Child)",
-            _("Fat Tissue (Adult)"): "Fat Tissue (Adult)",
-            _("Fat Tissue (Child)"): "Fat Tissue (Child)",
-            _("Skin Tissue (Adult)"): "Skin Tissue (Adult)",
-            _("Skin Tissue (Child)"): "Skin Tissue (Child)",
-            _("Custom"): "Custom",
-        }
-
         thresh_mri_new = {}
         for name in self.thresh_mri.keys():
-            thresh_mri_new[translate_to_en[name]] = self.thresh_mri[name]
+            thresh_mri_new[name] = self.thresh_mri[name]
 
         thresh_ct_new = {}
         for name in self.thresh_ct.keys():
-            thresh_ct_new[translate_to_en[name]] = self.thresh_ct[name]
+            thresh_ct_new[name] = self.thresh_ct[name]
 
         preset["thresh_mri"] = thresh_mri_new
         preset["thresh_ct"] = thresh_ct_new
@@ -138,39 +120,13 @@ class Presets:
         return os.path.split(filename)[1]
 
     def OpenPlist(self, filename: "str | Path") -> None:
-        translate_to_x = {
-            "Bone": _("Bone"),
-            "Soft Tissue": _("Soft Tissue"),
-            "Enamel (Adult)": _("Enamel (Adult)"),
-            "Enamel (Child)": _("Enamel (Child)"),
-            "Compact Bone (Adult)": _("Compact Bone (Adult)"),
-            "Compact Bone (Child)": _("Compact Bone (Child)"),
-            "Spongial Bone (Adult)": _("Spongial Bone (Adult)"),
-            "Spongial Bone (Child)": _("Spongial Bone (Child)"),
-            "Muscle Tissue (Adult)": _("Muscle Tissue (Adult)"),
-            "Muscle Tissue (Child)": _("Muscle Tissue (Child)"),
-            "Fat Tissue (Adult)": _("Fat Tissue (Adult)"),
-            "Fat Tissue (Child)": _("Fat Tissue (Child)"),
-            "Skin Tissue (Adult)": _("Skin Tissue (Adult)"),
-            "Skin Tissue (Child)": _("Skin Tissue (Child)"),
-            "Custom": _("Custom"),
-        }
-
         with open(filename, "rb") as f:
             p = plistlib.load(f, fmt=plistlib.FMT_XML)
         thresh_mri = p["thresh_mri"].copy()
         thresh_ct = p["thresh_ct"].copy()
 
-        thresh_ct_new = {}
-        for name in thresh_ct.keys():
-            thresh_ct_new[translate_to_x[name]] = thresh_ct[name]
-
-        thresh_mri_new = {}
-        for name in thresh_mri.keys():
-            thresh_mri_new[translate_to_x[name]] = thresh_mri[name]
-
-        self.thresh_mri = TwoWaysDictionary(thresh_mri_new)
-        self.thresh_ct = TwoWaysDictionary(thresh_ct_new)
+        self.thresh_mri = TwoWaysDictionary(thresh_mri)
+        self.thresh_ct = TwoWaysDictionary(thresh_ct)
 
 
 def get_wwwl_presets() -> Dict[str, str]:


### PR DESCRIPTION
Fixes #1067 
# 🛠️ Fix: Localization Crashes in Startup & DICOM Import

This PR resolves critical stability issues encountered when running InVesalius in non-English locales. The application was crashing due to internal key mismatches caused by localized strings being used for invariant lookups.

## 🐛 The Issues

1.  **Startup Crash**: The application failed to initialize in certain languages because it attempted to access `WINDOW_LEVEL` and `SLICE_COLOR_TABLE` using translated keys (e.g., expecting "Bone" but receiving a localized string), leading to `KeyError`.
2.  **DICOM Import Failure**: Users experienced a `ValueError: too many values to unpack` during DICOM import. This was traced to `THRESHOLD_PRESETS_INDEX` in [constants.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/constants.py:0:0-0:0) using a translated string, which broke the expected tuple structure in [task_slice.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/gui/task_slice.py:0:0-0:0).

---

## 💻 Technical Implementation

We successfully decoupled the **internal logic** from the **user interface language** by enforcing invariant keys across the codebase.

### Key Changes
-   **[invesalius/constants.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/constants.py:0:0-0:0)**:
    -   Fixed `THRESHOLD_PRESETS_INDEX` to use the invariant literal `"Bone"` instead of the translated [_("Bone")](cci:1://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/presets.py:33:4-73:28).
-   **[invesalius/presets.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/presets.py:0:0-0:0)**:
    -   Refactored `thresh_ct` and `thresh_mri` definitions to use standard English keys, removing translation markers [_()](cci:1://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/presets.py:33:4-73:28) from the dictionary keys themselves.
-   **[invesalius/gui/widgets/slice_menu.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/gui/widgets/slice_menu.py:0:0-0:0)**:
    -   Implemented a robust `ID_TO_CONST_KEY` mapping system.
    -   Updated `OnPopup` to resolve menu actions using these invariant keys, correctly handling Window/Level presets regardless of the UI language.
-   **[invesalius/control.py](cci:7://file:///Users/kushagrasingh/Documents/invesalius3/invesalius/control.py:0:0-0:0)** & **`dicom_preview_panel.py`**:
    -   Standardized all lookup calls to `WINDOW_LEVEL` to use invariant keys.

---

## ✅ Verification & Testing

The following scenarios were rigorously tested to ensure stability and correctness:

*   **Clean Installation**: Performed a full reset by deleting the `~/.config/invesalius` directory. The application generated a fresh configuration and started without issues.
*   **Locale Stress Testing**:
    *   Launched the application in **English** (Invariant).
    *   Launched the application in **Brazilian Portuguese** (Localized).
    *   Verified that startup no longer crashes in either locale.
*   **Feature Verification**:
    *   **DICOM Import**: Successfully imported DICOM datasets in both languages without `ValueError`.
    *   **Thresholds**: Confirmed that changing threshold presets (e.g., Bone, Soft Tissue) works correctly and applies the expected values.
    *   **Window/Level**: Verified that adjusting Window/Level from the slice menu works as expected.
*   **Code Integrity**: verified syntax with `python3 -m compileall .`