### PR TITLE
 Initialize spacing variable to prevent UnboundLocalError

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -1036,6 +1036,10 @@ class Controller:
                 filelist, size, orientation, resolution_percentage
             )
 
+            # Fix for issue #475: Initialize spacing with default value
+            # This prevents UnboundLocalError if orientation doesn't match expected values
+            spacing = (1.0, 1.0, 1.0)  # Default fallback spacing
+
             if orientation == "AXIAL":
                 spacing = xyspacing[0], xyspacing[1], zspacing
             elif orientation == "CORONAL":


### PR DESCRIPTION
## Description

This PR fixes an `UnboundLocalError` that occurs in the [OpenDicomGroup](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:974:4-1082:48) method when the DICOM image orientation is not one of the expected values (AXIAL, CORONAL, or SAGITTAL).

## Problem

In the [OpenDicomGroup](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:974:4-1082:48) method , the `spacing` variable is only initialized inside conditional blocks that check for specific orientations. If the orientation doesn't match any of these conditions, the `spacing` variable remains uninitialized, leading to an `UnboundLocalError` when it's accessed later in the code.

## Solution

Initialize the `spacing` variable with a default value before the orientation checks to ensure it's always defined, preventing the `UnboundLocalError`.