### PR TITLE
Fix 1079 clean polygons 3d edit

### DIFF
--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -1019,6 +1019,11 @@ class EditionTools(wx.Panel):
         Publisher.sendMessage("M3E set depth value", value=spin_val)
 
     def OnClearPolyMaskEdit3D(self, _evt):
+        # Only clear polygons when 3D mask editing is currently enabled.
+        # This prevents the "Clean Polygons" button from clearing edits
+        # when "Edit in 3D" is disabled (see issue #1079).
+        if not self.cbox_mask_edit_3d.GetValue():
+            return
         Publisher.sendMessage("M3E clear polygons")
 
 


### PR DESCRIPTION
Fixes #1079
FIX: Prevent “Clean Polygons” from clearing edits when “Edit in 3D” is disabled 

### Summary

This PR ensures that the **“Clean Polygons”** button only clears 3D mask polygons when **“Edit in 3D”** is enabled.  
Previously, clicking “Clean Polygons” would clear polygons even if “Edit in 3D” was turned off, which is the behavior described in issue **#1079**.

### Motivation

- Users can mistakenly click “Clean Polygons” while “Edit in 3D” is disabled and still lose their 3D edits.
- This is confusing and breaks the expectation that the “Clean Polygons” control applies only to the active 3D‑edit session.
- The state of the **“Edit in 3D”** checkbox (`cbox_mask_edit_3d`) is already the source of truth for whether 3D editing is active, so we can guard the clear action based on that.

### Changes

- **File**: `invesalius/gui/task_slice.py`
- **Handler**: `OnClearPolyMaskEdit3D`
- Added a simple state guard so polygons are only cleared when the **“Edit in 3D”** checkbox is checked:

```python
def OnClearPolyMaskEdit3D(self, _evt):
    # Only clear polygons when 3D mask editing is currently enabled.
    # This prevents the "Clean Polygons" button from clearing edits
    # when "Edit in 3D" is disabled (see issue #1079).
    if not self.cbox_mask_edit_3d.GetValue():
        return
    Publisher.sendMessage("M3E clear polygons")
```

### Behavior Before

1. Import DICOM and work with 3D mask editing.
2. Disable **“Edit in 3D”**.
3. Click **“Clean Polygons”**.
4. All polygons are cleared, even though 3D editing is disabled.

### Behavior After

1. Import DICOM and work with 3D mask editing.
2. Disable **“Edit in 3D”**.
3. Click **“Clean Polygons”**.
4. **Nothing happens** (no polygons are cleared) because 3D editing is not active.
5. Re‑enable **“Edit in 3D”** and click **“Clean Polygons”** → polygons are cleared as expected.

### Impact and Risk

- The change is **minimal and localized**: it only affects the `OnClearPolyMaskEdit3D` handler.
- No changes were made to the pubsub channel (`"M3E clear polygons"`) or to `Mask3DEditorInteractorStyle`.
- Risk is low: we simply prevent sending the clear message when the 3D‑edit mode is not active.

### Testing

- Manually verified flow:
  - With **“Edit in 3D” enabled**: “Clean Polygons” still clears polygons as before.
  - With **“Edit in 3D” disabled**: “Clean Polygons” does not clear polygons anymore.