### PR TITLE
Fix: AddPointReference function throws AttributeError (VTK API mismatch)

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -843,7 +843,7 @@ class Viewer(wx.Panel):
         point.SetRadius(radius)
 
         mapper = vtkPolyDataMapper()
-        mapper.SetInput(point.GetOutput())
+        mapper.SetInputConnection(point.GetOutputPort())
 
         p = vtkProperty()
         p.SetColor(colour)


### PR DESCRIPTION
fixes issue #927 
by updating the `AddPointReference` function in `viewer_volume.py` to use the modern VTK connection API.

### Problem
The `AddPointReference` function was using the deprecated `SetInput()` method which was removed in VTK 6.0+, causing an `AttributeError`:

`AttributeError: 'vtkmodules.vtkRenderingOpenGL2.vtkOpenGLPolyDataMa' object has no attribute 'SetInput'. Did you mean: 'GetInput'?
`
### Solution
Updated the deprecated API call from:

```python
mapper.SetInput(point.GetOutput())
```

to the modern VTK pipeline approach:

```python
mapper.SetInputConnection(point.GetOutputPort())
```

### Changes

- File: `invesalius/data/viewer_volume.py`
- Function: `AddPointReference()`
- Line: ~846

### Testing

- Verified that `AddPointReference()` can be called without throwing `AttributeError`
- The function correctly adds a point representation with custom radius and color to the 3D volume viewer

### Related Issue
Closes #927

