### PR TITLE
Fix: Enable Windows DPI awareness for high-resolution displays

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,23 @@ if sys.platform == "win32":
         import winreg
     except ImportError:
         import _winreg as winreg
+
+    # Enable DPI awareness for high-resolution displays (fixes #324)
+    # Must be called before wx initialization
+    try:
+        import ctypes
+
+        # Try to set per-monitor DPI awareness (Windows 10 1607+)
+        try:
+            ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+        except Exception:
+            # Fall back to system DPI awareness (Windows Vista+)
+            try:
+                ctypes.windll.user32.SetProcessDPIAware()
+            except Exception:
+                pass  # DPI awareness not available on this system
+    except Exception:
+        pass  # Silently continue if DPI awareness setup fails
 #  else:
 #  if sys.platform != 'darwin':
 #  import wxversion


### PR DESCRIPTION
## Description

Fixes #324 - Enables Windows DPI awareness to fix GUI scaling issues on high-resolution displays.

### Problem
On Windows with display scaling (150%, 200%, etc.), the GUI elements get cut off - Navigation panel is clipped, checkboxes hidden, and Tractography section not visible.

### Solution
Added Windows DPI awareness call (`SetProcessDpiAwareness`) in [app.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/app.py:0:0-0:0) before wxPython initialization:
- Per-monitor DPI awareness for Windows 10 1607+
- Falls back to system DPI awareness for older versions
- No impact on Linux/macOS

**Not tested on Windows** - Developed on macOS, so unable to test with actual Windows display scaling. Would appreciate validation from maintainers with Windows hardware.

### Expected Results
- 100% scaling: Works as before
- 150%/200% scaling: All UI elements visible and properly scaled
- Multi-monitor: App adapts to each monitor's DPI

Closes #324