### PR TITLE
Fix/mask 3d preview update 1080

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2651,8 +2651,8 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
                 # Capture old mask before selection changes, so we can hide its 3D preview
                 old_mask = self.viewer.slice_.current_mask
 
-                # If 3D preview is enabled, pre-create the 3D volume actor for the new mask 
-                # BEFORE it's added. This ensures that when _add_mask_into_proj triggers 
+                # If 3D preview is enabled, pre-create the 3D volume actor for the new mask
+                # BEFORE it's added. This ensures that when _add_mask_into_proj triggers
                 # "Show mask", data_notebook.py successfully finds the actor and loads it.
                 if ses.Session().mask_3d_preview:
                     self.config.mask.create_3d_preview()
@@ -2666,7 +2666,9 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
                     # Safely detach the old mask's 3D preview from the renderer.
                     # We do not destroy the volume data because the mask is still in the project.
                     if old_mask is not None and old_mask.volume is not None:
-                        Publisher.sendMessage("Remove mask preview", mask_3d_actor=old_mask.volume._actor)
+                        Publisher.sendMessage(
+                            "Remove mask preview", mask_3d_actor=old_mask.volume._actor
+                        )
                     Publisher.sendMessage("Render volume viewer")
 
             del self.viewer.slice_.aux_matrices["SELECT"]


### PR DESCRIPTION
## Fix: #1080

### Problem
When the "Mask 3D Preview" is enabled, using the "Select parts" tool to isolate a segment of a mask failed to update the 3D Volume window properly. The newly selected mask part would either overlay messily on top of the old mask's 3D actor, or fail to load entirely, confusing users and requiring manual toggling to fix the viewport. This was caused by the app failing to dynamically detach the old mask and attach the new one through its native rendering event pipeline.
___
## Solution
This PR implements a clean transition of the 3D viewport when a new mask part is selected:
1. **Pre-creates the VTK Actor:** Generates the new mask's 3D `VTKVolume` actor before the mask is formally added to the project, so that the ensuing native `"Show mask"` pubsub hook can smoothly fetch the actor and swap it into the VTK renderer.
2. **Safely Unloads Old Actor:** Unloads the old mask's 3D preview seamlessly using the safe `"Remove mask preview"` pubsub message. This prevents VTK segmentation faults and strictly preserves the old mask's background imaging data (allowing users to toggle the old mask back on later without a crash).

___
## Screenshots

**Testing the Fix:** The new isolated mask piece correctly replaces the old full skull mask in the 3D Volume quadrant automatically.

<img width="2540" height="1472" alt="image" src="https://github.com/user-attachments/assets/7965e3b7-d0c8-43ca-8951-7c65786ce75a" />

___

## Testing 
**Manual test — Select Parts with 3D Preview Enabled:**
1. Open a DICOM project with an existing mask
2. Go to **Tools → Mask → Mask 3D Preview** and click **Enable** to show the 3D mask in the Volume viewer.
3. Go to **Tools → Mask → Select Parts**. In any 2D slice, click on a desired isolated mask piece.
4. Click OK in the popup.
5. **Verified:** The original full 3D mask vanishes instantly and is cleanly replaced by the newly isolated piece.






