### PR TITLE
Fix #1078: remove polygon overlays after completing 3D edit

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -823,7 +823,13 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         """Complete the polygon by connecting the last point to the first one."""
         self.m3e_list[-1].complete_polygon()
         Publisher.sendMessage("M3E cut mask from 3D")
-        self.ClearPolygons()
+        # Clear polygons without restoring initial mask
+        self.viewer.canvas.draw_list = [
+            drawn_item
+            for drawn_item in self.viewer.canvas.draw_list
+            if not isinstance(drawn_item, PolygonSelectCanvas)
+        ]
+        self.m3e_list.clear()
         self.viewer.UpdateCanvas()
 
     def ReceiveVolumeViewerActiveCamera(self, cam: "vtkCamera"):


### PR DESCRIPTION
## Summary

Fixes #1078

After marking the polygons and deactivating the tool, interacting with the volume window causes the polygons to be displayed again.

---

## Root Cause

In the code, `self.m3e_list` stores the polygon objects on screen. When the editing operation is completed, the code calls `UpdateCanvas()` but never clears the polygon from the screen by calling `ClearPolygons()` after the edit operation completes. This is why the polygons stay visible on screen.

---

## Fix

Added a call `self.ClearPolygons()` in `OnInsertPolygon` immediately after publishing the edit event. It removes the polygon from `draw_list` and clears `m3e_list` - exactly what `ClearPolygons()` does.
This ensures polygon actors are removed and the viewer is refreshed once the edit completes.

---

## Testing

- Loaded DICOM sample
- Enabled "Edit in 3D"
- Drew polygon
- Click the "Edit in 3D" checkbox again
- Confirmed polygon overlay disappears immediately
- Verified multiple edit cycles work correctly

---

## Demo

The video below shows complete removal of the reappearance of polygons after the user clicks the “Edit in 3D” checkbox again.

https://github.com/user-attachments/assets/b2b86bd9-0df7-42f1-a4a2-b99ce36952cc

