### PR TITLE
fix: restore 3D mask preview quality after camera interaction 

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 class Base3DInteractorStyle(vtkInteractorStyleTrackballCamera):
     def __init__(self, viewer: "Viewer"):
+        self.viewer = viewer
         self.right_pressed = False
         self.left_pressed = False
         self.middle_pressed = False
@@ -67,18 +68,33 @@ class Base3DInteractorStyle(vtkInteractorStyleTrackballCamera):
 
     def OnReleaseLeftButton(self, evt, obj):
         self.left_pressed = False
+        # Force a final "still" render after interaction ends.
+        # VTK may use lower-quality volume rendering during interaction; without an extra render
+        # here the preview can remain stuck in that low-quality state.
+        try:
+            self.viewer.UpdateRender()
+        except Exception:
+            self.viewer.interactor.GetRenderWindow().Render()
 
     def OnPressRightButton(self, evt, obj):
         self.right_pressed = True
 
     def OnReleaseRightButton(self, evt, obj):
         self.right_pressed = False
+        try:
+            self.viewer.UpdateRender()
+        except Exception:
+            self.viewer.interactor.GetRenderWindow().Render()
 
     def OnMiddleButtonPressEvent(self, evt, obj):
         self.middle_pressed = True
 
     def OnMiddleButtonReleaseEvent(self, evt, obj):
         self.middle_pressed = False
+        try:
+            self.viewer.UpdateRender()
+        except Exception:
+            self.viewer.interactor.GetRenderWindow().Render()
 
 
 class DefaultInteractorStyle(Base3DInteractorStyle):


### PR DESCRIPTION
fixes: #791 

### Problem
When the 3D mask preview is enabled, after translating, panning, or rolling the 3D view, the mask can remain in a low‑resolution “interactive” rendering instead of returning to the normal high‑quality view once the mouse button is released

### Solution
Update Base3DInteractorStyle in styles_3d.py to trigger a final render when the left, right, or middle mouse button is released.
Call viewer.UpdateRender() on button release, and fall back to interactor.GetRenderWindow().Render() if needed.
This forces a final “still” frame after camera interaction ends, so the 3D mask preview no longer gets stuck in the low‑res interactive state.

### Testing
Open app.py and load a project with a mask (e.g. Cranium.inv3).
Enable the 3D mask preview.
Rotate, pan, and roll the 3D view while holding the mouse buttons.
Observe that while dragging, the mask may appear lower‑res for performance, but immediately after releasing the mouse button, the mask returns to full‑resolution rendering and does not stay stuck in low quality.
Verified this behaviour manually on my local environment 

### After fix: 

https://github.com/user-attachments/assets/3028628a-3070-48c2-b856-ed4ae05c3c77

