### PR TITLE
fix: prevent crashes when opening project

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -259,6 +259,18 @@ class Controller:
         # Open project
         filepath = dialog.ShowOpenProjectDialog()
         if filepath:
+            if not filepath.lower().endswith(".inv3"):
+                dlg = dialogs.ErrorMessageBox(
+                    None,
+                    _("Invalid file type"),
+                    _(
+                        "Please select an InVesalius 3 project file (.inv3).\n\n"
+                        "For DICOM files (.dcm), use File → Import DICOM instead."
+                    ),
+                )
+                dlg.ShowModal()
+                dlg.Destroy()
+                return
             if session.IsOpen():
                 self.CloseProject()
             self.OpenProject(filepath)

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -86,10 +86,14 @@ class Tracker(metaclass=Singleton):
         from typing import cast
 
         tracker_id: int = cast(int, state["tracker_id"])
-        tracker_fiducials: NDArray[np.float64] = np.array(state["tracker_fiducials"])
-        tracker_fiducials_raw: NDArray[np.float64] = np.array(state["tracker_fiducials_raw"])
+        tracker_fiducials: NDArray[np.float64] = np.array(
+            state["tracker_fiducials"], dtype=np.float64
+        )
+        tracker_fiducials_raw: NDArray[np.float64] = np.array(
+            state["tracker_fiducials_raw"], dtype=np.float64
+        )
         m_tracker_fiducials_raw: NDArray[np.float64] = np.array(
-            state["marker_tracker_fiducials_raw"]
+            state["marker_tracker_fiducials_raw"], dtype=np.float64
         )
         configuration: Optional[Dict[str, object]] = cast(
             Optional[Dict[str, object]], state["configuration"]


### PR DESCRIPTION
### Fixes: #1122

### Problems
When opening another project while one is already loaded, the app crashes with ValueError: cannot convert float NaN to integer in ResetTrackerFiducials, because tracker_fiducials can be loaded as an integer array from saved state but the code assigns np.nan.

Related: When using File → Open Project and selecting a DICOM file (.dcm) instead of an .inv3 project, the app crashes with tarfile.ReadError because the code treats the file as a tar archive.

### Changes
tracker.py: In LoadState, load tracker_fiducials, tracker_fiducials_raw, and m_tracker_fiducials_raw with dtype=np.float64 so they can store NaN.
control.py: Validate that the selected file has a .inv3 extension before opening. For non-.inv3 files (e.g. .dcm), show a clear error and direct users to File → Import DICOM instead.

### Testing
Load a project, then File → Open Project → select another .inv3 file → project opens without crash.
File → Open Project → select a .dcm file → friendly error shown, no crash.
Verified locally on macOS.

### After fix: 


https://github.com/user-attachments/assets/78f30fa5-ec52-4cbb-8180-647bd3f45423

