### PR TITLE
fix: display mask 3D preview when entering Edit in 3D mode (#1085)

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -676,11 +676,6 @@ class Controller:
         img_file = Path(outdir) / "proj_image.nii.gz"
         proj.export_project_to_nifti(img_file, save_masks=False)
 
-        # Ensure volume is loaded in 3D viewer (fixes #1085: empty volume after
-        # DICOM import when enabling Edit in 3D)
-        if not prj.Project().raycasting_preset:
-            Publisher.sendMessage("Load raycasting preset", preset_name=_("Standard"))
-
         Publisher.sendMessage("End busy cursor")
         Publisher.sendMessage("Project loaded successfully")
 

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -34,7 +34,6 @@ import invesalius.constants as const
 import invesalius.data.slice_ as slc
 import invesalius.project as prj
 import invesalius.session as ses
-from invesalius.i18n import tr as _
 from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
@@ -746,18 +745,18 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             "Update viewer caption", viewer_name="Volume", caption="Volume - 3D mask editor"
         )
 
-        # Ensure volume is loaded and displayed when entering 3D edit (fixes #1085)
-        n_vol = self.viewer.ren.GetVolumes().GetNumberOfItems()
-        if n_vol == 0:
-            Publisher.sendMessage("Load raycasting preset", preset_name=_("Standard"))
+        # Fixes #1085: when entering Edit in 3D, the mask 3D preview was already created
+        # by enable_mask_preview() above, but the camera was never reset to frame the new
+        # volume, making the 3D quadrant appear empty. A delayed camera reset fixes this.
+        # If the preview was already active before we entered this style, just re-render.
+        if self.has_set_mask_preview:
             wx.CallLater(400, self._refresh_volume_view)
         else:
             Publisher.sendMessage("Render volume viewer")
 
     def _refresh_volume_view(self):
-        self.viewer.ren.ResetCamera()
-        self.viewer.ren.ResetCameraClippingRange()
-        self.viewer.UpdateRender()
+        # Set the camera to front view — same orientation used by LoadVolume/AddSurface.
+        Publisher.sendMessage("Set volume view angle", view=const.VOL_FRONT)
         Publisher.sendMessage("Render volume viewer")
 
     def CleanUp(self):


### PR DESCRIPTION
### Fixes: #1085
### Replaces: #1130
_____
### Problem

After importing a DICOM study and enabling "Edit in 3D", the Volume quadrant stayed empty. The 3D volume only appeared after using the volume repositioning tool (see #1085).
______
### Solution

In `Mask3DEditorInteractorStyle.SetUp()` ([styles_3d.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:0:0-0:0)), after [enable_mask_preview()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:1244:4-1251:57) runs, schedule a `wx.CallLater(400, ...)` to send `"Set volume view angle"` with `VOL_FRONT`. The 400ms delay allows the volume to fully initialize before the camera is repositioned — matching the behaviour of [LoadVolume()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/viewer_volume.py:2939:4-2970:26) and [AddSurface()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/viewer_volume.py:2892:4-2919:26).

No changes to [control.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:0:0-0:0).
_______
### Testing

1. Import a DICOM study (e.g. from https://invesalius.github.io/download.html)
2. Expand "2. Select region of interest" → Manual edition
3. Enable "Edit in 3D"

**Expected:** The Volume quadrant shows the green mask 3D preview immediately. No need to use the volume repositioning tool.

## After fix:


https://github.com/user-attachments/assets/43a7239f-681c-4b30-9019-a2e1e9d5c2ac


