### PR TITLE
Fix/empty volume 3d edit after dicom 1085

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -1250,6 +1250,10 @@ class Controller:
             mask.create_3d_preview()
             Publisher.sendMessage("Load mask preview", mask_3d_actor=mask.volume._actor, flag=True)
             Publisher.sendMessage("Render volume viewer")
+            # Fixes #1085: reset camera to front view so the mask preview is immediately
+            # visible without the user needing to interact with the repositioning tool.
+            # Covers both the menu (Mask → Mask 3D Preview → Enable) and Edit in 3D paths.
+            Publisher.sendMessage("Set volume view angle", view=const.VOL_FRONT)
 
     def disable_mask_preview(self):
         ses.Session().mask_3d_preview = False

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -745,19 +745,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             "Update viewer caption", viewer_name="Volume", caption="Volume - 3D mask editor"
         )
 
-        # Fixes #1085: when entering Edit in 3D, the mask 3D preview was already created
-        # by enable_mask_preview() above, but the camera was never reset to frame the new
-        # volume, making the 3D quadrant appear empty. A delayed camera reset fixes this.
-        # If the preview was already active before we entered this style, just re-render.
-        if self.has_set_mask_preview:
-            wx.CallLater(400, self._refresh_volume_view)
-        else:
+        # If the mask preview was already active before entering this style,
+        # just trigger a re-render (camera was already positioned when preview was enabled).
+        if not self.has_set_mask_preview:
             Publisher.sendMessage("Render volume viewer")
-
-    def _refresh_volume_view(self):
-        # Set the camera to front view — same orientation used by LoadVolume/AddSurface.
-        Publisher.sendMessage("Set volume view angle", view=const.VOL_FRONT)
-        Publisher.sendMessage("Render volume viewer")
 
     def CleanUp(self):
         """Clean up is called when the interactor style is removed or changed.


### PR DESCRIPTION
### Fixes #1085
### Replaces #1130, #1132

## Problem

After importing a DICOM study, the Volume quadrant remained empty in two scenarios:
1. Going to **Mask → Mask 3D Preview → Enable**
2. Checking **Edit in 3D** (Manual edition panel)

The mask 3D preview only appeared after using the volume repositioning tool.


## Solution

Added `Publisher.sendMessage("Set volume view angle", view=const.VOL_FRONT)` at the end of [enable_mask_preview()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:1244:4-1255:80) in [control.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:0:0-0:0). Since this single function handles the `"Enable mask 3D preview"` message from both paths (menu + Edit in 3D), one change fixes both.

No changes to [LoadProject()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/control.py:601:4-679:60) — no regression on DICOM import.

## Testing

1. Import a DICOM study (e.g. from https://invesalius.github.io/download.html)
2. **Test A:** Top menu → **Mask → Mask 3D Preview → Enable** → green mask appears 
3. **Test B:** Manual edition → check **Edit in 3D** → green mask appears 
4. Without either: Volume quadrant stays **empty** (no regression)

## After fix


https://github.com/user-attachments/assets/0b168824-e6cd-4261-8715-da474d3fa92e


