### PR TITLE
fix: prevent Clear Polygons from clearing edits when Edit in 3D is di…

### DIFF
--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -1007,8 +1007,13 @@ class EditionTools(wx.Panel):
         if self.cbox_mask_edit_3d.GetValue():
             Publisher.sendMessage("Enable style", style=style_id)
             Publisher.sendMessage("M3E set depth value", value=spin_val)
+            # Enable Clear Polygons button only when Edit in 3D is active
+            self.btn_clear_3d_poly.Enable()
         else:
             Publisher.sendMessage("Disable style", style=style_id)
+            # Disable Clear Polygons button when Edit in 3D is inactive
+            # to prevent clearing mask edits when the tool is not active.
+            self.btn_clear_3d_poly.Disable()
 
     def OnComboMaskEdit3DMode(self, evt: wx.CommandEvent):
         op_id = evt.GetSelection()
@@ -1019,7 +1024,10 @@ class EditionTools(wx.Panel):
         Publisher.sendMessage("M3E set depth value", value=spin_val)
 
     def OnClearPolyMaskEdit3D(self, _evt):
-        Publisher.sendMessage("M3E clear polygons")
+        # Only clear polygons when Edit in 3D is active.
+        # Fixes #1079: the button was clearing edits even when unchecked.
+        if self.cbox_mask_edit_3d.GetValue():
+            Publisher.sendMessage("M3E clear polygons")
 
 
 class WatershedTool(EditionTools):


### PR DESCRIPTION
### Fixes #1079

## Problem

After the user finishes using the **Edit in 3D** tool and unchecks the checkbox, clicking the **"Clear Polygons"** button still cleared all the mask edits that were made.

The "Clear Polygons" button should only be active when **Edit in 3D** is enabled.

## Solution

- [OnClearPolyMaskEdit3D()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/task_slice.py:1025:4-1029:55) now checks `cbox_mask_edit_3d.GetValue()` before
  sending the `"M3E clear polygons"` message — so it does nothing when the tool is inactive
- [OnCheckboxMaskEdit3D()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/task_slice.py:1002:4-1015:44) now **disables** the "Clear Polygons" button when "Edit in 3D"
  is unchecked, and **re-enables** it when checked — giving clear visual feedback

## Testing

1. Import DICOM → Select region of interest → Manual edition
2. Adjust threshold → click Create Surface (3D skull appears)
3. Check "Edit in 3D" → draw a polygon on the 3D skull
4. Uncheck "Edit in 3D" → notice "Clear Polygons" is now disabled 
5. Click "Clear Polygons" → nothing happens, edits are preserved 
6. Re-check "Edit in 3D" → click "Clear Polygons" → polygons are cleared

## After fix:


https://github.com/user-attachments/assets/f65b0061-ef91-431e-b0f1-9c3714f0e432


