### PR TITLE
FIX: remove debug print statement in ProgressDicomReader

### DIFF
--- a/invesalius/reader/dicom_reader.py
+++ b/invesalius/reader/dicom_reader.py
@@ -331,7 +331,6 @@ class ProgressDicomReader:
 
         y = yGetDicomGroups(path, recursive)
         for value_progress in y:
-            print(">>>>", value_progress)
             if not self.running:
                 break
             if isinstance(value_progress, tuple):


### PR DESCRIPTION
Fixes #1148

Removes a debug `print` statement that was accidentally left in 
`ProgressDicomReader.GetDicomGroups`.