### PR TITLE
Fix: Update interpolation slice status to default to off

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -213,7 +213,7 @@ class Viewer(wx.Panel):
         self.slice_data = None
 
         self.slice_actor = None
-        self.interpolation_slice_status = True
+        self.interpolation_slice_status = False
 
         self.canvas = None
 
@@ -1251,9 +1251,9 @@ class Viewer(wx.Panel):
 
         session = ses.Session()
         if session.GetConfig("slice_interpolation"):
-            actor.InterpolateOff()
-        else:
             actor.InterpolateOn()
+        else:
+            actor.InterpolateOff()
 
         slice_data = sd.SliceData()
         slice_data.SetOrientation(self.orientation)
@@ -1272,9 +1272,9 @@ class Viewer(wx.Panel):
         if self.slice_actor is not None:
             session = ses.Session()
             if session.GetConfig("slice_interpolation"):
-                self.slice_actor.InterpolateOff()
-            else:
                 self.slice_actor.InterpolateOn()
+            else:
+                self.slice_actor.InterpolateOff()
             if not self.nav_status:
                 self.UpdateRender()
 


### PR DESCRIPTION
Fixes #1150 

## The Bug
The slice_interpolation config value had inverted logic in the viewer
The menu correctly treated 0 = off, but the viewer incorrectly treated 0 = on. They were backwards.

Changes (all in viewer_slice.py)

3 changes, 1 file:

- Line 216: interpolation_slice_status = True → False (match default config of 0)
- Lines 1253-1256: Swapped InterpolateOn/InterpolateOff (fix inverted logic on slice creation)
- Lines 1274-1277: Same swap in UpdateInterpolatedSlice() (fix inverted logic on preference update)

Now config 0 = unchecked = no interpolation, and config 1 = checked = interpolation. Menu and viewer are in sync.

To test: delete ~/.config/invesalius/config.json, launch the app, import a study then slices should render without interpolation and the menu should be unchecked.

## NOTE
if anything, wrong please help me fixing the issue it's my first PR to this Repository