### PR TITLE
Fix : constant image handling in image_normalize()

### DIFF
--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -579,6 +579,9 @@ def get_LUT_value_normalized(img, a_min, a_max, b_min=0.0, b_max=1.0, clip=True)
 def image_normalize(image, min_=0.0, max_=1.0, output_dtype=np.int16):
     output = np.empty(shape=image.shape, dtype=output_dtype)
     imin, imax = image.min(), image.max()
+    if imin == imax:
+        output[:] = min_
+        return output
     output[:] = (image - imin) * ((max_ - min_) / (imax - imin)) + min_
     return output
 


### PR DESCRIPTION
### SUMMARY

Fixes a division-by-zero bug in `image_normalize()` when the input image has constant intensity. This affects `invesalius/data/imagedata_utils.py` and can cause crashes or NaNs in segmentation preprocessing.

---

### FIX

* **Cause:** `(imax - imin)` becomes zero for constant images.
* **Fix:** Add a small guard and return `min_` for all pixels in that case.

**Before:**

```python
imin, imax = image.min(), image.max()
output[:] = (image - imin) * ((max_ - min_) / (imax - imin)) + min_
```

**After:**

```python
imin, imax = image.min(), image.max()
if imin == imax:
    output[:] = min_
    return output
output[:] = (image - imin) * ((max_ - min_) / (imax - imin)) + min_
```

