### PR TITLE
fix: 3D mask editor polygon alignment on window resize

### DIFF
--- a/invesalius/data/polygon_select.py
+++ b/invesalius/data/polygon_select.py
@@ -48,7 +48,7 @@ class PolygonSelectCanvas(CanvasHandlerBase):
         self.location = const.SURFACE
         self.index = 0
 
-        self.polygon = Polygon(self, fill=False, closed=False, line_colour=colour, is_3d=False)
+        self.polygon = Polygon(self, fill=False, closed=False, line_colour=colour, is_3d=True)
         self.polygon.layer = 1
         self.add_child(self.polygon)
         self.complete = False

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -28,7 +28,7 @@ from vtkmodules.vtkInteractionStyle import (
     vtkInteractorStyleRubberBandZoom,
     vtkInteractorStyleTrackballCamera,
 )
-from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkPointPicker, vtkPropPicker
+from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkCoordinate, vtkPointPicker, vtkPropPicker
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slc
@@ -810,6 +810,38 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.OnRestoreInitMask()
         self.viewer.UpdateCanvas()
 
+    def _display_to_world_focal_plane(
+        self, display_x: float, display_y: float
+    ) -> Tuple[float, float, float]:
+        """Convert display coordinates to world coordinates on the camera focal plane.
+
+        Projects the given 2D display position onto the plane perpendicular to the
+        camera view direction passing through the focal point. This allows polygon
+        points to be stored in world space, so they remain aligned with the volume
+        when the window is resized, zoomed, or panned.
+
+        Args:
+            display_x: X position in display (pixel) coordinates.
+            display_y: Y position in display (pixel) coordinates.
+
+        Returns:
+            Tuple with (x, y, z) world coordinates on the focal plane.
+        """
+        renderer = self.viewer.ren
+        focal_point = renderer.GetActiveCamera().GetFocalPoint()
+
+        # Find the depth value of the focal point in display coordinates
+        renderer.SetWorldPoint(*focal_point, 1.0)
+        renderer.WorldToDisplay()
+        focal_depth = renderer.GetDisplayPoint()[2]
+
+        # Unproject the 2D mouse position at the focal plane depth
+        renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+        renderer.DisplayToWorld()
+        world_point = renderer.GetWorldPoint()
+        w = world_point[3]
+        return (world_point[0] / w, world_point[1] / w, world_point[2] / w)
+
     def OnInsertPolygonPoint(self, _evt):
         """Insert a point in the polygon.
 
@@ -820,8 +852,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         if len(self.m3e_list) == 0 or self.m3e_list[-1].complete:
             self.init_new_polygon()
 
+        world_point = self._display_to_world_focal_plane(mouse_x, mouse_y)
+
         current_masker = self.m3e_list[-1]
-        current_masker.insert_point((mouse_x, mouse_y))
+        current_masker.insert_point(world_point)
         self.viewer.UpdateCanvas()
 
     def OnInsertPolygon(self, _evt):
@@ -876,12 +910,24 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.update_views(_mat)
 
     def get_filters(self) -> List[npt.NDArray]:
-        """Create a boolean mask filter based on the polygon points and viewer size."""
+        """Create a boolean mask filter based on the polygon points and viewer size.
+
+        Since polygon points are stored in world coordinates, they are projected
+        back to display coordinates using the current camera before generating
+        the mask.
+        """
         w, h = self.resolution
-        # get the mask of the polygon in the shape of the screen resolution
-        filters = [
-            polygon2mask((w, h), poly_canvas.polygon.points) for poly_canvas in self.m3e_list
-        ]
+        renderer = self.viewer.ren
+        coord = vtkCoordinate()
+
+        filters = []
+        for poly_canvas in self.m3e_list:
+            display_points = []
+            for point in poly_canvas.polygon.points:
+                coord.SetValue(point)
+                px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                display_points.append((px, py))
+            filters.append(polygon2mask((w, h), display_points))
         return filters
 
     def CutMaskFromPolygons(self):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2665,7 +2665,7 @@ class Viewer(wx.Panel):
         Publisher.sendMessage("Receive volume viewer active camera", cam=cam)
 
     def SendViewerSize(self):
-        width, height = self.GetSize()
+        width, height = self.interactor.GetRenderWindow().GetSize()
         Publisher.sendMessage("Receive volume viewer size", size=(width, height))
 
     # Note: Not in use currently, this method is not called from anywhere.


### PR DESCRIPTION
## Problem
When the "Volume - 3D mask editor" panel is maximized (or the window is resized), the polygon overlays become misaligned with the 3D volume. The polygon stays stuck at its original pixel position while the volume re-centers in the larger window.

<img width="1914" height="1023" alt="Screenshot 2026-03-03 165045" src="https://github.com/user-attachments/assets/85c6123f-6d52-4573-82e5-ffeffd211163" />
<img width="1914" height="1014" alt="Screenshot 2026-03-03 165100" src="https://github.com/user-attachments/assets/7e7b5e1d-0afb-4c53-a686-d1a18d33fd45" />


**Root cause:** `PolygonSelectCanvas` stored polygon points as raw display pixel coordinates (`is_3d=False`). When the VTK render window resizes, the 3D volume's projection changes (re-centers), but the polygon's absolute pixel coordinates remain unchanged — causing visual misalignment.

## Solution
Store polygon points as **3D world coordinates** projected onto the camera's focal plane instead of raw pixels. This makes the polygon track the volume naturally through resize, zoom, and pan operations.

### Changes
- **`polygon_select.py`**: Changed `Polygon(..., is_3d=False)` → `Polygon(..., is_3d=True)` so the polygon re-projects its points from world to display coordinates on every paint.
- **`styles_3d.py`**: Added `_display_to_world_focal_plane()` to convert 2D mouse clicks to 3D world coordinates on the camera focal plane. Updated `get_filters()` to convert world points back to display coordinates for mask cutting via `polygon2mask`.
- **`viewer_volume.py`**: Fixed `SendViewerSize()` to use `self.interactor.GetRenderWindow().GetSize()` instead of `self.GetSize()` for correct viewport dimensions (the wx.Panel size includes toolbar padding).

## Testing
1. Open a DICOM dataset in InVesalius
2. Enable "Edit in 3D" checkbox
3. Draw a polygon lasso in the 3D mask editor
4. Maximize the Volume panel → polygon remains aligned with the volume 
5. Restore to 4-panel view → polygon remains aligned 
6. Complete polygon (double-click) → mask cut matches the polygon boundary 
<img width="1915" height="1013" alt="Screenshot 2026-03-03 215101" src="https://github.com/user-attachments/assets/1c3ea453-fd23-413a-bc90-9dddf0e6808f" /><img width="1919" height="1015" alt="Screenshot 2026-03-03 215121" src="https://github.com/user-attachments/assets/6fe74209-b183-4489-a45d-f5982b36f520" />


