### PR TITLE
fix: zero off-screen voxels in include mode for 3D polygon selection

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -923,7 +923,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             self.world_to_screen,
             self.world_to_camera_coordinates,
             out,
+            self.edit_mode,
         )
+
         self.update_views(out)
 
     def update_views(self, _mat: npt.NDArray):

--- a/invesalius_rs/src/mask_cut.rs
+++ b/invesalius_rs/src/mask_cut.rs
@@ -18,6 +18,7 @@ pub fn mask_cut_internal<T, U>(
     m: ArrayView2<f64>,
     mv: ArrayView2<f64>,
     mut out: ArrayViewMut3<U>,
+    edit_mode: i32,
 ) where
     T: PartialOrd + Copy + Send + Sync + NumCast + AsPrimitive<f64>,
     U: PartialOrd + Copy + Send + Sync + NumCast + AsPrimitive<i32>,
@@ -47,10 +48,17 @@ pub fn mask_cut_internal<T, U>(
                     let px = (q[0] / 2.0 + 0.5) * (w - 1) as f64;
                     let py = (q[1] / 2.0 + 0.5) * (h - 1) as f64;
 
-                    if px >= 0.0 && px < w as f64 && py >= 0.0 && py < h as f64
-                        && mask[[py as usize, px as usize]] {
+                    if px >= 0.0 && px < w as f64 && py >= 0.0 && py < h as f64 {
+                        // Voxel is on screen — zero it if inside the polygon mask
+                        if mask[[py as usize, px as usize]] {
                             *val = NumCast::from(0).unwrap();
                         }
+                    } else if edit_mode == 0 {
+                        // Voxel projects outside the visible viewport.
+                        // In include mode (0) the polygon can never cover it,
+                        // so it must be zeroed out.  Fixes #1084.
+                        *val = NumCast::from(0).unwrap();
+                    }
                 }
             }
         }
@@ -68,6 +76,7 @@ pub fn mask_cut<'py>(
     m: PyReadonlyArray2<f64>,
     mv: PyReadonlyArray2<f64>,
     out: MaskTypesMut3<'py>,
+    edit_mode: i32,
 ) -> PyResult<()> {
     match (image, out) {
         (ImageTypes3::I16(image), MaskTypesMut3::U8(mut out)) => {
@@ -81,6 +90,7 @@ pub fn mask_cut<'py>(
                 m.as_array(),
                 mv.as_array(),
                 out.as_array_mut(),
+                edit_mode,
             );
             Ok(())
         }
@@ -95,6 +105,7 @@ pub fn mask_cut<'py>(
                 m.as_array(),
                 mv.as_array(),
                 out.as_array_mut(),
+                edit_mode,
             );
             Ok(())
         }
@@ -109,6 +120,7 @@ pub fn mask_cut<'py>(
                 m.as_array(),
                 mv.as_array(),
                 out.as_array_mut(),
+                edit_mode,
             );
             Ok(())
         }


### PR DESCRIPTION
### Fixes #1084

### Problem
When the 3D volume is zoomed in beyond the viewport boundary, using the polygon selection tool in **Include Inside** mode incorrectly preserves voxels that project off-screen. Only the region inside the drawn polygon should be kept, but off-screen parts of the model were also retained.

### Solution

The core issue was that [mask_cut](cci:1://file:///Users/shivamchaudhary/Downloads/lib.rs:10:0-156:1) in [invesalius_rs](cci:1://file:///Users/shivamchaudhary/Downloads/lib.rs:158:0-163:1) only evaluated voxels that projected within the visible viewport, silently skipping any voxels that fell outside screen bounds. In **include mode**, this meant off-screen voxels were never removed — regardless of whether the polygon could ever reach them.

The fix adds an `edit_mode` parameter to the [mask_cut](cci:1://file:///Users/shivamchaudhary/Downloads/lib.rs:10:0-156:1) function in [invesalius_rs/src/mask_cut.rs](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius_rs/src/mask_cut.rs:0:0-0:0). Now, when a voxel projects outside the viewport in include mode, it is immediately zeroed — the same way on-screen voxels outside the polygon are handled. No separate post-processing step is needed.

A single corresponding change in [invesalius/data/styles_3d.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:0:0-0:0)
passes the current edit mode to [mask_cut](cci:1://file:///Users/shivamchaudhary/Downloads/lib.rs:10:0-156:1) when the polygon cut is applied.


### Testing
1. Load DICOM → Create 3D surface → Enable **Edit in 3D** (Include Inside)
2. Zoom in until parts of the skull go off-screen
3. Draw a small polygon on the visible region → double-click to close
4. **Before fix:** Off-screen skull portions incorrectly preserved
5. **After fix:** Only the region inside the drawn polygon is kept 

### After fix:


https://github.com/user-attachments/assets/c21db637-69d0-43c1-8adb-ff3dd04a113f
