### PR TITLE
Fix #1078: remove polygon overlays after completing 3D edit

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -828,7 +828,13 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         """Complete the polygon by connecting the last point to the first one."""
         self.m3e_list[-1].complete_polygon()
         Publisher.sendMessage("M3E cut mask from 3D")
-        self.ClearPolygons()
+        # Clear polygons without restoring initial mask
+        self.viewer.canvas.draw_list = [
+            drawn_item
+            for drawn_item in self.viewer.canvas.draw_list
+            if not isinstance(drawn_item, PolygonSelectCanvas)
+        ]
+        self.m3e_list.clear()
         self.viewer.UpdateCanvas()
 
     def ReceiveVolumeViewerActiveCamera(self, cam: "vtkCamera"):


### PR DESCRIPTION
## Summary

Fixes #1078

Reopening #1115 as requested by @paulojamorim — branch has been synced with upstream/master.

---

## Root Cause

When the editing operation completes, `UpdateCanvas()` is called but the polygon
actors are never cleared from `draw_list` or `m3e_list`, causing them to reappear
on the next canvas interaction.

---

## Fix

Two changes in `invesalius/data/styles_3d.py`:

1. Added `self.ClearPolygons()` call in `OnInsertPolygon` after the edit event
   is published, so polygon overlays are removed as soon as the cut completes.

2. Fixed `CleanUp` to fully remove polygon actors from `draw_list` instead of
   just hiding them, ensuring no ghost polygons remain when the style is exited.

---

## Testing

- Loaded DICOM sample
- Enabled "Edit in 3D"
- Drew polygon and double-clicked to complete
- Confirmed polygon overlay disappears immediately after cut
- Clicked around the volume — confirmed polygons do not reappear
- Verified multiple edit cycles work correctly

---

## Demo

The video below shows complete removal of the reappearance of polygons after the user clicks the “Edit in 3D” checkbox again. (Includes the previous updated fix as well)

https://github.com/user-attachments/assets/cf401848-26cd-469f-8524-783abcac22cb


