### PR TITLE
Fix #1159  CMD+Click preview modifying mask permanently (related to #1081)

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2693,15 +2693,18 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
             self._create_new_mask()
 
         if iren.GetControlKey():
+            _preview = self.config.mask.matrix[1:, 1:, 1:]
+            _out = _preview.copy()
             floodfill.floodfill_threshold(
-                self.config.mask.matrix[1:, 1:, 1:],
+                _preview,
                 ((x, y, z),),
                 254,
                 255,
                 0,
                 bstruct,
-                self.config.mask.matrix[1:, 1:, 1:],
+                _out,
             )
+            _preview[:] = _out
         else:
             floodfill.floodfill_threshold(
                 mask,


### PR DESCRIPTION
## This PR addresses part of #1081 and fixes #1159 .

While working on #1081, I noticed that CMD+Click preview was directly modifying the mask matrix instead of behaving as a temporary preview. This caused the red selection to be permanently altered and, in some cases, led to instability/crash during repeated operations.

## Root cause:
The preview path was writing directly into `self.config.mask.matrix`, so the original mask data was being mutated during what should be a non-destructive preview.

## Fix:
CMD+Click now uses a temporary output buffer for the floodfill operation and only updates the preview view, without modifying the original mask matrix.

## This ensures:
- Non-destructive preview behavior
- Proper revert of red selection on CMD+Click
- No unintended mask mutation

Work on #1081 continues.

## Visual verification


https://github.com/user-attachments/assets/a52740f1-ee60-43ed-b248-dfd19af8b98f

