### PR TITLE
fix: 3D mask editor polygon alignment and Clear Polygons noise

### DIFF
--- a/invesalius/data/polygon_select.py
+++ b/invesalius/data/polygon_select.py
@@ -18,7 +18,9 @@
 # --------------------------------------------------------------------------
 
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, List, Tuple
+
+from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 import invesalius.constants as const
 from invesalius.gui.widgets.canvas_renderer import CanvasHandlerBase, Polygon
@@ -30,10 +32,30 @@ if TYPE_CHECKING:
     from invesalius.gui.widgets.canvas_renderer import CanvasEvent, CanvasRendererCTX
 
 
+def _display_to_world(renderer, display_x, display_y):
+    """Convert display coordinates to world coordinates on the camera focal plane."""
+    focal_point = renderer.GetActiveCamera().GetFocalPoint()
+    renderer.SetWorldPoint(*focal_point, 1.0)
+    renderer.WorldToDisplay()
+    focal_depth = renderer.GetDisplayPoint()[2]
+
+    renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+    renderer.DisplayToWorld()
+    wp = renderer.GetWorldPoint()
+    w = wp[3]
+    return (wp[0] / w, wp[1] / w, wp[2] / w)
+
+
 class PolygonSelectCanvas(CanvasHandlerBase):
     """Tool for selecting a polygon on a wx-based canvas.
 
     Inspired on PolygonDensityMeasure, stores and renders a polygon for a canvas.
+
+    The polygon uses is_3d=False to preserve interactive point-dragging
+    behavior. A parallel list of 3D world coordinates is maintained so
+    the polygon can be reprojected to the current display coordinates
+    when the viewport size or camera changes, keeping it aligned with
+    the volume through window resize, zoom, and pan.
 
     Args:
         colour (tuple[int, int, int, int]): RGBA tuple for the polygon line color.
@@ -55,19 +77,67 @@ class PolygonSelectCanvas(CanvasHandlerBase):
 
         self.interactive = interactive
 
+        # Parallel list of 3D world coordinates for each polygon point.
+        self._world_points: List[Tuple[float, float, float]] = []
+
+        # Track camera/viewport state to detect changes that require reprojection.
+        self._last_camera_mtime: int = 0
+        self._last_renderer_size: Tuple[int, int] = (0, 0)
+
     def draw_to_canvas(self, gc: "wx.GraphicsContext", canvas: "CanvasRendererCTX") -> None:
-        ## abstract method from super class. needs implementation but does nothing here
+        """Reproject world coordinates to display coords only when camera/viewport changes.
+
+        During normal interaction (dragging), points are not overwritten,
+        preserving smooth point-dragging behavior.
+        """
+        if self._world_points and len(self._world_points) == len(self.polygon.points):
+            renderer = canvas.evt_renderer
+            camera = renderer.GetActiveCamera()
+            current_mtime = camera.GetMTime()
+            current_size = renderer.GetSize()
+
+            if current_mtime != self._last_camera_mtime or current_size != self._last_renderer_size:
+                # Camera or viewport changed — reproject world points to display
+                coord = vtkCoordinate()
+                for i, world_pt in enumerate(self._world_points):
+                    coord.SetValue(world_pt)
+                    px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                    self.polygon.points[i] = (px, py)
+                    if i < len(self.polygon.handlers):
+                        self.polygon.handlers[i].position = (px, py)
+
+                self._last_camera_mtime = current_mtime
+                self._last_renderer_size = current_size
+
         super().draw_to_canvas(gc, canvas)
 
     def on_mouse_move(self, _evt: "CanvasEvent"):
         pass
 
-    def on_drag_end(self, _evt):
+    def on_drag_end(self, evt: "CanvasEvent"):
+        """Update world coordinates from the dragged display positions, then cut."""
+        if hasattr(evt, "renderer") and evt.renderer is not None:
+            renderer = evt.renderer
+            for i, display_pt in enumerate(self.polygon.points):
+                if i < len(self._world_points):
+                    self._world_points[i] = _display_to_world(
+                        renderer, display_pt[0], display_pt[1]
+                    )
         Publisher.sendMessage("M3E cut mask from 3D")
 
-    def insert_point(self, point: Tuple[int, int]):
-        """Insert a new point to the polygon."""
-        self.polygon.append_point(point)
+    def insert_point(
+        self,
+        display_point: Tuple[float, float],
+        world_point: Tuple[float, float, float],
+    ):
+        """Insert a new point to the polygon.
+
+        Args:
+            display_point: The 2D display coordinates (px, py) from the mouse.
+            world_point: The corresponding 3D world coordinates on the focal plane.
+        """
+        self.polygon.append_point(display_point)
+        self._world_points.append(world_point)
 
     def complete_polygon(self):
         if len(self.polygon.points) >= 3:

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -28,7 +28,7 @@ from vtkmodules.vtkInteractionStyle import (
     vtkInteractorStyleRubberBandZoom,
     vtkInteractorStyleTrackballCamera,
 )
-from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkPointPicker, vtkPropPicker
+from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkCoordinate, vtkPointPicker, vtkPropPicker
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slc
@@ -695,8 +695,6 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
     def __init__(self, viewer: "Viewer"):
         super().__init__(viewer)
 
-        # mask_data is captured in SetUp() after the mask preview is enabled,
-        # so that do_threshold_to_all_slices() has already run.
         self.mask_data = None
 
         self.m3e_list: list[PolygonSelectCanvas] = []
@@ -709,11 +707,6 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
 
         # keep track if we set preview here or not for UX
         self.has_set_mask_preview = False
-
-        # Initialise resolution from the current viewer widget size so that
-        # CutMaskFromPolygons always has a valid aspect ratio even before the
-        # first "Receive volume viewer size" message arrives (fixes #1086).
-        self.resolution: Tuple[int, int] = tuple(viewer.GetSize())
 
         self._bind_events()
         Publisher.subscribe(self.ClearPolygons, "M3E clear polygons")
@@ -744,21 +737,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
                 drawn_polygon.set_interactive(True)
                 self.m3e_list.append(drawn_polygon)
 
-        # Synchronize edit mode and depth value from the GUI's current state
-        import invesalius.pubsub as pub
-
-        pub.pub.sendMessage("M3E ask for edit mode")
-        pub.pub.sendMessage("M3E ask for depth value")
-
         if not ses.Session().mask_3d_preview:
             self.has_set_mask_preview = True
             Publisher.sendMessage("Enable mask 3D preview")
-
-        # Capture mask_data HERE, after Enable mask 3D preview has called
-        # do_threshold_to_all_slices().  Capturing it in __init__ was too early:
-        # the mask matrix was still all-zeros at that point, so every cut would
-        # restore to an empty mask.  Fixes #1086 (no-surface path).
-        self.mask_data = slc.Slice().current_mask.matrix.copy()
 
         Publisher.sendMessage(
             "Update viewer caption", viewer_name="Volume", caption="Volume - 3D mask editor"
@@ -768,6 +749,11 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         # just trigger a re-render (camera was already positioned when preview was enabled).
         if not self.has_set_mask_preview:
             Publisher.sendMessage("Render volume viewer")
+
+        # Capture the mask snapshot AFTER enabling the 3D preview, which runs
+        # do_threshold_to_all_slices and modifies the mask. This ensures
+        # ClearPolygons restores the correct post-threshold mask state.
+        self.mask_data = slc.Slice().current_mask.matrix.copy()
 
     def CleanUp(self):
         """Clean up is called when the interactor style is removed or changed.
@@ -829,6 +815,38 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.OnRestoreInitMask()
         self.viewer.UpdateCanvas()
 
+    def _display_to_world_focal_plane(
+        self, display_x: float, display_y: float
+    ) -> Tuple[float, float, float]:
+        """Convert display coordinates to world coordinates on the camera focal plane.
+
+        Projects the given 2D display position onto the plane perpendicular to the
+        camera view direction passing through the focal point. This allows polygon
+        points to be stored in world space, so they remain aligned with the volume
+        when the window is resized, zoomed, or panned.
+
+        Args:
+            display_x: X position in display (pixel) coordinates.
+            display_y: Y position in display (pixel) coordinates.
+
+        Returns:
+            Tuple with (x, y, z) world coordinates on the focal plane.
+        """
+        renderer = self.viewer.ren
+        focal_point = renderer.GetActiveCamera().GetFocalPoint()
+
+        # Find the depth value of the focal point in display coordinates
+        renderer.SetWorldPoint(*focal_point, 1.0)
+        renderer.WorldToDisplay()
+        focal_depth = renderer.GetDisplayPoint()[2]
+
+        # Unproject the 2D mouse position at the focal plane depth
+        renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+        renderer.DisplayToWorld()
+        world_point = renderer.GetWorldPoint()
+        w = world_point[3]
+        return (world_point[0] / w, world_point[1] / w, world_point[2] / w)
+
     def OnInsertPolygonPoint(self, _evt):
         """Insert a point in the polygon.
 
@@ -839,8 +857,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         if len(self.m3e_list) == 0 or self.m3e_list[-1].complete:
             self.init_new_polygon()
 
+        world_point = self._display_to_world_focal_plane(mouse_x, mouse_y)
+
         current_masker = self.m3e_list[-1]
-        current_masker.insert_point((mouse_x, mouse_y))
+        current_masker.insert_point((mouse_x, mouse_y), world_point)
         self.viewer.UpdateCanvas()
 
     def OnInsertPolygon(self, _evt):
@@ -895,22 +915,24 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.update_views(_mat)
 
     def get_filters(self) -> List[npt.NDArray]:
-        """Create a boolean mask filter based on the polygon points and viewer size."""
+        """Create a boolean mask filter based on the polygon points and viewer size.
+
+        Since polygon points are stored with parallel world coordinates,
+        they are projected back to display coordinates using the current
+        camera before generating the mask.
+        """
         w, h = self.resolution
+        renderer = self.viewer.ren
+        coord = vtkCoordinate()
 
-        # Get scale factor (necessary for Mac HighDPI displays where physical
-        # mouse coords are scaled by 2x but viewer resolution is logical w,h)
-        import wx
-
-        scale = wx.GetApp().GetTopWindow().GetContentScaleFactor()
-
-        # polygon2mask((w, h), points_as_xy): treats (x, y) as (row, col) in a (w, h) array.
-        # After the .T in CutMaskFromPolygons the result is (h, w) which the Rust code reads as
-        # shape (h, w) and indexes as mask[py][px] — correctly matching VTK screen coordinates.
-        filters = [
-            polygon2mask((w, h), [(x / scale, y / scale) for x, y in poly_canvas.polygon.points])
-            for poly_canvas in self.m3e_list
-        ]
+        filters = []
+        for poly_canvas in self.m3e_list:
+            display_points = []
+            for world_pt in poly_canvas._world_points:
+                coord.SetValue(world_pt)
+                px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                display_points.append((px, py))
+            filters.append(polygon2mask((w, h), display_points))
         return filters
 
     def CutMaskFromPolygons(self):
@@ -919,21 +941,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         if len(completed_polygons) == 0:
             return
 
-        if self.mask_data is None:
-            return
-
         # All m3e will be updated with correct viewer settings
         Publisher.sendMessage("Send volume viewer size")
         Publisher.sendMessage("Send volume viewer active camera")
-
-        # Guard: if the viewer has not reported a valid size yet (e.g. on the
-        # very first Enable after a fresh DICOM import before the widget has
-        # been fully painted), skip the cut to avoid an incorrect projection
-        # matrix that would corrupt the mask.  The polygon stays in place so
-        # the user can re-apply once the viewer is ready.  Fixes #1086.
-        w, h = self.resolution
-        if h == 0:
-            return
 
         filters = self.get_filters()
 
@@ -950,21 +960,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         slice = slc.Slice()
         sx, sy, sz = slice.spacing
 
-        try:
-            near, far = self.clipping_range
-        except AttributeError:
-            print("[DEBUG] self.clipping_range not set yet — skipping cut")
-            return
+        print(f"\n\n\n\n{self.world_to_screen.flags=}\n{self.world_to_camera_coordinates.flags=}\n")
 
+        near, far = self.clipping_range
         depth = near + (far - near) * self.depth_val
-
-        try:
-            wts = self.world_to_screen
-            wtc = self.world_to_camera_coordinates
-        except AttributeError:
-            print("[DEBUG] self.world_to_screen not set yet — skipping cut")
-            return
-
         mask_cut(
             _mat,
             sx,
@@ -972,8 +971,8 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             sz,
             depth,
             filter,
-            wts,
-            wtc,
+            self.world_to_screen,
+            self.world_to_camera_coordinates,
             out,
             self.edit_mode,
         )

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2665,7 +2665,7 @@ class Viewer(wx.Panel):
         Publisher.sendMessage("Receive volume viewer active camera", cam=cam)
 
     def SendViewerSize(self):
-        width, height = self.GetSize()
+        width, height = self.interactor.GetRenderWindow().GetSize()
         Publisher.sendMessage("Receive volume viewer size", size=(width, height))
 
     # Note: Not in use currently, this method is not called from anywhere.


### PR DESCRIPTION
## Problem

Two bugs in the "Volume - 3D mask editor":

1. **Polygon alignment:** When the panel is maximized or resized, polygon overlays become misaligned — they stay stuck at their original pixel position while the volume re-centers.
<img width="1914" height="1023" alt="Screenshot 2026-03-03 165045" src="https://github.com/user-attachments/assets/85c6123f-6d52-4573-82e5-ffeffd211163" />
<img width="1914" height="1014" alt="Screenshot 2026-03-03 165100" src="https://github.com/user-attachments/assets/7e7b5e1d-0afb-4c53-a686-d1a18d33fd45" />
2. **Noisy 3D rendering:** After clicking "Clear Polygons", the 3D volume preview shows noisy artifacts.
<img width="1915" height="1022" alt="Screenshot 2026-03-03 222041" src="https://github.com/user-attachments/assets/ed1a3080-648a-4149-86a4-6657c9db0b58" />

## Root Cause

1. [PolygonSelectCanvas](cci:2://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:47:0-153:51) stored polygon points as raw display pixel coordinates. When VTK resizes the render window, the volume's projection changes but the polygon's absolute pixel coordinates remain unchanged.
2. The mask data snapshot (`self.mask_data`) was captured in [__init__](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:577:4-580:28) before [SetUp](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:475:4-476:85) ran `do_threshold_to_all_slices`, so "Clear Polygons" restored a stale pre-threshold mask.>

## Solution

### Polygon alignment
Store a parallel list of 3D world coordinates (`_world_points`) in [PolygonSelectCanvas](cci:2://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:47:0-153:51) while keeping `is_3d=False` on the underlying [Polygon](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:806:4-815:34) to preserve interactive point-dragging. On each paint, [draw_to_canvas](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:85:4-110:42) reprojects world → display coordinates **only when** `camera.GetMTime()` or `renderer.GetSize()` changes, so dragging works smoothly during normal interaction. When dragging ends, [on_drag_end](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:115:4-124:53) syncs `_world_points` from the new display positions.

### Clear Polygons noise
Move the mask data snapshot from [__init__](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:577:4-580:28) to the end of [SetUp()](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:475:4-476:85), after the 3D preview is enabled and thresholding is applied.

## Changes

- **[polygon_select.py](cci:7://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:0:0-0:0)**: Add `_world_points` list, override [draw_to_canvas](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:85:4-110:42) for conditional reprojection, update [on_drag_end](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:115:4-124:53) to sync world coordinates after drag
- **[styles_3d.py](cci:7://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:0:0-0:0)**: Add [_display_to_world_focal_plane()](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:817:4-847:75) helper, pass both display and world coords to [insert_point](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/polygon_select.py:126:4-138:46), reproject `_world_points` in [get_filters](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:916:4-935:22), move mask snapshot to [SetUp](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/styles_3d.py:475:4-476:85)
- **[viewer_volume.py](cci:7://file:///d:/Gsoc/invesalius3/invesalius/data/viewer_volume.py:0:0-0:0)**: Fix [SendViewerSize()](cci:1://file:///d:/Gsoc/invesalius3/invesalius/data/viewer_volume.py:2666:4-2668:81) to use `self.interactor.GetRenderWindow().GetSize()` instead of `self.GetSize()`

## Testing

1. Draw polygon points → appear under cursor 
2. Drag a point → moves freely 
5. Maximize/restore window → polygon stays aligned with volume 
6. Complete polygon (double-click) → mask cut matches polygon 
7. Clear Polygons → 3D volume stays clean 

https://github.com/user-attachments/assets/7dd5bf2b-20bb-454a-888f-d9df652f4d8e



