### PR TITLE
fix: initialise resolution from viewer size to prevent incorrect 3D e…

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -708,6 +708,11 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         # keep track if we set preview here or not for UX
         self.has_set_mask_preview = False
 
+        # Initialise resolution from the current viewer widget size so that
+        # CutMaskFromPolygons always has a valid aspect ratio even before the
+        # first "Receive volume viewer size" message arrives (fixes #1086).
+        self.resolution: Tuple[int, int] = tuple(viewer.GetSize())
+
         self._bind_events()
         Publisher.subscribe(self.ClearPolygons, "M3E clear polygons")
 
@@ -893,6 +898,15 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         # All m3e will be updated with correct viewer settings
         Publisher.sendMessage("Send volume viewer size")
         Publisher.sendMessage("Send volume viewer active camera")
+
+        # Guard: if the viewer has not reported a valid size yet (e.g. on the
+        # very first Enable after a fresh DICOM import before the widget has
+        # been fully painted), skip the cut to avoid an incorrect projection
+        # matrix that would corrupt the mask.  The polygon stays in place so
+        # the user can re-apply once the viewer is ready.  Fixes #1086.
+        w, h = self.resolution
+        if h == 0:
+            return
 
         filters = self.get_filters()
 


### PR DESCRIPTION
### Fixes #1086

## Problem
After importing a DICOM study and enabling "Edit in 3D", performing a polygon operation (include/exclude) produces an incorrectly edited volume.

This happens because [Mask3DEditorInteractorStyle](cci:2://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:682:0-962:52) never initialised `self.resolution` before it was used. When [CutMaskFromPolygons](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:891:4-942:30) was triggered (for example, on the first depth or mode change right after
enabling the style), it called `Send volume viewer size` but `self.resolution` had not yet been set from the incoming message. The subsequent `GetCompositeProjectionTransformMatrix(width / height, …)` call then used a stale or zero aspect ratio, producing a completely incorrect world-to-screen projection matrix — and therefore a wrong cut.

## Solution
Initialise `self.resolution` directly from `viewer.GetSize()` inside
[__init__](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:506:4-516:82) so there is always a valid aspect ratio available before the first "Receive volume viewer size" pubsub message arrives.

Added a guard in [CutMaskFromPolygons](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:891:4-942:30) to skip the cut entirely when the reported height is still 0 (widget not yet painted), rather than corrupting the mask with a degenerate projection.

## How to Test
1. Run the app and import a DICOM study via **Load data → Import DICOM**
2. Apply a bone threshold and click **Create Surface**
3. Under **Manual edition**, check **Edit in 3D** (Include Inside)
4. Draw a polygon on the 3D model → double-click to close
5. **Before fix:** polygon cut produces a wrong or empty result
6. **After fix:** only the region inside the polygon is kept 

### After fix:


https://github.com/user-attachments/assets/79f083f9-9586-49fa-9d88-908b1e7ea426
