### PR TITLE
Fix: division by zero in get_LUT_value_normalized and remove debug print

### DIFF
--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -566,7 +566,9 @@ def get_LUT_value(data: np.ndarray, window: int, level: int) -> np.ndarray:
 def get_LUT_value_normalized(img, a_min, a_max, b_min=0.0, b_max=1.0, clip=True):
     # based on https://docs.monai.io/en/latest/_modules/monai/transforms/intensity/array.html#ScaleIntensity
 
-    print(a_min, a_max, b_min, b_max, clip)
+    if a_min == a_max:
+        return np.full_like(img, fill_value=b_min, dtype=float)
+
     img = (img - a_min) / (a_max - a_min)
     img = img * (b_max - b_min) + b_min
 


### PR DESCRIPTION

# SUMMARY

This PR fixes a division-by-zero edge case in `get_LUT_value_normalized` in `invesalius/data/imagedata_utils.py`. When the input image is constant (`a_min == a_max`), the normalization step divides by zero and produces invalid values.
It also removes a leftover debug `print` statement that currently runs during segmentation.

---

# FIX

* **Root cause:** normalization divides by `(a_max - a_min)`, which becomes `0` for constant images.
* **Fix:** add a guard for this case and return an array filled with `b_min`. The debug print was also removed.

### Before

```python
print(a_min, a_max, b_min, b_max, clip)
img = (img - a_min) / (a_max - a_min)
```

### After

```python
if a_min == a_max:
    return np.full_like(img, b_min, dtype=float)
```
