### PR TITLE
feat: replace volume rendering progress bar with wx.ProgressDialog

### DIFF
--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -508,7 +508,11 @@ class Volume:
         number_filters = len(self.config["convolutionFilters"])
         if number_filters:
             if not (update_progress):
-                update_progress = vtk_utils.ShowProgress(number_filters)
+                update_progress = vtk_utils.ShowProgress(
+                    number_filters,
+                    dialog_type="ProgressDialog",
+                    msg=_("Rendering volume..."),
+                )
             for filter in self.config["convolutionFilters"]:
                 convolve = vtkImageConvolve()
                 convolve.SetInputData(imagedata)
@@ -555,7 +559,11 @@ class Volume:
         #     flip_image = False
 
         # if (flip_image):
-        update_progress = vtk_utils.ShowProgress(2 + number_filters)
+        update_progress = vtk_utils.ShowProgress(
+            2 + number_filters,
+            dialog_type="ProgressDialog",
+            msg=_("Rendering volume..."),
+        )
         # Flip original vtkImageData
         flip = vtkImageFlip()
         flip.SetInputData(image)

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -47,14 +47,16 @@ if TYPE_CHECKING:
 
 
 class ProgressDialog:
-    def __init__(self, parent: Optional[wx.Window], maximum: int, abort: bool = False):
+    def __init__(
+        self, parent: Optional[wx.Window], maximum: int, abort: bool = False, msg: str = ""
+    ):
         self.title = "InVesalius 3"
-        self.msg = _("Loading DICOM files")
+        self.msg = msg if msg else _("Loading DICOM files")
         self.maximum = maximum
         self.current = 0
-        self.style = wx.PD_APP_MODAL
+        self.style = wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME
         if abort:
-            self.style = wx.PD_APP_MODAL | wx.PD_CAN_ABORT
+            self.style = self.style | wx.PD_CAN_ABORT
 
         self.dlg = wx.ProgressDialog(
             self.title, self.msg, maximum=self.maximum, parent=parent, style=self.style
@@ -103,7 +105,7 @@ else:
 
 
 def ShowProgress(
-    number_of_filters: int = 1, dialog_type: str = "GaugeProgress"
+    number_of_filters: int = 1, dialog_type: str = "GaugeProgress", msg: str = ""
 ) -> Callable[[Union[float, int, "vtkAlgorithm"], str], float]:
     """
     To use this closure, do something like this:
@@ -114,7 +116,7 @@ def ShowProgress(
     last_obj_progress: List[float] = [0]
     if dialog_type == "ProgressDialog":
         try:
-            dlg = ProgressDialog(wx.GetApp().GetTopWindow(), 100)
+            dlg = ProgressDialog(wx.GetApp().GetTopWindow(), 100, msg=msg)
         except (wx.PyNoAppError, AttributeError):
             return lambda obj, label: 0
 


### PR DESCRIPTION
## Fixes #708

## Problem
When volume rendering is activated (via the Raycasting view presets),the progress is shown only as a small bar in the bottom-right corner of the main window, which is easy to miss and lacks time information.

## Solution:
Replaced the `GaugeProgress` (status-bar widget) with a centred `wx.ProgressDialog` popup for the two progress callbacks inside `Volume.LoadVolume()` and `Volume.ApplyConvolution()`.

- **[vtk_utils.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/vtk_utils.py:0:0-0:0)**: [ProgressDialog](cci:2://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/vtk_utils.py:48:0-80:26) now accepts a custom `msg=`  parameter so callers can set a meaningful message. Also added  `wx.PD_ELAPSED_TIME` flag so elapsed time is always shown. [ShowProgress()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/vtk_utils.py:104:0-160:25) now accepts and forwards the `msg=` parameter.
- **[volume.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/volume.py:0:0-0:0)**: Both [ShowProgress](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/vtk_utils.py:104:0-160:25) calls now use `dialog_type="ProgressDialog"` with `msg=_("Rendering volume...")`
  so a proper popup appears during volume rendering.

## Testing
1. Import DICOM → set Threshold
2. In the **Volume** panel (bottom-right), click the **Raycasting icon**
3. Select any preset (e.g. **Standard**, **Soft**, **Bone + Skin**)
4. **Before:** small progress bar in bottom-right corner
5. **After:** centred popup dialog — "Rendering volume..." + progress bar  + elapsed time 

## After fix: 


https://github.com/user-attachments/assets/ce0a0801-f25d-4ecb-8d73-c8987150131d


