### PR TITLE
fix: resolve UnboundLocalError in on category visibility toggle when surface list is empty

### DIFF
--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1078,9 +1078,8 @@ class SurfacePage(wx.Panel):
                     break
             except wx.wxAssertionError:
                 continue
-
+        new_visibility = not is_visible
         for global_surface_id, local_pos in listctrl.surface_list_index.items():
-            new_visibility = not is_visible
             listctrl.SetItemImage(local_pos, int(new_visibility))
             Publisher.sendMessage(
                 "Show surface", index=global_surface_id, visibility=new_visibility


### PR DESCRIPTION
## Problem
When clicking "Toggle visibility for all surfaces in category" on a category 
with no surfaces, the app crashes with:

UnboundLocalError: cannot access local variable 'new_visibility' 
where it is not associated with a value

This happens because new_visibility was assigned inside the for loop but 
used outside it. When the surface list is empty, the loop never executes 
and new_visibility is never assigned.

https://github.com/user-attachments/assets/f68754fa-8161-4dc9-b20a-bd543a16b2fe



## Fix
Moved new_visibility = not is_visible to before the for loop so it is 
always assigned regardless of whether the loop executes.

## Steps to reproduce
1. Load DICOM
2. In Data secction click 3D surfaces then.
3. Click "Toggle visibility for all surfaces in category"
4. App crashes with UnboundLocalError

## After fix
Clicking the toggle button on an empty category works correctly without crashing.