### PR TITLE
fix: prevent main window minimization after creating 3D surface   on Windows

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6039,7 +6039,8 @@ class TractographyProgressWindow:
         self.title = "InVesalius 3"
         self.msg = msg
         self.style = wx.PD_APP_MODAL | wx.PD_APP_MODAL | wx.PD_CAN_ABORT
-        self.dlg = wx.ProgressDialog(self.title, self.msg, parent=None, style=self.style)
+        parent = wx.GetApp().GetTopWindow() if wx.GetApp() else None
+        self.dlg = wx.ProgressDialog(self.title, self.msg, parent=parent, style=self.style)
         self.running = True
         self.error = None
         self.dlg.Show()
@@ -6104,7 +6105,8 @@ class SurfaceProgressWindow:
         self.title = "InVesalius 3"
         self.msg = _("Creating 3D surface ...")
         self.style = wx.PD_APP_MODAL | wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME
-        self.dlg = wx.ProgressDialog(self.title, self.msg, parent=None, style=self.style)
+        parent = wx.GetApp().GetTopWindow() if wx.GetApp() else None
+        self.dlg = wx.ProgressDialog(self.title, self.msg, parent=parent, style=self.style)
         self.running = True
         self.error = None
         self.dlg.Show()


### PR DESCRIPTION
## Problem
I observed several times After creating the 3D surface the main window was minimizing to taskbar.
After investigation i found that
wx.ProgressDialog was created with parent=None in two places:
- SurfaceProgressWindow (line 6107)
- TractographyProgressWindow (line 6042)

On Windows, when a modal dialog with no parent is destroyed, the OS 
sometimes does not return focus to the main window, causing it to minimize.


https://github.com/user-attachments/assets/a2d838a0-4d73-4249-9b1e-9fda849ff49d


## Steps to reproduce
1. Load DICOM dataset
2. Create a mask using threshold
3. Click "Create new 3D surface"
4. Click OK in the surface creation dialog
5. Observe: entire InVesalius window minimizes automatically

## Fix
Parent both dialogs to the main application window using:
wx.GetApp().GetTopWindow()

Defensive check added in case GetApp() returns None.

## Files changed
- invesalius/gui/dialogs.py (lines 6107, 6042)

## After fix
- Created 3D surface → window no longer minimizes 
- Tractography dialog → window no longer minimizes 