### PR TITLE
FIX: correct loop indentation and division by zero in CreateLUTTableForEfield

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1823,9 +1823,9 @@ class Viewer(wx.Panel):
         threshold = self.efield_threshold
         highlight_rgb = (255, 165, 0)
         for i in range(n):
-            norm_val = i / (n - 1)
-        if norm_val >= threshold:
-            lut.SetTableValue(i, *(np.array(highlight_rgb) / 255.0), 1.0)  # Set to orange
+            norm_val = i / (n - 1) if n > 1 else 0
+            if norm_val >= threshold:
+                lut.SetTableValue(i, *(np.array(highlight_rgb) / 255.0), 1.0)
         return lut
 
     def GetEfieldMaxMin(self, e_field_norms):


### PR DESCRIPTION
## Summary

- Fix indentation bug where the `if` block and `lut.SetTableValue()` call were outside the `for` loop, causing only the last LUT entry to be highlighted instead of all entries above the e-field threshold
- Add guard against `ZeroDivisionError` when `n == 1` by using `max(n - 1, 1)` as the divisor

Fixes #1174 

## Problem

In `CreateLUTTableForEfield()` (`invesalius/data/viewer_volume.py`), incorrect indentation placed the threshold check and color assignment **outside** the loop