### PR TITLE
fix(mask): clear 3d polygons when leaving edit in 3d mode

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -777,9 +777,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         super().CleanUp()
         self.viewer.canvas.unsubscribe_event("LeftButtonPressEvent", self.OnInsertPolygonPoint)
         self.viewer.canvas.unsubscribe_event("LeftButtonDoubleClickEvent", self.OnInsertPolygon)
-        for drawn_polygon in self.m3e_list:
-            drawn_polygon.visible = False
-            drawn_polygon.set_interactive(False)
+
+        # Issue #1078: When the 3D editor is disabled, polygons shouldn't just be hidden
+        # (which doesn't work properly due to CanvasHandlerBase), they should be fully removed.
+        self.ClearPolygons()
 
         if self.has_set_mask_preview:
             Publisher.sendMessage("Disable mask 3D preview")


### PR DESCRIPTION
## Fixes #1078
____
### Problem
As reported in issue #1078, after a user enabled the "Edit in 3D" tool and drew a polygon to remove a part of the model, disabling the "Edit in 3D" tool left the polygon control points visible and floating over the volume window canvas. 

This occurred because `Mask3DEditorInteractorStyle.CleanUp()` iterated through `m3e_list` and set `visible = False` on the instances. However, due to how [CanvasHandlerBase](cci:2://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/widgets/canvas_renderer.py:929:0-965:19) and VTK handle underlying graphic layers, merely toggling the object's [visible](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/widgets/canvas_renderer.py:940:4-944:33) property did not actually remove the child polygon elements from the viewer canvas.
______
### Solution
Modified `Mask3DEditorInteractorStyle.CleanUp()` in [styles_3d.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:0:0-0:0) to call `self.ClearPolygons()` instead of looping through and setting the [visible](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/gui/widgets/canvas_renderer.py:940:4-944:33) property. [ClearPolygons()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:821:4-830:34) explicitly purges instances of [PolygonSelectCanvas](cci:2://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/polygon_select.py:32:0-84:51) from the `viewer.canvas.draw_list`, ensuring that all polygon points and lines are completely removed from the 3D window whenever the "Edit in 3D" mode is disabled or swapped out.
______
### Testing
Enable the 3D editor and draw a crop polygon.
Perform a cut to remove a part of the model.
Disable the 3D editor.
Verify that interacting with the volume window no longer displays lingering polygon points.

### After fix:


https://github.com/user-attachments/assets/c93cd451-5768-4d8c-9edc-2d012b7bf79c





