### PR TITLE
Added translucency to measurement labels to prevent anatomical structure occlusion

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -65,7 +65,7 @@ map_id_locations = {
 if sys.platform == "win32":
     MEASURE_LINE_COLOUR = (255, 0, 0, 255)
     MEASURE_TEXT_COLOUR = (0, 0, 0)
-    MEASURE_TEXTBOX_COLOUR = (255, 255, 165, 255)
+    MEASURE_TEXTBOX_COLOUR = (255, 255, 165, 128)
 else:
     MEASURE_LINE_COLOUR = (255, 0, 0, 128)
     MEASURE_TEXT_COLOUR = (0, 0, 0)
@@ -726,8 +726,7 @@ class LinearMeasure:
         a.DragableOn()
         a.GetPositionCoordinate().SetCoordinateSystemToWorld()
         a.GetPositionCoordinate().SetValue(x, y, z)
-        a.GetProperty().SetColor((0, 1, 0))
-        a.GetProperty().SetOpacity(0.75)
+        a.GetProperty().SetOpacity(0.5)
         self.text_actor = a
 
     def draw_to_canvas(self, gc, canvas):
@@ -978,6 +977,7 @@ class AngularMeasure:
         a.DragableOn()
         a.GetPositionCoordinate().SetCoordinateSystemToWorld()
         a.GetPositionCoordinate().SetValue(x, y, z)
+        a.GetProperty().SetOpacity(0.5)
         self.text_actor = a
 
     def draw_to_canvas(self, gc, canvas):


### PR DESCRIPTION
#1178
This PR implements 50% translucency for the measurement labels. This improvement allows users to maintain visual context of the structures underneath the labels while keeping the measurement values perfectly legible

Changes Made
2D Viewers: Updated MEASURE_TEXTBOX_COLOUR in 

invesalius/data/measures.py
 to include an alpha channel value of 128 (50% transparency).
3D/Surface View: Added SetOpacity(0.5) to the vtkActor2D properties for both 

LinearMeasure
 and 

AngularMeasure
 classes.
Unified Experience: Ensured the look and feel is consistent across all Axial, Coronal, Sagittal, and 3D views.
How to Test
Open any DICOM set.
Use the Linear Measurement or Angular Measurement tool.
Observe that the yellow background of the measurement label is semi-transparent, allowing you to see the underlying anatomy.
Verify this behavior in both the 2D slice panes and the 3D volume/surface pane.
