### PR TITLE
Fix #1183 Guard wx.CallAfter in coordinates.py to avoid potential shutdown race condition

### DIFF
--- a/invesalius/data/coordinates.py
+++ b/invesalius/data/coordinates.py
@@ -35,6 +35,12 @@ if TYPE_CHECKING:
     from invesalius.data.tracker_connection import TrackerConnection
 
 
+def _safe_call_after(func, *args, **kwargs):
+    """Call *func* on the main thread only if the wx.App still exists."""
+    if wx.GetApp() is not None:
+        wx.CallAfter(func, *args, **kwargs)
+
+
 class TrackerCoordinates:
     def __init__(self):
         self.coord: Optional[np.ndarray] = None
@@ -53,31 +59,31 @@ class TrackerCoordinates:
         self.coord = coord
         self.marker_visibilities = marker_visibilities
         if not self.nav_status:
-            wx.CallAfter(
+            _safe_call_after(
                 Publisher.sendMessage,
                 "From Neuronavigation: Update tracker poses",
                 poses=self.coord.tolist(),
                 visibilities=self.marker_visibilities,
             )
             if self.previous_marker_visibilities != self.marker_visibilities:
-                wx.CallAfter(
+                _safe_call_after(
                     Publisher.sendMessage,
                     "Sensors ID",
                     marker_visibilities=self.marker_visibilities,
                 )
-                wx.CallAfter(Publisher.sendMessage, "Render volume viewer")
+                _safe_call_after(Publisher.sendMessage, "Render volume viewer")
                 self.previous_marker_visibilities = self.marker_visibilities
 
     def GetCoordinates(self) -> Tuple[Optional[np.ndarray], List[bool]]:
         if self.nav_status:
-            wx.CallAfter(
+            _safe_call_after(
                 Publisher.sendMessage,
                 "From Neuronavigation: Update tracker poses",
                 poses=self.coord.tolist(),
                 visibilities=self.marker_visibilities,
             )
             if self.previous_marker_visibilities != self.marker_visibilities:
-                wx.CallAfter(
+                _safe_call_after(
                     Publisher.sendMessage,
                     "Sensors ID",
                     marker_visibilities=self.marker_visibilities,


### PR DESCRIPTION
fixes #1183 

This PR adds a small safeguard around `wx.CallAfter` calls in `invesalius/data/coordinates.py`.

`ReceiveCoordinates` runs as a background thread and schedules UI updates using `wx.CallAfter`. During application shutdown, the thread may still attempt to schedule UI updates after `wx.App` has already been destroyed, which can trigger the wxPython assertion:

`assert app is not None, 'No wx.App created yet'`

To prevent this potential shutdown race condition, a helper function `_safe_call_after()` was introduced that checks `wx.GetApp()` before invoking `wx.CallAfter`. All `wx.CallAfter(...)` calls in `coordinates.py` were replaced with `_safe_call_after(...)`.

This change does not modify existing logic and only adds a small safety guard.

Changes: 11 insertions, 5 deletions — 1 file (`invesalius/data/coordinates.py`).