### PR TITLE
fix(mask): clear 3d polygons when leaving edit in 3d mode

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -777,9 +777,17 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         super().CleanUp()
         self.viewer.canvas.unsubscribe_event("LeftButtonPressEvent", self.OnInsertPolygonPoint)
         self.viewer.canvas.unsubscribe_event("LeftButtonDoubleClickEvent", self.OnInsertPolygon)
-        for drawn_polygon in self.m3e_list:
-            drawn_polygon.visible = False
-            drawn_polygon.set_interactive(False)
+
+        # Issue #1078: When the 3D editor is disabled, polygons shouldn't just be hidden
+        # (which doesn't work properly due to CanvasHandlerBase), they should be fully removed.
+        # However, we cannot call self.ClearPolygons() because it also triggers
+        # self.OnRestoreInitMask() which reverts the cut! Instead, just remove the canvases:
+        self.viewer.canvas.draw_list = [
+            drawn_item
+            for drawn_item in self.viewer.canvas.draw_list
+            if not isinstance(drawn_item, PolygonSelectCanvas)
+        ]
+        self.m3e_list.clear()
 
         if self.has_set_mask_preview:
             Publisher.sendMessage("Disable mask 3D preview")


### PR DESCRIPTION
### Fixes #1078
### Replace #1177

### Problem
 As reported in issue #1078, disabling the "Edit in 3D" tool left polygon control points visible on the volume canvas. In a previous attempt to fix this, Mask3DEditorInteractorStyle.CleanUp() was modified to call self.ClearPolygons(). However, as pointed out by the reviewers, self.ClearPolygons() not only removed the polygon canvas elements but also invoked self.OnRestoreInitMask(). This inadvertently reverted all mask operations, causing the user's edits in the 2D slices and the newly generated 3D surface to be discarded.

### Solution 
This PR fixes the UI bug without destroying the mask data.

Modified Mask3DEditorInteractorStyle.CleanUp() in styles_3d.py to selectively purge PolygonSelectCanvas instances directly from self.viewer.canvas.draw_list using a list comprehension, followed by self.m3e_list.clear().

By extracting just the UI clearing logic from ClearPolygons() and intentionally omitting the OnRestoreInitMask() call, the 3D viewer is successfully wiped of lingering polygon points when the tool is disabled, while preserving all accumulated mask cuts and additions.
### Testing

Enable the 3D editor and draw a crop polygon.
Perform a cut to remove a part of the model.
Disable the 3D editor.
Verify that interacting with the volume window no longer displays lingering polygon points.
Verify that the cut applied to the mask remains intact on the 2D slices.
Verify that re-enabling "Edit in 3D" correctly generates a new preview mesh that reflects the latest edits.

After fix:



https://github.com/user-attachments/assets/3769c4dc-d3a5-4268-a1c6-88fd00ae8732



