### PR TITLE
fix: use dictionary parameter instead of module-level info in DumpDictionary

### DIFF
--- a/invesalius/reader/dicom.py
+++ b/invesalius/reader/dicom.py
@@ -1752,9 +1752,8 @@ def DumpDictionary(filename, dictionary=info):
     """
     import pickle
 
-    fp = open(filename, "wb")
-    pickle.dump(info, fp)
-    fp.close()
+    with open(filename, "wb") as fp:
+        pickle.dump(dictionary, fp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1195

## Summary

Fix `DumpDictionary()` in `invesalius/reader/dicom.py` to use the dictionary parameter instead of the module-level info variable
Also convert bare `open()/close()` to a `with` statement to prevent resource leak on exception


## Problem
```python
def DumpDictionary(filename, dictionary=info):
    pickle.dump(info, fp)   # always dumps module-level `info`, ignores `dictionary`
```
The dictionary parameter is never referenced in the function body info is hardcoded instead.