### PR TITLE
FIX: replace bare except clauses with except Exception (#1197)

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1430,7 +1430,7 @@ class ObjectTab(wx.Panel):
 
                 msg = _("Object file successfully loaded")
                 wx.MessageBox(msg, _("InVesalius 3"))
-        except:
+        except Exception:
             wx.MessageBox(_("Object registration file incompatible."), _("InVesalius 3"))
             Publisher.sendMessage("Update status text in GUI", label="")
 

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2821,7 +2821,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         # In the future, it would be better if the panel could initialize itself based on markers in MarkersControl
         try:
             self.markers.LoadState()
-        except:
+        except Exception:
             self.session.DeleteStateFile()  # Delete state file if it is erroneous
 
         # Add all lines into main sizer

--- a/invesalius/navigation/image.py
+++ b/invesalius/navigation/image.py
@@ -136,7 +136,7 @@ class Image:
                 self.load_from_state = False
                 try:
                     self.LoadState()
-                except:
+                except Exception:
                     ses.Session.DeleteStateFile()
                     self.LoadProject()  # Load project if failed to load from state
             else:


### PR DESCRIPTION
Fixes #1197

Replaces three bare `except:` clauses with `except Exception:` to avoid 
silently catching `KeyboardInterrupt` and `SystemExit`.

- `invesalius/navigation/image.py` line 139
- `invesalius/gui/preferences.py` line 1433
- `invesalius/gui/task_navigator.py` line 2824