### PR TITLE
fix: add missing x_mtms, y_mtms, r_mtms, intensity_mtms fields to Marker dataclass

### DIFF
--- a/invesalius/data/markers/marker.py
+++ b/invesalius/data/markers/marker.py
@@ -78,6 +78,10 @@ class Marker:
     # #TODO: add a reference to original coil marker to relate it to MEP
     # in micro Volts (but scale in milli Volts for display)
     mep_value: float = dataclasses.field(default=None)
+    x_mtms: float = dataclasses.field(default=None)
+    y_mtms: float = dataclasses.field(default=None)
+    r_mtms: float = dataclasses.field(default=None)
+    intensity_mtms: float = dataclasses.field(default=None)
     brain_target_list: list = dataclasses.field(default_factory=list)
 
     # x, y, z can be jointly accessed as position
@@ -265,6 +269,10 @@ class Marker:
             "z_rotation": self.z_rotation,
             "z_offset": self.z_offset,
             "mep_value": self.mep_value,
+            "x_mtms": self.x_mtms,
+            "y_mtms": self.y_mtms,
+            "r_mtms": self.r_mtms,
+            "intensity_mtms": self.intensity_mtms,
             "brain_target_list": self.brain_target_list,
             "marker_uuid": self.marker_uuid,
         }
@@ -312,6 +320,10 @@ class Marker:
         z_rotation = d.get("z_rotation", 0.0)
         is_point_of_interest = d.get("is_point_of_interest", False)
         mep_value = d.get("mep_value", None)
+        x_mtms = d.get("x_mtms", None)
+        y_mtms = d.get("y_mtms", None)
+        r_mtms = d.get("r_mtms", None)
+        intensity_mtms = d.get("intensity_mtms", None)
         brain_target_list = d.get("brain_target_list", [])
         marker_uuid = d.get("marker_uuid", "")
 
@@ -330,6 +342,10 @@ class Marker:
         self.z_offset = z_offset
         self.z_rotation = z_rotation
         self.mep_value = mep_value
+        self.x_mtms = x_mtms
+        self.y_mtms = y_mtms
+        self.r_mtms = r_mtms
+        self.intensity_mtms = intensity_mtms
         self.brain_target_list = brain_target_list
         self.marker_uuid = marker_uuid
 


### PR DESCRIPTION
## Problem

While reading through marker.py to understand the Marker dataclass for my GSoC proposal on marker visualization, I noticed that to_brain_targets_dict() references four attributes that are never defined in the dataclass:

- self.x_mtms
- self.y_mtms
- self.r_mtms
- self.intensity_mtms

I verified the fields are missing with a simple check:

>>(invesalius) PS D:\Gsoc\invesalius3> python -c "
>> from invesalius.data.markers.marker import Marker
>> m = Marker()
>> print(hasattr(m, 'x_mtms'))
>> print(hasattr(m, 'y_mtms'))
>> print(hasattr(m, 'r_mtms'))
>> print(hasattr(m, 'intensity_mtms'))
>> "
Restoring a previous state...
State file found. C:\Users\puran\.config\invesalius\state.json
False
False
False
False

These fields are being set dynamically in task_navigator.py (lines 3100-3103, 3797-3800, 3813-3816)  before   to_brain_targets_dict()
is called  which is why the normal mTMS workflow doesn't crash.
But any fresh Marker() object that calls to_brain_targets_dict() directly will crash with AttributeError.

to_brain_targets_dict() is called in 4 places in task_navigator.py:
Line 3105
Line 3801
Line 3817
Line 3967

Fix:

Added the four missing fields to the Marker dataclass with None
as default  consistent with how mep_value and cortex fields
are handled.
Also added them to to_dict() and from_dict() for consistency
with the rest of the serialization logic.

Verification
PS D:\Gsoc\invesalius3> .venv\Scripts\activate
>>(invesalius) PS D:\Gsoc\invesalius3> python -c "
>> from invesalius.data.markers.marker import Marker
>> m = Marker()
>> print(hasattr(m, 'x_mtms'))
>> print(hasattr(m, 'y_mtms'))
>> print(hasattr(m, 'r_mtms'))
>> print(hasattr(m, 'intensity_mtms'))
>> print(m.x_mtms, m.y_mtms, m.r_mtms, m.intensity_mtms)
>> "
>>True
>>True
>>True
>>True
>>None None None None