### PR TITLE
fix: remove duplicate variable assignments in MarkerVisualizer.AddMarker

### DIFF
--- a/invesalius/data/visualization/marker_visualizer.py
+++ b/invesalius/data/visualization/marker_visualizer.py
@@ -122,18 +122,11 @@ class MarkerVisualizer:
         """
         position = marker.position
         orientation = marker.orientation
-
-        position_flipped = list(position)
-        position_flipped[1] = -position_flipped[1]
-
-        position = marker.position
-        orientation = marker.orientation
         marker_id = marker.marker_id
         marker_type = marker.marker_type
         colour = marker.colour
         size = marker.size
         cortex_marker = marker.cortex_position_orientation
-
         position_flipped = list(position)
         position_flipped[1] = -position_flipped[1]
 


### PR DESCRIPTION
## Problem

While reading through `marker_visualizer.py` to understand the 3D marker visualization for my GSoC proposal, I noticed that the first **5 lines of `AddMarker()`** are completely **dead code** — they are immediately overwritten by identical assignments a few lines later.

### Dead Code Block (lines 123–127)

```python
def AddMarker(self, marker, render, focus):
        """
        Visualize marker and add the visualization to the marker object.

        If 'render' is True, the interactor will be rendered after adding the marker.
        """
        position = marker.position
        orientation = marker.orientation

        position_flipped = list(position)
        position_flipped[1] = -position_flipped[1]

        position = marker.position
        orientation = marker.orientation
        marker_id = marker.marker_id
        marker_type = marker.marker_type
        colour = marker.colour
        size = marker.size
        cortex_marker = marker.cortex_position_orientation

        position_flipped = list(position)
        position_flipped[1] = -position_flipped[1]
```

The first block assigns `position`, `orientation`, and `position_flipped` — but all three are **reassigned before they are ever used**.

Therefore, the **first block has never had any effect**.

Verified with `git log` — the duplicate has been present since the method was introduced.

---

## Fix

Removed the first **dead code block**.  
The second block remains **exactly as is** — no logic changed.

---

## Verification

```python
python -c "
from invesalius.data.visualization.marker_visualizer import MarkerVisualizer
print('Import OK')
"
```

**Output**

```
Import OK
```