### PR TITLE
Fix Mask 3D Preview: Select Parts bugs (#1081) for red selecti…

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2712,7 +2712,7 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
                         Publisher.sendMessage(
                             "Remove mask preview", mask_3d_actor=old_mask.volume._actor
                         )
-                    
+
                 # Now that actors are ready, trigger the final visibility and render
                 Publisher.sendMessage("Show mask", index=self.config.mask.index, value=True)
                 Publisher.sendMessage("Render volume viewer")
@@ -2764,7 +2764,7 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
 
         self.config.mask.was_edited = True
         Publisher.sendMessage("Reload actual slice")
-        
+
         # Bug 1 fix: also update the 3D Mask Preview to show selection in red
         if ses.Session().mask_3d_preview:
             self.config.mask.imagedata = self.config.mask.as_vtkimagedata()


### PR DESCRIPTION
### Description
This PR fixes two visual bugs related to the 3D Mask Preview mode when using the "Select Parts" tool.

**1. Fixes Issue #1081 (3D Volume not highlighting in red)**
Previously, when flood-filling an area using "Select Parts", only the 2D slices correctly temporarily highlighted in red. The 3D volume preview remained unaffected.

**2. Fixes Color Flashing / Black Screen Issue (Related to #1080)**
Previously, when the user clicked "OK" to finalize the selection, the 3D viewer would briefly flash black or rapidly change colors before settling on the new mask color.

***

### Changes
* **[invesalius/data/styles.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles.py:0:0-0:0) ([OnSelect](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles.py:2724:4-2775:57)):** Added logic to generate the 3D volume preview and explicitly set its color to red [(1.0, 0.0, 0.0)](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/mask.py:93:4-105:57) when a region is selected, synchronizing it with the 2D behavior.
* **[invesalius/data/styles.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles.py:0:0-0:0) ([CleanUp](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:248:4-254:86)):** 
  * Explicitly set the final assigned color onto the mask actor *before* any render events occur.
  * Overlapped the actor state transitions by loading the new, correctly colored 3D actor into the renderer *before* the temporary preview actor is removed.
  * Passed `show=False` to [_add_mask_into_proj](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/slice_.py:1487:4-1508:56) to prevent the system from implicitly triggering early rendering.
  * Manually triggered `Show mask` and `Render volume viewer` only when the actor setup is 100% complete, eliminating the intermediate flickering frame.

***

### How to Test
1. Load a sample in InVesalius.
2. Enable Mask 3D Preview (`Tools -> Mask -> Mask 3D Preview -> Enable`).
3. Open Select Parts (`Tools -> Mask -> Select Parts`).
4. Click a region on a 2D slice — **verify both the 2D slices and the 3D preview turn red**.
5. Click **OK** on the dialog — **verify the mask transitions smoothly directly to its generated color without flashing or turning black**.

### After fix:


https://github.com/user-attachments/assets/8812711e-7258-480a-8e6a-cdbb4ac52db5

