### PR TITLE
fix: resolve vtkIdFilter deprecation and maintain backward compatibility

### DIFF
--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -22,18 +22,23 @@ from typing import Iterable, List
 
 import numpy as np
 from vtkmodules.util import numpy_support
-from vtkmodules.vtkCommonCore import vtkIdList, vtkIdTypeArray
+from vtkmodules.vtkCommonCore import vtkIdList, vtkIdTypeArray, vtkVersion
 from vtkmodules.vtkCommonDataModel import vtkPolyData, vtkSelection, vtkSelectionNode
 from vtkmodules.vtkFiltersCore import (
     vtkAppendPolyData,
     vtkCleanPolyData,
-    vtkIdFilter,
     vtkMassProperties,
     vtkPolyDataConnectivityFilter,
     vtkQuadricDecimation,
     vtkSmoothPolyDataFilter,
     vtkTriangleFilter,
 )
+
+if vtkVersion.GetVTKMajorVersion() >= 9.4:
+    from vtkmodules.vtkFiltersCore import vtkGenerateIds as vtkIdFilter
+else:
+    from vtkmodules.vtkFiltersCore import vtkIdFilter
+
 from vtkmodules.vtkFiltersExtraction import vtkExtractSelection
 from vtkmodules.vtkFiltersGeometry import vtkGeometryFilter
 from vtkmodules.vtkFiltersModeling import vtkFillHolesFilter


### PR DESCRIPTION
This PR addresses the startup crash on modern VTK releases as described in #1221.

**Changes**
 
- Added a version check for vtk
- Imports vtkGenerateIds as vtkFilterId to prevent more code changes for versions >=9.4
- Import vtkFilterId in the case of versions before 9.4

Verified on Ubuntu 24.0.4. Invesalius ran perfectly fine.

`Closes #1221 `