### PR TITLE
Fix Mask 3D Preview color not reverting when canceling Select Parts

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2717,7 +2717,11 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
                 Publisher.sendMessage("Show mask", index=self.config.mask.index, value=True)
                 Publisher.sendMessage("Render volume viewer")
             else:
-                if ses.Session().mask_3d_preview and hasattr(self.config.mask, 'volume') and self.config.mask.volume is not None:
+                if (
+                    ses.Session().mask_3d_preview
+                    and hasattr(self.config.mask, "volume")
+                    and self.config.mask.volume is not None
+                ):
                     Publisher.sendMessage(
                         "Remove mask preview", mask_3d_actor=self.config.mask.volume._actor
                     )


### PR DESCRIPTION
### Description
Fixes an issue where canceling the "Select Parts" tool on a mask while "3D Mask Preview" is active would leave the 3D volume colored with the temporary selection color (red) instead of reverting to its original state.

### Changes
The temporary 3D mask preview actor was not being properly removed when the interactor finished without applying the changes (i.e., when canceled). 

Added an `else` condition inside `SelectMaskPartsInteractorStyle` to explicitly publish the `"Remove mask preview"` event and trigger `"Render volume viewer"` when the operation is wrapped up without applying a selection. This ensures the temporary selection actor is cleaned up correctly.

### Testing
1. Load a DICOM project or volume and generate a mask.
2. Ensure the **3D Mask Preview** is enabled.
3. Open the **Select Parts** tool.
4. Attempt to select a part (the region should highlight).
5. **Cancel** the operation.
6. Observe the 3D model: it should now correctly revert to its original state without the temporary selection color lingering.


### After fix:


https://github.com/user-attachments/assets/dbacefed-ab8e-4b6b-a832-95976990b97f

