### PR TITLE
Fix Mask3DEditorInteractorStyle rotation crash when Shift is held

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -732,9 +732,18 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         ## Remove observers and bindings from super
         self.RemoveObservers("LeftButtonPressEvent")
         self.viewer.interactor.Unbind(wx.EVT_LEFT_DCLICK, handler=self.SetCameraFocus)
+        self.RemoveObservers("MouseWheelForwardEvent")
+        self.RemoveObservers("MouseWheelBackwardEvent")
+        self.RemoveObservers("MouseMoveEvent")
+
         ## Bind events for this style
-        self.viewer.canvas.subscribe_event("LeftButtonPressEvent", self.OnInsertPolygonPoint)
-        self.viewer.canvas.subscribe_event("LeftButtonDoubleClickEvent", self.OnInsertPolygon)
+        self.viewer.canvas.subscribe_event("LeftButtonPressEvent", self.OnLeftButtonPress)
+        self.viewer.canvas.subscribe_event(
+            "LeftButtonDoubleClickEvent", self.OnLeftButtonDoubleClick
+        )
+        self.AddObserver("MouseMoveEvent", self.OnMouseMove)
+        self.AddObserver("MouseWheelForwardEvent", self.OnScrollForward)
+        self.AddObserver("MouseWheelBackwardEvent", self.OnScrollBackward)
 
         sub = Publisher.subscribe
         sub(self.ReceiveVolumeViewerActiveCamera, "Receive volume viewer active camera")
@@ -785,8 +794,10 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         This is called by the volume ``Viewer.SetInteractorStyle`` method.
         """
         super().CleanUp()
-        self.viewer.canvas.unsubscribe_event("LeftButtonPressEvent", self.OnInsertPolygonPoint)
-        self.viewer.canvas.unsubscribe_event("LeftButtonDoubleClickEvent", self.OnInsertPolygon)
+        self.viewer.canvas.unsubscribe_event("LeftButtonPressEvent", self.OnLeftButtonPress)
+        self.viewer.canvas.unsubscribe_event(
+            "LeftButtonDoubleClickEvent", self.OnLeftButtonDoubleClick
+        )
 
         # Issue #1078: When the 3D editor is disabled, polygons shouldn't just be hidden
         # (which doesn't work properly due to CanvasHandlerBase), they should be fully removed.
@@ -847,7 +858,43 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.OnRestoreInitMask()
         self.viewer.UpdateCanvas()
 
-    def OnInsertPolygonPoint(self, _evt):
+    def OnLeftButtonPress(self, evt):
+        if self.viewer.interactor.GetShiftKey():
+            # Delegate to standard camera rotation
+            self.left_pressed = True
+            self.StartRotate()
+            return
+
+        # Original polygon insertion logic
+        self.OnInsertPolygonPoint(evt)
+
+    def OnLeftButtonDoubleClick(self, evt):
+        if self.viewer.interactor.GetShiftKey():
+            # Delegate to standard camera focus
+            self.SetCameraFocus(evt)
+            return
+
+        # Original polygon completion logic
+        self.OnInsertPolygon(evt)
+
+    def OnMouseMove(self, obj, evt):
+        if self.viewer.interactor.GetShiftKey():
+            # If standard camera manipulation was started via shift+left/middle/right click
+            if self.left_pressed or self.middle_pressed or self.right_pressed:
+                super().OnMouseMove(obj, evt)
+                return
+
+        super().OnMouseMove(obj, evt)
+
+    def OnScrollForward(self, obj, evt):
+        if self.viewer.interactor.GetShiftKey():
+            super().OnScrollForward(obj, evt)
+
+    def OnScrollBackward(self, obj, evt):
+        if self.viewer.interactor.GetShiftKey():
+            super().OnScrollBackward(obj, evt)
+
+    def OnInsertPolygonPoint(self, evt):
         """Insert a point in the polygon.
 
         If no polygon is open, it initializes a new one.
@@ -861,11 +908,12 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         current_masker.insert_point((mouse_x, mouse_y))
         self.viewer.UpdateCanvas()
 
-    def OnInsertPolygon(self, _evt):
+    def OnInsertPolygon(self, evt):
         """Complete the polygon by connecting the last point to the first one."""
-        self.m3e_list[-1].complete_polygon()
-        Publisher.sendMessage("M3E cut mask from 3D")
-        self.viewer.UpdateCanvas()
+        if len(self.m3e_list) > 0 and not self.m3e_list[-1].complete:
+            self.m3e_list[-1].complete_polygon()
+            Publisher.sendMessage("M3E cut mask from 3D")
+            self.viewer.UpdateCanvas()
 
     def ReceiveVolumeViewerActiveCamera(self, cam: "vtkCamera"):
         """Receive the active camera from the volume viewer through pubsub.


### PR DESCRIPTION
## Description

### fixes : #1229 
This PR fixes a critical crash that occurred when a user pressed `Shift` and attempted to rotate the 3D model while the "Edit 3D" mode was active.


## Solution
* Updated [OnLeftButtonPress](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:856:4-864:38) in [invesalius/data/styles_3d.py](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:0:0-0:0) to properly handle Shift-clicks. It now sets `self.left_pressed = True` and explicitly invokes `self.StartRotate()`. This safely replicates the standard rotation logic inherited from [Base3DInteractorStyle](cci:2://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:49:0-89:35).

## Testing 
* Created a dummy project and generated a 3D surface.
* Navigated to the "Edit 3D" mode.
* Held down the `Shift` key and left-click-dragged the 3D model.
* Verified that the model rotates smoothly without raising any exceptions or crashing the application.

### After fix:


https://github.com/user-attachments/assets/5095c1a6-f062-43a0-99d4-df1d1fefbc46
