### PR TITLE
Fix: Data Panel Collapse Overlay Issue

### DIFF
--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -159,9 +159,7 @@ class Panel(wx.Panel):
 class LowerTaskPanel(wx.Panel):
     def __init__(self, parent):
         wx.Panel.__init__(self, parent, size=(150, -1))
-        fold_panel = fpb.FoldPanelBar(
-            self, -1, style=FPB_DEFAULT_STYLE
-        )
+        fold_panel = fpb.FoldPanelBar(self, -1, style=FPB_DEFAULT_STYLE)
 
         self.fold_panel = fold_panel
         fold_panel.Bind(fpb.EVT_CAPTIONBAR, self.OnCaptionBar)
@@ -260,19 +258,19 @@ class LowerTaskPanel(wx.Panel):
         item = self.enable_items[0]
         # Check if the fold panel item is visually expanded
         is_expanded = item.IsExpanded()
-        
+
         x_current, _ = self.GetSize()
         # Fallback to -1 so GridBagSizer can stretch it horizontally
         if x_current <= 20:
             x_current = -1
-            
+
         if is_expanded:
             y_needed = 240 if sys.platform != "win32" else 230
         else:
             y_needed = self.fold_panel.GetPanelsLength(0, 0)[2]
-            
+
         self.SetMinSize((x_current, y_needed))
-        
+
         parent = self.GetParent()
         if parent:
             parent.Layout()
@@ -426,20 +424,20 @@ class UpperTaskPanel(wx.Panel):
         item = self.enable_items[0]
         # Check if the fold panel item is visually expanded
         is_expanded = item.IsExpanded()
-        
+
         if is_expanded:
             y_needed = 240 if sys.platform != "win32" else 230
         else:
             y_needed = self.fold_panel.GetPanelsLength(0, 0)[2]
-            
+
         self.fold_panel.SetMinSize((-1, y_needed))
         self.fold_panel.SetSize((-1, y_needed))
-        
-        # We must also tell the parent (LowerTaskPanel) to refresh its min size 
+
+        # We must also tell the parent (LowerTaskPanel) to refresh its min size
         # based on the new fold_panel size
         self.SetMinSize((-1, y_needed))
         self.SetSize((-1, y_needed))
-        
+
         parent = self.GetParent()
         if parent:
             parent.Layout()


### PR DESCRIPTION

### Problem

When collapsing the data section in the lower task panel, the panel height was not recalculated properly. This caused layout inconsistencies and overlay issues in the UI.
<img width="492" height="1016" alt="image" src="https://github.com/user-attachments/assets/e5a97e83-4cd6-47bf-b4f0-318a1ee9d2f2" />

### Solution

This patch improves the "ResizeFPB()" logic by:

- Detecting whether the fold panel item is expanded using "IsExpanded()"
- Dynamically calculating the required panel height
- Updating both the fold panel and its parent layout to ensure proper resizing
- Removing the "FPB_COLLAPSE_TO_BOTTOM" style that caused inconsistent behavior

### Result

The lower task panel now resizes correctly when the data section is expanded or collapsed, preventing overlay and layout issues.
<img width="483" height="902" alt="image" src="https://github.com/user-attachments/assets/41750d23-a6cf-4f88-a7dc-ad0339e206e0" />


### Files Changed

- "invesalius/gui/default_tasks.py"