### PR TITLE
fix(markers): Fix volume turning red and slices jumping to 0  on marker creation

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1643,6 +1643,20 @@ class Viewer(wx.Panel):
         if self.orientation != "AXIAL":
             return
 
+        # Validate marker position is within volume bounds
+        if not hasattr(self, "slice_") or self.slice_ is None:
+            return
+        if not hasattr(self.slice_, "matrix") or self.slice_.matrix is None:
+            return
+
+        try:
+            vx, vy, vz = self.get_voxel_coord_by_world_pos(marker.x, marker.y, marker.z)
+            dz, dy, dx = self.slice_.matrix.shape
+            if not (0 <= vx < dx and 0 <= vy < dy and 0 <= vz < dz):
+                return
+        except Exception:
+            return
+
         if not self.nav_status:
             Publisher.sendMessage(
                 "Set cross focal point", position=[marker.x, marker.y, marker.z, None, None, None]

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -4143,7 +4143,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             cortex_position_orientation=cortex_position_orientation,
             mep_value=mep_value,
         )
-        self.markers.AddMarker(marker, render=True, focus=True)
+        self.markers.AddMarker(marker, render=True, focus=self.nav_status)
 
     # Given a string, try to parse it as an integer, float, or string.
     #
@@ -4390,6 +4390,16 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         """
         if label is None:
             label = self.GetNextMarkerLabel()
+
+        # Fallback to current slice position when current_position is [0,0,0] and navigation is inactive
+        if position is None and self.current_position == [0, 0, 0] and not self.nav_status:
+            sl = slice_.Slice()
+            spacing = sl.spacing
+            position = [
+                sl.buffer_slices["SAGITAL"].index * spacing[0],
+                sl.buffer_slices["CORONAL"].index * spacing[1],
+                sl.buffer_slices["AXIAL"].index * spacing[2],
+            ]
 
         marker = Marker()
 


### PR DESCRIPTION
## Summary
Fixes #1237 — Volume viewer turns red and slices jump to [0,0,0] 
when creating or selecting a marker without active navigation.

## Root Cause
Two related issues:

1. In `CreateMarker()`, when navigation is inactive, `self.current_position` 
   defaults to `[0,0,0]`. This caused markers to be placed at the origin, 
   triggering slice synchronization to an invalid position.

2. In `OnHighlightMarker()`, no bounds validation existed — any marker 
   position outside volume bounds would cause slices to jump and corrupt 
   volume rendering.

## Fix
**`task_navigator.py`** — Restored deterministic position calculation as 
fallback in `CreateMarker()`. When `current_position` is `[0,0,0]` and 
navigation is inactive, position is derived from current `buffer_slices` 
indices and image spacing — the same approach used before it was simplified.

**`data/viewer_slice.py`** — Added bounds validation in `OnHighlightMarker()` 
before sending `"Set cross focal point"`. If marker position is outside 
volume bounds, slice synchronization is skipped gracefully.

## Testing
- [x] Create marker without navigation → Volume stays normal
- [x] Click marker in list → Slices sync to correct position
- [x] Volume does not turn red or yellow
- [x] Existing slice synchronization behavior unaffected

## Related
Builds on #1143 — Stage 1: Synchronize slice viewers on marker selection

