### PR TITLE
Fix Python 3.12 SyntaxWarning (invalid escape sequence) logs

### DIFF
--- a/invesalius/data/transformations.py
+++ b/invesalius/data/transformations.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Homogeneous Transformation Matrices and Quaternions.
+r"""Homogeneous Transformation Matrices and Quaternions.
 
 A library for calculating 4x4 matrices for translating, rotating, reflecting,
 scaling, shearing, projecting, orthogonalizing, and superimposing arrays of
@@ -893,7 +893,7 @@ def orthogonalization_matrix(lengths, angles):
 
 
 def affine_matrix_from_points(v0, v1, shear=True, scale=True, usesvd=True):
-    """Return affine transform matrix to register two point sets.
+    r"""Return affine transform matrix to register two point sets.
 
     v0 and v1 are shape (ndims, \*) arrays of at least ndims non-homogeneous
     coordinates, where ndims is the dimensionality of the coordinate space.
@@ -1004,7 +1004,7 @@ def affine_matrix_from_points(v0, v1, shear=True, scale=True, usesvd=True):
 
 
 def superimposition_matrix(v0, v1, scale=False, usesvd=True):
-    """Return matrix to transform given 3D point set into second point set.
+    r"""Return matrix to transform given 3D point set into second point set.
 
     v0 and v1 are shape (3, \*) or (4, \*) arrays of at least 3 points.
 

--- a/invesalius/reader/bitmap_reader.py
+++ b/invesalius/reader/bitmap_reader.py
@@ -125,7 +125,7 @@ class BitmapFiles:
         self.bitmapfiles.append(bmp)
 
     def Sort(self, x):
-        c_re = re.compile("\d+")
+        c_re = re.compile(r"\d+")
         if len(c_re.findall(x[6])) > 0:
             return [int(i) for i in c_re.findall(x[6])]
         else:


### PR DESCRIPTION
Hi everyone!

While setting up InVesalius on my local machine to prepare for GSoC 2026, I noticed a few red warning logs popping up in the terminal when I ran app.py using Python 3.12.

Since Python 3.12 is stricter about how text strings are written, it throws a SyntaxWarning: invalid escape sequence when it sees backslashes (\) inside normal strings.

To fix this, I just added an r in front of the specific strings in invesalius/data/transformations.py and invesalius/reader/bitmap_reader.py to turn them into raw strings. The app runs perfectly now, and the terminal is clear of those warnings!

A quick note on testing:
I also ran the built-in doctests for transformations.py locally. A few tests failed, but looking closely at the logs, it seems to be because modern versions of NumPy format array strings with different spacing than NumPy 1.9 did back in 2015 (e.g., [ 1.,  1.] vs [1., 1.]), and there is a slight floating-point precision difference in shear_from_matrix. My string prefix changes didn't affect the math!

This is my first small PR to get familiar with the codebase and the contribution process here. Please let me know if everything looks good or if I should change anything!

Thanks,
Aditya