### PR TITLE
Add selected marker visualization on 2D image slices

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -24,6 +24,7 @@ import sys
 import wx
 from vtkmodules.vtkFiltersGeneral import vtkCursor3D
 from vtkmodules.vtkFiltersHybrid import vtkRenderLargeImage
+from vtkmodules.vtkFiltersSources import vtkRegularPolygonSource
 from vtkmodules.vtkInteractionStyle import vtkInteractorStyleImage
 from vtkmodules.vtkIOExport import vtkPOVExporter
 from vtkmodules.vtkIOImage import (
@@ -248,6 +249,7 @@ class Viewer(wx.Panel):
         # VTK pipeline and actors
         self.__config_interactor()
         self.cross_actor = vtkActor()
+        self.marker_indicator_actor = None
 
         self.__bind_events()
         self.__bind_events_wx()
@@ -943,6 +945,7 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.UpdateCross, "Update cross pos")
         Publisher.subscribe(self.OnNavigationStatus, "Navigation status")
         Publisher.subscribe(self.OnHighlightMarker, "Highlight marker")
+        Publisher.subscribe(self.OnUnhighlightMarker, "Unhighlight marker")
 
     def RefreshViewer(self):
         self.Refresh()
@@ -1066,6 +1069,7 @@ class Viewer(wx.Panel):
         self.cursor = None
         self.wl_text = None
         self.pick = vtkWorldPointPicker()
+        self.marker_indicator_actor = None
 
     def OnSetInteractorStyle(self, style):
         self.SetInteractorStyle(style)
@@ -1159,6 +1163,7 @@ class Viewer(wx.Panel):
         self.slice_data.SetCursor(self.__create_cursor())
         self.cam = self.slice_data.renderer.GetActiveCamera()
         self.__build_cross_lines()
+        self.__build_marker_indicator()
 
         self.canvas = CanvasRendererCTX(
             self, self.slice_data.renderer, self.slice_data.canvas_renderer, self.orientation
@@ -1635,18 +1640,56 @@ class Viewer(wx.Panel):
         if not self.nav_status:
             self.UpdateRender()
 
+    def __build_marker_indicator(self):
+        """Build a small sphere actor used to highlight the selected marker position on 2D slices."""
+        from vtkmodules.vtkFiltersSources import vtkSphereSource
+        
+        renderer = self.slice_data.overlay_renderer
+
+        # Create a sphere so it appears circular regardless of the slice orientation
+        sphere_source = vtkSphereSource()
+        sphere_source.SetRadius(3.0)
+        sphere_source.SetThetaResolution(16)
+        sphere_source.SetPhiResolution(16)
+        self._marker_indicator_source = sphere_source
+
+        mapper = vtkPolyDataMapper()
+        mapper.SetInputConnection(sphere_source.GetOutputPort())
+
+        actor = vtkActor()
+        actor.SetMapper(mapper)
+        actor.GetProperty().SetColor(1.0, 1.0, 0.0)  # Yellow
+        actor.GetProperty().SetOpacity(0.85)
+        actor.VisibilityOff()
+        actor.PickableOff()
+
+        self.marker_indicator_actor = actor
+        renderer.AddActor(actor)
+
     def OnHighlightMarker(self, marker):
-        """Synchronize slice viewers to the selected marker's position."""
+        """Synchronize slice viewers to the selected marker's position and show marker indicator."""
         if marker is None:
             return
 
-        if self.orientation != "AXIAL":
-            return
-
+        # Move the cross focal point and scroll slices to the marker position.
         if not self.nav_status:
             Publisher.sendMessage(
                 "Set cross focal point", position=[marker.x, marker.y, marker.z, None, None, None]
             )
+
+        # Show the marker indicator circle at the marker's world position.
+        if self.marker_indicator_actor is not None:
+            self.marker_indicator_actor.SetPosition(marker.x, marker.y, marker.z)
+            self.marker_indicator_actor.VisibilityOn()
+            if not self.nav_status:
+                self.UpdateRender()
+
+    def OnUnhighlightMarker(self):
+        """Hide the marker indicator on 2D slices when a marker is deselected."""
+        if self.marker_indicator_actor is not None:
+            self.marker_indicator_actor.VisibilityOff()
+            if not self.nav_status:
+                self.UpdateRender()
 
     def AddActors(self, actors, slice_number):
         "Inserting actors"

--- a/invesalius/navigation/markers.py
+++ b/invesalius/navigation/markers.py
@@ -284,6 +284,9 @@ class MarkersControl(metaclass=Singleton):
         # keyboard events.
         self.transformator.UpdateSelectedMarker(None)
 
+        # Unhighlight marker in viewer volume and 2D slice viewers.
+        Publisher.sendMessage("Unhighlight marker")
+
     def CreateCoilTargetFromLandmark(self, marker: Marker, label: str = None) -> None:
         new_marker = marker.duplicate()
 


### PR DESCRIPTION
# feat: Add selected marker visualization on 2D image slices

## 🎯 Purpose
This PR implements the feature for visualizing selected markers on axial, sagittal, and coronal image slices. This directly addresses the GSoC project requirement to improve spatial understanding during neuronavigation tasks by synchronizing marker selection with orthogonal slice views.

## 🛠 Changes

### Core Visualization ([invesalius/data/viewer_slice.py](cci:7://file:///Users/armaanbawa/invesalius3/invesalius/data/viewer_slice.py:0:0-0:0))
- **New Marker Indicator**: Added a 3D sphere indicator (`vtkSphereSource`) to the overlay renderer of all three slice orientations. Using a sphere ensures the marker remains visible as a filled circle regardless of the slice angle.
- **Improved Synchronization**: Updated [OnHighlightMarker](cci:1://file:///Users/armaanbawa/invesalius3/invesalius/data/viewer_slice.py:1637:4-1648:13) to handle all slice orientations (axial, coronal, and sagittal). The viewer now automatically scrolls to the marker's depth and toggles the visibility of the indicator.
- **Cleanup logic**: Added [OnUnhighlightMarker](cci:1://file:///Users/armaanbawa/invesalius3/invesalius/data/viewer_slice.py:1686:4-1691:35) to hide the indicator when markers are deselected, and ensured proper cleanup in [CloseProject](cci:1://file:///Users/armaanbawa/invesalius3/invesalius/data/viewer_slice.py:1047:4-1067:41).

### Navigation Control ([invesalius/navigation/markers.py](cci:7://file:///Users/armaanbawa/invesalius3/invesalius/navigation/markers.py:0:0-0:0))
- **Event Propagation**: Updated [DeselectMarker](cci:1://file:///Users/armaanbawa/invesalius3/invesalius/navigation/markers.py:281:4-287:51) to publish the `"Unhighlight marker"` event, ensuring that the 2D slice viewers correctly clear the indicator when a user clicks away from a selected marker.

## 🧪 Verification Results

### Manual Test Steps
1. Load a DICOM dataset.
2. Enable **Navigation Mode** from the [Mode](cci:1://file:///Users/armaanbawa/invesalius3/invesalius/gui/frame.py:856:4-865:71) menu.
3. Add a marker in the Navigation panel.
4. **Select the marker**: Observe that a yellow circle appears on all 3 slice views and the slices scroll to the correct position.
5. **Deselect the marker**: Observe that the yellow indicator disappears from all slices.

### Internal Verification
- [x] Verified Python syntax and imports.
- [x] Confirmed consistent PubSub event wiring between [markers.py](cci:7://file:///Users/armaanbawa/invesalius3/invesalius/navigation/markers.py:0:0-0:0) and [viewer_slice.py](cci:7://file:///Users/armaanbawa/invesalius3/invesalius/data/viewer_slice.py:0:0-0:0).
- [x] Successfully tested in a live session with a loaded CT dataset.

## 📸 Screenshots

<img width="1023" height="719" alt="before" src="https://github.com/user-attachments/assets/e9e2eb1c-fe3b-42a4-b348-32ba8c7891de" />
<img width="1022" height="718" alt="after" src="https://github.com/user-attachments/assets/68f00024-ed12-4fad-b604-f2fe66fd516d" />