### PR TITLE
fix(surface): resolve UnboundLocalError and incorrect traceback print…

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -1068,6 +1068,12 @@ class SurfaceManager:
             overwrite = False
         mask.matrix.flush()
 
+        # Default values (Optimal *)
+        imagedata_resolution = const.SURFACE_QUALITY[const.DEFAULT_SURFACE_QUALITY][0]
+        smooth_iterations = const.SURFACE_QUALITY[const.DEFAULT_SURFACE_QUALITY][1]
+        smooth_relaxation_factor = const.SURFACE_QUALITY[const.DEFAULT_SURFACE_QUALITY][2]
+        decimate_reduction = const.SURFACE_QUALITY[const.DEFAULT_SURFACE_QUALITY][3]
+
         if quality in const.SURFACE_QUALITY.keys():
             imagedata_resolution = const.SURFACE_QUALITY[quality][0]
             smooth_iterations = const.SURFACE_QUALITY[quality][1]
@@ -1176,7 +1182,7 @@ class SurfaceManager:
                 surface_filename, surface_measures = f.get()
             except Exception:
                 print(_("InVesalius was not able to create the surface"))
-                print(traceback.print_exc())
+                traceback.print_exc()
                 return
 
             reader = vtkXMLPolyDataReader()


### PR DESCRIPTION
Fixes #1248 
# Description

This PR fixes two bugs in `invesalius/data/surface.py` identified in the surface generation pipeline to ensure improved stability and error visibility.

## Fixes Implemented:

1. **Resolved `UnboundLocalError` in Surface Properties:**
   - **How it was fixed:** Default fallback values (derived from the "Optimal *" configuration) are now instantiated *before* the conditional check for `quality in const.SURFACE_QUALITY.keys()`. 
   - **Why this works:** If the provided `quality` metric doesn't match a predefined key, the variables `imagedata_resolution`, `smooth_iterations`, `smooth_relaxation_factor`, and `decimate_reduction` are already instantiated with sensible, safe defaults, allowing the codebase to proceed unconditionally without crashing.

2. **Corrected Exception Logging Tracebacks:**
   - **How it was fixed:** Removed the redundant `print()` wrapper around `traceback.print_exc()`. 
   - **Why this works:** `traceback.print_exc()` independently manages formatting and printing the exception stack trace to the standard error buffer (`stderr`). Removing the `print()` wrapper prevents the function from returning and printing a literal `None` string, ensuring developers can actually read the root cause of the exception.

## Validation:
- Ran the existing test suites (`pytest tests/test_mesh_generation.py`), validating that mesh generation, smoothing, and decimation still succeed. 
- The codebase was analyzed to verify the scoping of the default parameters.