### PR TITLE
fix: IndexError when loading legacy `.obr` files by validating before indexing

### DIFF
--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1417,16 +1417,18 @@ class ObjectTab(wx.Panel):
                 obj_fiducials = registration_coordinates[:, :3]
                 obj_orients = registration_coordinates[:, 3:]
 
-                coil_name = data[0][0][2:]
-                coil_path = data[0][1].encode(const.FS_ENCODE)
-                tracker_id = int(data[0][3])
-                obj_id = int(data[0][-1])
-                coil_name = "default_coil" if self.navigation.n_coils == 1 else coil_name
-
                 # Handle old OBR file which lacks coil_name and tracker information
                 if len(data[0]) < 6:
                     coil_name = "default_coil"
+                    coil_path = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl").encode(const.FS_ENCODE)
                     tracker_id = self.tracker.tracker_id
+                    obj_id = int(data[0][-1])
+                else:
+                    coil_name = data[0][0][2:]
+                    coil_path = data[0][1].encode(const.FS_ENCODE)
+                    tracker_id = int(data[0][3])
+                    obj_id = int(data[0][-1])
+                coil_name = "default_coil" if self.navigation.n_coils == 1 else coil_name
 
                 if coil_name in self.coil_registrations and coil_name != "default_coil":
                     # Warn that we are overwriting an old registration


### PR DESCRIPTION
## **SUMMARY**

This PR fixes an `IndexError` when loading legacy `.obr` files by ensuring validation occurs before accessing indexed fields. The issue is caused by accessing `data[0][3]` and similar indices before checking the data length.

---

## **FIX**

* **Root cause:**
  A validation guard (`len(data[0]) < 6`) was placed *after* unsafe indexing, causing an `IndexError` for old-format `.obr` files before fallback logic could run.


### **Before**

```python
coil_name = data[0][0][2:]
tracker_id = int(data[0][3])  

if len(data[0]) < 6:
    coil_name = "default_coil"
```


### **After**

```python
if len(data[0]) < 6:
    coil_name = "default_coil"
    tracker_id = self.tracker.tracker_id
else:
    coil_name = data[0][0][2:]
    tracker_id = int(data[0][3])
```

---

## **RESULT**

* Legacy `.obr` files (with fewer than 6 fields) now load successfully instead of triggering an `IndexError`.
* The fallback logic (`default_coil`, default path, tracker ID) is correctly applied as originally intended.
* The misleading “Object registration file incompatible” error is no longer shown for valid old-format files.
* Behavior for modern `.obr` files remains unchanged.


