### PR TITLE
fix: correct slice comparison in DICOM grouper using next slice

### DIFF
--- a/invesalius/reader/dicom_grouper.py
+++ b/invesalius/reader/dicom_grouper.py
@@ -311,10 +311,10 @@ class PatientGroup:
             axis = ORIENT_MAP[group_key[0]]  # based on orientation
             for index in range(len(sorted_list) - 1):
                 current = sorted_list[index]
-                # next = sorted_list[index + 1]
+                next_item = sorted_list[index + 1]
 
                 pos_current = current.image.position[axis]
-                pos_next = current.image.position[axis]
+                pos_next = next_item.image.position[axis]
                 spacing = current.image.spacing
 
                 if (pos_next - pos_current) <= (spacing[2] * 2):


### PR DESCRIPTION
## SUMMARY

Fixes incorrect DICOM slice grouping where all slices were merged into one volume due to comparing a slice with itself. 

## FIX

* **Root cause:** `next` slice reference was commented out, causing `(pos_next - pos_current)` to always be `0`
* **Fix:** Restore next slice reference and use it correctly

**Before:**

```python
current = sorted_list[index]

pos_current = current.image.position[axis]
pos_next = current.image.position[axis]
```

**After:**

```python
current = sorted_list[index]
next_item = sorted_list[index + 1]

pos_current = current.image.position[axis]
pos_next = next_item.image.position[axis]
```

## RESULT

* Slice grouping now correctly separates distinct volumetric series
* Prevents silent merging of unrelated DICOM acquisitions
* No impact on single-series datasets
