### PR TITLE
fix: resolve polygon misalignment in 3D mask editor 

### DIFF
--- a/invesalius/data/polygon_select.py
+++ b/invesalius/data/polygon_select.py
@@ -18,7 +18,9 @@
 # --------------------------------------------------------------------------
 
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, List, Tuple
+
+from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 import invesalius.constants as const
 from invesalius.gui.widgets.canvas_renderer import CanvasHandlerBase, Polygon
@@ -28,6 +30,19 @@ if TYPE_CHECKING:
     import wx
 
     from invesalius.gui.widgets.canvas_renderer import CanvasEvent, CanvasRendererCTX
+
+
+def _display_to_world(renderer, display_x, display_y):
+    """Convert display coordinates to world coordinates on the camera focal plane."""
+    focal_point = renderer.GetActiveCamera().GetFocalPoint()
+    renderer.SetWorldPoint(*focal_point, 1.0)
+    renderer.WorldToDisplay()
+    focal_depth = renderer.GetDisplayPoint()[2]
+    renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+    renderer.DisplayToWorld()
+    wp = renderer.GetWorldPoint()
+    w = wp[3]
+    return (wp[0] / w, wp[1] / w, wp[2] / w)
 
 
 class PolygonSelectCanvas(CanvasHandlerBase):
@@ -55,19 +70,63 @@ class PolygonSelectCanvas(CanvasHandlerBase):
 
         self.interactive = interactive
 
+        # Parallel list of 3D world coordinates for each polygon point.
+        self._world_points: List[Tuple[float, float, float]] = []
+        # Track camera/viewport state to detect changes that require reprojection.
+        self._last_camera_mtime: int = 0
+        self._last_renderer_size: Tuple[int, int] = (0, 0)
+
     def draw_to_canvas(self, gc: "wx.GraphicsContext", canvas: "CanvasRendererCTX") -> None:
         ## abstract method from super class. needs implementation but does nothing here
+        """Reproject world coordinates to display coords only when camera/viewport changes.
+        During normal interaction (dragging), points are not overwritten,
+        preserving smooth point-dragging behavior.
+        """
+        if self._world_points and len(self._world_points) == len(self.polygon.points):
+            renderer = canvas.evt_renderer
+            camera = renderer.GetActiveCamera()
+            current_mtime = camera.GetMTime()
+            current_size = renderer.GetSize()
+            if current_mtime != self._last_camera_mtime or current_size != self._last_renderer_size:
+                # Camera or viewport changed — reproject world points to display
+                coord = vtkCoordinate()
+                for i, world_pt in enumerate(self._world_points):
+                    coord.SetValue(world_pt)
+                    px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                    self.polygon.points[i] = (px, py)
+                    if i < len(self.polygon.handlers):
+                        self.polygon.handlers[i].position = (px, py)
+                self._last_camera_mtime = current_mtime
+                self._last_renderer_size = current_size
         super().draw_to_canvas(gc, canvas)
 
     def on_mouse_move(self, _evt: "CanvasEvent"):
         pass
 
-    def on_drag_end(self, _evt):
+    def on_drag_end(self, evt: "CanvasEvent"):
+        """Update world coordinates from the dragged display positions, then cut."""
+        if hasattr(evt, "renderer") and evt.renderer is not None:
+            renderer = evt.renderer
+            for i, display_pt in enumerate(self.polygon.points):
+                if i < len(self._world_points):
+                    self._world_points[i] = _display_to_world(
+                        renderer, display_pt[0], display_pt[1]
+                    )
         Publisher.sendMessage("M3E cut mask from 3D")
 
-    def insert_point(self, point: Tuple[int, int]):
-        """Insert a new point to the polygon."""
-        self.polygon.append_point(point)
+    def insert_point(
+        self,
+        display_point: Tuple[float, float],
+        world_point: Tuple[float, float, float],
+    ):
+        """Insert a new point to the polygon.
+
+        Args:
+            display_point: The 2D display coordinates (px, py) from the mouse.
+            world_point: The corresponding 3D world coordinates on the focal plane.
+        """
+        self.polygon.append_point(display_point)
+        self._world_points.append(world_point)
 
     def complete_polygon(self):
         if len(self.polygon.points) >= 3:

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -28,7 +28,7 @@ from vtkmodules.vtkInteractionStyle import (
     vtkInteractorStyleRubberBandZoom,
     vtkInteractorStyleTrackballCamera,
 )
-from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkPointPicker, vtkPropPicker
+from vtkmodules.vtkRenderingCore import vtkCellPicker, vtkCoordinate, vtkPointPicker, vtkPropPicker
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slc
@@ -800,6 +800,11 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         if not self.has_set_mask_preview:
             Publisher.sendMessage("Render volume viewer")
 
+        # Capture the mask snapshot AFTER enabling the 3D preview, which runs
+        # do_threshold_to_all_slices and modifies the mask. This ensures
+        # ClearPolygons restores the correct post-threshold mask state.
+        self.mask_data = slc.Slice().current_mask.matrix.copy()
+
     def CleanUp(self):
         """Clean up is called when the interactor style is removed or changed.
 
@@ -827,6 +832,35 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
 
         Publisher.sendMessage("Update viewer caption", viewer_name="Volume", caption="Volume")
         self.viewer.UpdateCanvas()
+
+    def _display_to_world_focal_plane(
+        self, display_x: float, display_y: float
+    ) -> Tuple[float, float, float]:
+        """Convert display coordinates to world coordinates on the camera focal plane.
+        Projects the given 2D display position onto the plane perpendicular to the
+        camera view direction passing through the focal point. This allows polygon
+        points to be stored in world space, so they remain aligned with the volume
+        when the window is resized, zoomed, or panned.
+
+        Args:
+            display_x: X position in display (pixel) coordinates.
+            display_y: Y position in display (pixel) coordinates.
+
+        Returns:
+            Tuple with (x, y, z) world coordinates on the focal plane.
+        """
+        renderer = self.viewer.ren
+        focal_point = renderer.GetActiveCamera().GetFocalPoint()
+        # Find the depth value of the focal point in display coordinates
+        renderer.SetWorldPoint(*focal_point, 1.0)
+        renderer.WorldToDisplay()
+        focal_depth = renderer.GetDisplayPoint()[2]
+        # Unproject the 2D mouse position at the focal plane depth
+        renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+        renderer.DisplayToWorld()
+        world_point = renderer.GetWorldPoint()
+        w = world_point[3]
+        return (world_point[0] / w, world_point[1] / w, world_point[2] / w)
 
     def SetEditMode(self, mode: int):
         """Set edit mode for the style.
@@ -901,10 +935,14 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
     def OnScrollForward(self, obj, evt):
         if self.viewer.interactor.GetShiftKey():
             super().OnScrollForward(obj, evt)
+        else:
+            self.OnMouseWheelForward()
 
     def OnScrollBackward(self, obj, evt):
         if self.viewer.interactor.GetShiftKey():
             super().OnScrollBackward(obj, evt)
+        else:
+            self.OnMouseWheelBackward()
 
     def OnInsertPolygonPoint(self, evt):
         """Insert a point in the polygon.
@@ -916,8 +954,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         if len(self.m3e_list) == 0 or self.m3e_list[-1].complete:
             self.init_new_polygon()
 
+        world_point = self._display_to_world_focal_plane(mouse_x, mouse_y)
         current_masker = self.m3e_list[-1]
-        current_masker.insert_point((mouse_x, mouse_y))
+        current_masker.insert_point((mouse_x, mouse_y), world_point)
         self.viewer.UpdateCanvas()
 
     def OnInsertPolygon(self, evt):
@@ -973,22 +1012,23 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.update_views(_mat)
 
     def get_filters(self) -> List[npt.NDArray]:
-        """Create a boolean mask filter based on the polygon points and viewer size."""
+        """Create a boolean mask filter based on the polygon points and viewer size.
+
+        Since polygon points are stored with parallel world coordinates,
+        they are projected back to display coordinates using the current
+        camera before generating the mask.
+        """
         w, h = self.resolution
-
-        # Get scale factor (necessary for Mac HighDPI displays where physical
-        # mouse coords are scaled by 2x but viewer resolution is logical w,h)
-        import wx
-
-        scale = wx.GetApp().GetTopWindow().GetContentScaleFactor()
-
-        # polygon2mask((w, h), points_as_xy): treats (x, y) as (row, col) in a (w, h) array.
-        # After the .T in CutMaskFromPolygons the result is (h, w) which the Rust code reads as
-        # shape (h, w) and indexes as mask[py][px] — correctly matching VTK screen coordinates.
-        filters = [
-            polygon2mask((w, h), [(x / scale, y / scale) for x, y in poly_canvas.polygon.points])
-            for poly_canvas in self.m3e_list
-        ]
+        renderer = self.viewer.ren
+        coord = vtkCoordinate()
+        filters = []
+        for poly_canvas in self.m3e_list:
+            display_points = []
+            for world_pt in poly_canvas._world_points:
+                coord.SetValue(world_pt)
+                px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                display_points.append((px, py))
+            filters.append(polygon2mask((w, h), display_points))
         return filters
 
     def CutMaskFromPolygons(self):
@@ -1035,6 +1075,7 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             return
 
         depth = near + (far - near) * self.depth_val
+        print(f"\n\n\n\n{self.world_to_screen.flags=}\n{self.world_to_camera_coordinates.flags=}\n")
 
         try:
             wts = self.world_to_screen

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2665,7 +2665,7 @@ class Viewer(wx.Panel):
         Publisher.sendMessage("Receive volume viewer active camera", cam=cam)
 
     def SendViewerSize(self):
-        width, height = self.GetSize()
+        width, height = self.interactor.GetRenderWindow().GetSize()
         Publisher.sendMessage("Receive volume viewer size", size=(width, height))
 
     # Note: Not in use currently, this method is not called from anywhere.


### PR DESCRIPTION
### Problem
When using the 3D mask editor , drawing polygons and then resizing the window, zooming, would cause the polygon points to become misaligned with the volume. This happened because polygon points were stored only in display  coordinates, which become invalid when the viewport changes.
<img width="1916" height="1008" alt="Screenshot 2026-03-18 205635" src="https://github.com/user-attachments/assets/29b392bc-bf24-45c3-906d-fc673ef14eaa" />


### Solution
The fix stores parallel 3D world coordinates for each polygon point, allowing them to be reprojected to the current display coordinates when needed.

### Changes
### 1.  invesalius/data/polygon_select.py
Added _world_points list to store 3D world coordinates alongside display coordinates
Added _display_to_world() function for coordinate conversion
Modified draw_to_canvas() to reproject world points when camera/viewport changes
Modified on_drag_end() to update world coordinates after dragging
Modified insert_point() to accept both display and world coordinates

### 2. invesalius/data/styles_3d.py
Added vtkCoordinate import
Added _display_to_world_focal_plane() method to project mouse position onto the camera focal plane
Modified OnInsertPolygonPoint() to compute and store world coordinates
Modified get_filters() to project world points back to display for mask generation
Fixed mouse wheel zoom to work without requiring Shift key
Added mask_data capture after enabling 3D preview

### 3.invesalius/data/viewer_volume.py
Changed SendViewerSize() to use self.interactor.GetRenderWindow().GetSize() instead of self.GetSize() for accurate dimensions

### Testing 
 Draw a polygon in the 3D mask editor
 Resize the window - polygon should stay aligned with volume
 Zoom in/out - polygon should stay aligned
 Mouse wheel zoom should work without holding Shift key
<img width="1919" height="1021" alt="Screenshot 2026-03-18 210408" src="https://github.com/user-attachments/assets/2ed01f53-c8f5-4fd5-944a-e0df72d530b6" />

<img width="1918" height="1039" alt="Screenshot 2026-03-18 210502" src="https://github.com/user-attachments/assets/6b027c70-c5d8-4e81-b4c4-1ff2d4078ace" />
