### PR TITLE
Fix #1258: rebuild VTK imagedata after polygon cut so 3D volume updates

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -763,6 +763,7 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         sub(self.CutMaskFromPolygons, "M3E cut mask from 3D")
         sub(self.SetEditMode, "M3E set edit mode")
         sub(self.SetDepthValue, "M3E set depth value")
+        sub(self.OnMaskChanged, "Change mask selected")
 
     def SetUp(self):
         """Set up is called just before the style is set in the interactor.
@@ -1058,6 +1059,17 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
 
         self.update_views(out)
 
+    def OnMaskChanged(self, index: int):
+        """Refresh mask_data when the active mask changes (e.g. after Select Parts).
+
+        Without this, the 3D editor keeps the stale matrix from the old mask,
+        so the first polygon cut after a 'Select Parts' would restore the old
+        mask instead of operating on the new one.  Fixes #1258.
+        """
+        cur_mask = slc.Slice().current_mask
+        if cur_mask is not None:
+            self.mask_data = cur_mask.matrix.copy()
+
     def update_views(self, _mat: npt.NDArray):
         """Update the views with the given mask data."""
         slice = slc.Slice()
@@ -1066,6 +1078,16 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             _cur_mask.matrix[:] = 1
             _cur_mask.matrix[1:, 1:, 1:] = _mat
             _cur_mask.was_edited = True
+
+            # Explicitly rebuild the VTK imagedata from the updated numpy matrix
+            # so that the 3D volume re-renders with the new polygon-cut data.
+            # Calling modified(all_volume=True) only calls imagedata.Modified()
+            # which does NOT transfer the numpy changes into the VTK scalar array.
+            # Fix for #1258: rebuild imagedata so 3D window reflects the cut.
+            if _cur_mask.volume is not None and ses.Session().mask_3d_preview:
+                _cur_mask.imagedata = _cur_mask.as_vtkimagedata()
+                _cur_mask.volume.change_imagedata()
+
             _cur_mask.modified(all_volume=True)
 
         # Discard all buffers to reupdate view
@@ -1075,7 +1097,7 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         # Save modification in the history
         _cur_mask.save_history(0, "VOLUME", _cur_mask.matrix.copy(), self.mask_data)
 
-        Publisher.sendMessage("Update mask 3D preview")
+        Publisher.sendMessage("Render volume viewer")  # Fix #1258: re-render 3D window after cut
         Publisher.sendMessage("Reload actual slice")
 
 


### PR DESCRIPTION
### Description
### Fixes: #1258 

where the 3D volume window fails to update after using **Tools → Mask → Select Parts** and after making a **polygon selection** in the 3D mask editor.


### Solution

1. **Added [OnMaskChanged](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:1061:4-1070:51) handler** — subscribes to `"Change mask selected"` and refreshes `self.mask_data` from the new active mask's matrix whenever `Select Parts` (or any other operation) changes the active mask.

2. **Rebuilt VTK imagedata in [update_views()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/styles_3d.py:1072:4-1100:52)** — after updating the numpy matrix, we now call `mask.as_vtkimagedata()` to rebuild the full VTK imagedata from scratch, then `volume.change_imagedata()` to swap it into the active VTK actor, followed by `"Render volume viewer"` to force a repaint.

### How to test:
1. Import any DICOM dataset.
2. Create a mask and enable 3D editing.
3. **Tools → Mask → Select Parts** → click a region → click **OK**.
   - 3D volume window should immediately update to show only the selected part.
4. Draw a polygon in the 3D volume window and complete it (double-click).
   - 3D volume should now reflect the polygon cut, matching the 2D slice views.
   
### After fix:


https://github.com/user-attachments/assets/73baa209-b4db-40ed-a1ad-2bacda585bf2




