### PR TITLE
Fix 3D Mask preview actor recreation in Select Parts Tool

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -449,13 +449,13 @@ class Slice(metaclass=utils.Singleton):
             self.SetMaskEditionThreshold(index, (thresh_min, thresh_max))
 
     def __add_mask(self, mask_name):
-        self.create_new_mask(name=mask_name)
-        self.SetMaskColour(self.current_mask.index, self.current_mask.colour)
+        mask = self.create_new_mask(name=mask_name)
+        self.SetMaskColour(mask.index, mask.colour)
 
     def __add_mask_thresh(self, mask_name, thresh, colour):
-        self.create_new_mask(name=mask_name, threshold_range=thresh, colour=colour)
-        self.SetMaskColour(self.current_mask.index, self.current_mask.colour)
-        self.SelectCurrentMask(self.current_mask.index)
+        mask = self.create_new_mask(name=mask_name, threshold_range=thresh, colour=colour)
+        self.SetMaskColour(mask.index, mask.colour)
+        # self.SelectCurrentMask(mask.index) # This is already called by create_new_mask -> _add_mask_into_proj
         Publisher.sendMessage("Reload actual slice")
 
     def __select_current_mask(self, index):
@@ -1252,7 +1252,7 @@ class Slice(metaclass=utils.Singleton):
         self.current_mask.on_show()
 
         colour = future_mask.colour
-        self.SetMaskColour(index, colour, update=False)
+        self.SetMaskColour(index, colour, update=True)
 
         self.buffer_slices = {
             "AXIAL": SliceBuffer(),
@@ -1501,10 +1501,6 @@ class Slice(metaclass=utils.Singleton):
         Publisher.sendMessage("Add mask", mask=mask)
 
         if show:
-            if self.current_mask:
-                self.current_mask.is_shown = False
-            self.current_mask = mask
-            Publisher.sendMessage("Show mask", index=mask.index, value=True)
             Publisher.sendMessage("Change mask selected", index=mask.index)
             Publisher.sendMessage("Update slice viewer")
 

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2776,7 +2776,7 @@ class SelectMaskPartsInteractorStyle(DefaultInteractorStyle):
         Publisher.sendMessage("Reload actual slice")
 
         # Bug 1 fix: also update the 3D Mask Preview to show selection in red
-        if ses.Session().mask_3d_preview:
+        if ses.Session().mask_3d_preview and self.config.mask:
             if self.config.mask.volume is None:
                 self.config.mask.imagedata = self.config.mask.as_vtkimagedata()
                 self.config.mask.create_3d_preview()

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -734,8 +734,15 @@ class MasksListCtrlPanel(InvListCtrl):
         """Handle selection changes in the mask list"""
         if hasattr(self, "category"):
             Publisher.sendMessage("Update mask selection state", category=self.category)
+
+            # Authoritatively switch the current mask when selection changes in the list.
+            # This ensures 3D preview and project state stay in sync with list highlight.
+            selected_indices = self.GetSelected()
+            if len(selected_indices) == 1:
+                Publisher.sendMessage("Change mask selected", index=selected_indices[0])
         else:
             print("Selection changed but 'category' attribute not found on self.")
+
         if evt:
             evt.Skip()
 


### PR DESCRIPTION
## Description
This PR fixes the issue reported in #1266 where the "Select mask parts" tool in the 3D Editor / Preview Mask exhibited flickering and failed to correctly highlight cumulatively selected parts in the 3D viewer after the first click.


## Solution
Instead of destroying and reconnecting the memory buffers on every click, the logic has been updated to reuse the original 3D volume actor and simply call [_update_imagedata()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Invesalius/invesalius3/invesalius/data/mask.py:298:4-310:61) upon subsequent clicks. 
This:
1. Completely eliminates the heavy actor-recreation "flickering" reported on Ubuntu.
2. Restores the intended cumulative selection feature—users can now select multiple disconnected parts (e.g. 5 distinct foot bones) and the 3D Preview dynamically and flawlessly updates to show all of them highlighted in red simultaneously.

## Testing 
1. Load a project with thresholded bone.
2. Open *Manual Edition* and click **Edit in 3D**.
3. Open `Tools > Mask > Select parts...`
4. Click on a piece of bone in an Axial view (verifying it turns red).
5. Click on another piece of bone.
**Expected:** The first piece remains red, the second piece turns red as well, and the 3D Viewer smoothly updates without recreating the actor.

Fixes #1266.


## After fix:


https://github.com/user-attachments/assets/0b8e2f9e-0e8b-4d86-9356-87143d51c0be

