### PR TITLE
fix: prevent TypeError in download_url_to_file when Content-Length he…

### DIFF
--- a/invesalius/net/utils.py
+++ b/invesalius/net/utils.py
@@ -35,7 +35,7 @@ def download_url_to_file(
             f.write(buffer)
             if hash:
                 calc_hash.update(buffer)
-            if callback is not None:
+            if callback is not None and file_size is not None::
                 callback(100 * total_downloaded / file_size)
         f.close()
         if hash is not None:


### PR DESCRIPTION
Closes #1273

`download_url_to_file()` in `invesalius/net/utils.py` crashes with a
`TypeError` when the HTTP response omits the `Content-Length` header
(common with CDNs, chunked transfer encoding, and compressed responses),
because the progress callback unconditionally divides by `file_size`
which remains `None`.

This patch adds `file_size is not None` to the existing guard on the
callback invocation, allowing the download to complete without progress
reporting when the total size is unknown.