### PR TITLE
fix: replace deprecated DataFrame.append with pd.concat in mTMS handler

### DIFF
--- a/invesalius/navigation/mtms.py
+++ b/invesalius/navigation/mtms.py
@@ -71,7 +71,10 @@ class mTMS:
                 "coil_pose(nav)": coil_pose_flip,
                 "intensity": self.intensity,
             }
-            self.df = self.df.append(pd.DataFrame([new_row], columns=self.df.columns))
+            self.df = pd.concat(
+                [self.df, pd.DataFrame([new_row], columns=self.df.columns)],
+                ignore_index=True,
+            )
         else:
             print("Target is not valid. The offset is: ", offset)
 


### PR DESCRIPTION
Closes #1275 

`invesalius/navigation/mtms.py` uses `pd.DataFrame.append()` which was
removed in pandas 2.0 (April 2023). Any user running a modern Python
environment hits `AttributeError: 'DataFrame' object has no attribute 'append'`
when using the mTMS stimulation logging feature.

This patch replaces the single `DataFrame.append()` call with `pd.concat()`.
No other DataFrame `.append()` calls exist in this file.