### PR TITLE
Fixed crash when no surfaces exist in region of interest and splitting.

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -382,8 +382,15 @@ class SurfaceManager:
         """
         proj = prj.Project()
         index = self.last_surface_index
+        # if index not in proj.surface_dict:
+        #     print(f"[Error] Surface index {index} not found in surface_dict.")
+        #     return
+        if not hasattr(proj, "surface_dict") or not proj.surface_dict:
+            dialogs.LargestSurfaceNotExist()
+            return
+
         if index not in proj.surface_dict:
-            print(f"[Error] Surface index {index} not found in surface_dict.")
+            dialogs.SurfaceIndexNotExist(index)
             return
         progress_dialog = dialogs.SelectLargestSurfaceProgressWindow()
         progress_dialog.Update()

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -316,14 +316,13 @@ class SurfaceManager:
         index = self.last_surface_index
         proj = prj.Project()
 
-        if not hasattr(proj, 'surface_dict') or not proj.surface_dict:
+        if not hasattr(proj, "surface_dict") or not proj.surface_dict:
             print("No surfaces exist, cannot create a seeded surface.")
-            return  
+            return
 
         if index not in proj.surface_dict:
             print(f"Surface index {index} does not exist.")
             return
-        
 
         surface = proj.surface_dict[index]
 
@@ -356,15 +355,14 @@ class SurfaceManager:
         """
         index = self.last_surface_index
         proj = prj.Project()
-        
-        if not hasattr(proj, 'surface_dict') or not proj.surface_dict:
+
+        if not hasattr(proj, "surface_dict") or not proj.surface_dict:
             print("No surfaces exist, cannot split surfaces.")
-            return 
+            return
 
         if index not in proj.surface_dict:
             print(f"Surface index {index} does not exist, cannot split.")
             return
-
 
         surface = proj.surface_dict[index]
 

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -315,6 +315,16 @@ class SurfaceManager:
         points_id_list = seeds
         index = self.last_surface_index
         proj = prj.Project()
+
+        if not hasattr(proj, 'surface_dict') or not proj.surface_dict:
+            print("No surfaces exist, cannot create a seeded surface.")
+            return  
+
+        if index not in proj.surface_dict:
+            print(f"Surface index {index} does not exist.")
+            return
+        
+
         surface = proj.surface_dict[index]
 
         new_polydata = pu.JoinSeedsParts(surface.polydata, points_id_list)
@@ -346,6 +356,16 @@ class SurfaceManager:
         """
         index = self.last_surface_index
         proj = prj.Project()
+        
+        if not hasattr(proj, 'surface_dict') or not proj.surface_dict:
+            print("No surfaces exist, cannot split surfaces.")
+            return 
+
+        if index not in proj.surface_dict:
+            print(f"Surface index {index} does not exist, cannot split.")
+            return
+
+
         surface = proj.surface_dict[index]
 
         index_list = []

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -317,11 +317,11 @@ class SurfaceManager:
         proj = prj.Project()
 
         if not hasattr(proj, "surface_dict") or not proj.surface_dict:
-            print("No surfaces exist, cannot create a seeded surface.")
+            dialogs.SeedSurfaceNotExist()
             return
 
         if index not in proj.surface_dict:
-            print(f"Surface index {index} does not exist.")
+            dialogs.SurfaceIndexNotExist(index)
             return
 
         surface = proj.surface_dict[index]
@@ -357,11 +357,11 @@ class SurfaceManager:
         proj = prj.Project()
 
         if not hasattr(proj, "surface_dict") or not proj.surface_dict:
-            print("No surfaces exist, cannot split surfaces.")
+            dialogs.SplitSurfaceNotExist()
             return
 
         if index not in proj.surface_dict:
-            print(f"Surface index {index} does not exist, cannot split.")
+            dialogs.SurfaceIndexNotExist(index)
             return
 
         surface = proj.surface_dict[index]

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -1047,7 +1047,7 @@ def SurfaceSelectionRequiredForDuplication() -> None:
 
 
 def SeedSurfaceNotExist() -> None:
-    msg = _("No surfaces exist, cannot create a seeded surface.")
+    msg = _("No surfaces exist, therefore cannot create a seeded surface.")
     if sys.platform == "darwin":
         dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
     else:
@@ -1057,7 +1057,17 @@ def SeedSurfaceNotExist() -> None:
 
 
 def SplitSurfaceNotExist() -> None:
-    msg = _("No surfaces exist, cannot split surfaces.")
+    msg = _("No surfaces exist, therefore cannot split surfaces.")
+    if sys.platform == "darwin":
+        dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
+    else:
+        dlg = wx.MessageDialog(None, msg, "InVesalius 3", wx.OK | wx.ICON_ERROR)
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+def LargestSurfaceNotExist() -> None:
+    msg = _("No surfaces exist, therefore cannot select the largest surface.")
     if sys.platform == "darwin":
         dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
     else:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -24,20 +24,14 @@ import os
 import random
 import sys
 import time
+from collections.abc import Iterable, MutableSequence, Sequence
 from concurrent import futures
 from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterable,
-    List,
     Literal,
-    MutableSequence,
     Optional,
-    Sequence,
-    Tuple,
-    Union,
 )
 
 if sys.platform == "win32":
@@ -197,7 +191,7 @@ class NumberDialog(wx.Dialog):
     def SetValue(self, value: int) -> None:
         self.num_ctrl.SetValue(value)
 
-    def GetValue(self) -> Union[int, float, None]:
+    def GetValue(self) -> int | float | None:
         return self.num_ctrl.GetValue()
 
 
@@ -257,7 +251,7 @@ class ResizeImageDialog(wx.Dialog):
         self.Layout()
         self.Centre()
 
-    def SetValue(self, value: Union[float, str]) -> None:
+    def SetValue(self, value: float | str) -> None:
         self.num_ctrl_porcent.SetValue(value)
 
     def GetValue(self) -> int:
@@ -267,7 +261,7 @@ class ResizeImageDialog(wx.Dialog):
         self.Destroy()
 
 
-def ShowNumberDialog(message: str, value: int = 0) -> Union[int, float, None]:
+def ShowNumberDialog(message: str, value: int = 0) -> int | float | None:
     dlg = NumberDialog(message, value)
     dlg.SetValue(value)
 
@@ -307,7 +301,7 @@ WILDCARD_MESH_FILES = (
 WILDCARD_JSON_FILES = "JSON File format (*.json|*.json|All files (*.*)|*.*"
 
 
-def ShowOpenProjectDialog() -> Union[str, None]:
+def ShowOpenProjectDialog() -> str | None:
     # Default system path
     current_dir = os.path.abspath(".")
     session = ses.Session()
@@ -345,7 +339,7 @@ def ShowOpenProjectDialog() -> Union[str, None]:
     return filepath
 
 
-def ShowImportDirDialog(self) -> Union[str, bytes, None]:
+def ShowImportDirDialog(self) -> str | bytes | None:
     current_dir = os.path.abspath(".")
 
     if sys.platform == "win32" or sys.platform.startswith("linux"):
@@ -386,7 +380,7 @@ def ShowImportDirDialog(self) -> Union[str, bytes, None]:
     return path
 
 
-def ShowImportBitmapDirDialog(self) -> Optional[str]:
+def ShowImportBitmapDirDialog(self) -> str | None:
     current_dir = os.path.abspath(".")
 
     session = ses.Session()
@@ -421,7 +415,7 @@ def ShowImportBitmapDirDialog(self) -> Optional[str]:
 
 def ShowImportOtherFilesDialog(
     id_type: wx.WindowIDRef, msg: str = "Import NIFTi 1 file"
-) -> Union[str, bytes, None]:
+) -> str | bytes | None:
     # Default system path
     session = ses.Session()
     last_directory = session.GetConfig("last_directory_%d" % id_type, "")
@@ -485,7 +479,7 @@ def ShowImportOtherFilesDialog(
     return filename
 
 
-def ShowImportMeshFilesDialog() -> Optional[str]:
+def ShowImportMeshFilesDialog() -> str | None:
     from invesalius.data.slice_ import Slice
 
     # Default system path
@@ -562,7 +556,7 @@ def ImportMeshCoordSystem() -> bool:
     return flag
 
 
-def ShowSaveAsProjectDialog(default_filename: str) -> Tuple[Optional[str], bool]:
+def ShowSaveAsProjectDialog(default_filename: str) -> tuple[str | None, bool]:
     current_dir = os.path.abspath(".")
 
     session = ses.Session()
@@ -612,7 +606,7 @@ def ShowLoadCSVDebugEfield(
     style: int = wx.FD_OPEN | wx.FD_CHANGE_DIR,
     wildcard: str = _("(*.csv)|*.csv"),
     default_filename: str = "",
-) -> Optional[np.ndarray]:
+) -> np.ndarray | None:
     dlg = wx.FileDialog(
         None,
         message=message,
@@ -662,8 +656,8 @@ def ShowLoadSaveDialog(
     style: int = wx.FD_OPEN | wx.FD_CHANGE_DIR,
     wildcard: str = _("Registration files (*.obr)|*.obr"),
     default_filename: str = "",
-    save_ext: Optional[str] = None,
-) -> Optional[str]:
+    save_ext: str | None = None,
+) -> str | None:
     dlg = wx.FileDialog(
         None,
         message=message,
@@ -699,7 +693,7 @@ def ShowLoadSaveDialog(
     return filepath
 
 
-def LoadConfigEfield() -> Optional[str]:
+def LoadConfigEfield() -> str | None:
     # Default system path
     current_dir = os.path.abspath(".")
 
@@ -879,7 +873,7 @@ class MessageBox(wx.Dialog):
 class ErrorMessageBox(wx.Dialog):
     def __init__(
         self,
-        parent: Optional[wx.Window],
+        parent: wx.Window | None,
         title: str,
         message: str,
         caption: str = "InVesalius3 Error",
@@ -1048,6 +1042,36 @@ def SurfaceSelectionRequiredForDuplication() -> None:
         dlg = wx.MessageDialog(None, "", msg, wx.ICON_INFORMATION | wx.OK)
     else:
         dlg = wx.MessageDialog(None, msg, "InVesalius 3", wx.ICON_INFORMATION | wx.OK)
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+def SeedSurfaceNotExist() -> None:
+    msg = _("No surfaces exist, cannot create a seeded surface.")
+    if sys.platform == "darwin":
+        dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
+    else:
+        dlg = wx.MessageDialog(None, msg, "InVesalius 3", wx.OK | wx.ICON_ERROR)
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+def SplitSurfaceNotExist() -> None:
+    msg = _("No surfaces exist, cannot split surfaces.")
+    if sys.platform == "darwin":
+        dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
+    else:
+        dlg = wx.MessageDialog(None, msg, "InVesalius 3", wx.OK | wx.ICON_ERROR)
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+def SurfaceIndexNotExist(index: int) -> None:
+    msg = _(f"Surface index {index} does not exist.")
+    if sys.platform == "darwin":
+        dlg = wx.MessageDialog(None, "", msg, wx.OK | wx.ICON_ERROR)
+    else:
+        dlg = wx.MessageDialog(None, msg, "InVesalius 3", wx.OK | wx.ICON_ERROR)
     dlg.ShowModal()
     dlg.Destroy()
 
@@ -1292,7 +1316,7 @@ def ShowConfirmationDialog(msg: str = _("Proceed?")) -> int:
 
 def ShowColorDialog(
     color_current: "ColourType",
-) -> Optional[Tuple[int, int, int]]:
+) -> tuple[int, int, int] | None:
     cdata = wx.ColourData()
     cdata.SetColour(wx.Colour(color_current))
     dlg = wx.ColourDialog(None, data=cdata)
@@ -1313,7 +1337,7 @@ def ShowColorDialog(
 class NewMask(wx.Dialog):
     def __init__(
         self,
-        parent: Optional[wx.Window] = None,
+        parent: wx.Window | None = None,
         ID: int = -1,
         title: str = "InVesalius 3",
         size: wx.Size = wx.DefaultSize,
@@ -1444,7 +1468,7 @@ class NewMask(wx.Dialog):
             index = self.thresh_list.index(_("Custom"))
             self.combo_thresh.SetSelection(index)
 
-    def GetValue(self) -> Tuple[str, List[int], List[float]]:
+    def GetValue(self) -> tuple[str, list[int], list[float]]:
         # mask_index = self.combo_mask.GetSelection()
         mask_name = self.text.GetValue()
         thresh_value = [self.gradient.GetMinValue(), self.gradient.GetMaxValue()]
@@ -1604,7 +1628,7 @@ def ShowAboutDialog(parent: wx.Window) -> None:
     AboutBox(info)
 
 
-def ShowSavePresetDialog(default_filename: str = "raycasting") -> Optional[str]:
+def ShowSavePresetDialog(default_filename: str = "raycasting") -> str | None:
     dlg = wx.TextEntryDialog(None, _("Save raycasting preset as:"), "InVesalius 3")
     # dlg.SetFilterIndex(0) # default is VTI
     filename = None
@@ -1620,7 +1644,7 @@ def ShowSavePresetDialog(default_filename: str = "raycasting") -> Optional[str]:
 class NewSurfaceDialog(wx.Dialog):
     def __init__(
         self,
-        parent: Optional[wx.Window] = None,
+        parent: wx.Window | None = None,
         ID: int = -1,
         title: str = "InVesalius 3",
         size: wx.Size = wx.DefaultSize,
@@ -1730,7 +1754,7 @@ class NewSurfaceDialog(wx.Dialog):
         self.SetSizer(sizer)
         sizer.Fit(self)
 
-    def GetValue(self) -> Tuple[int, str, str, bool, bool]:
+    def GetValue(self) -> tuple[int, str, str, bool, bool]:
         mask_index = self.combo_mask.GetSelection()
         surface_name = self.text.GetValue()
         quality = const.SURFACE_QUALITY_LIST[self.combo_quality.GetSelection()]
@@ -1739,7 +1763,7 @@ class NewSurfaceDialog(wx.Dialog):
         return (mask_index, surface_name, quality, fill_holes, keep_largest)
 
 
-def ExportPicture(type_: str = "") -> Union[Tuple[str, wx.WindowIDRef], Tuple[()]]:
+def ExportPicture(type_: str = "") -> tuple[str, wx.WindowIDRef] | tuple[()]:
     import invesalius.constants as const
     import invesalius.project as proj
 
@@ -1835,7 +1859,7 @@ class SurfaceDialog(wx.Dialog):
         self.SetSizer(self.main_sizer)
         self.Fit()
 
-    def GetOptions(self) -> Dict[str, float]:
+    def GetOptions(self) -> dict[str, float]:
         return self.ca.GetOptions()
 
     def GetAlgorithmSelected(self) -> str:
@@ -1846,7 +1870,7 @@ class SurfaceDialog(wx.Dialog):
 class SurfaceCreationDialog(wx.Dialog):
     def __init__(
         self,
-        parent: Optional[wx.Window] = None,
+        parent: wx.Window | None = None,
         ID: int = -1,
         title: str = _("Surface creation"),
         size: wx.Size = wx.DefaultSize,
@@ -1905,7 +1929,7 @@ class SurfaceCreationDialog(wx.Dialog):
 
     def GetValue(
         self,
-    ) -> "Dict[str, Dict[str, str | Dict[str, float]] | Dict[str, str | int | bool]]":
+    ) -> "dict[str, dict[str, str | dict[str, float]] | dict[str, str | int | bool]]":
         return {"method": self.ca.GetValue(), "options": self.nsd.GetValue()}
 
 
@@ -2007,7 +2031,7 @@ class SurfaceCreationOptionsPanel(wx.Panel):
         new_evt = MaskEvent(myEVT_MASK_SET, -1, self.combo_mask.GetSelection())
         self.GetEventHandler().ProcessEvent(new_evt)
 
-    def GetValue(self) -> Dict[str, Union[str, int, bool]]:
+    def GetValue(self) -> dict[str, str | int | bool]:
         mask_index = self.combo_mask.GetSelection()
         surface_name = self.text.GetValue()
         quality = const.SURFACE_QUALITY_LIST[self.combo_quality.GetSelection()]
@@ -2034,7 +2058,7 @@ class SelectLargestSurfaceProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -2053,7 +2077,7 @@ class SmoothSurfaceProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -2072,7 +2096,7 @@ class RemoveNonVisibleFacesProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -2084,7 +2108,7 @@ class RemoveNonVisibleFacesProgressWindow:
 
 class SurfaceTransparencyDialog(wx.Dialog):
     def __init__(
-        self, parent: Optional[wx.Window], surface_index: int = 0, transparency: int = 0
+        self, parent: wx.Window | None, surface_index: int = 0, transparency: int = 0
     ) -> None:
         super().__init__(parent)
 
@@ -2264,7 +2288,7 @@ class SurfaceMethodPanel(wx.Panel):
     def GetAlgorithmSelected(self) -> str:
         return self.alg_types.get(self.cb_types.GetValue(), "Default")
 
-    def GetOptions(self) -> Dict[str, float]:
+    def GetOptions(self) -> dict[str, float]:
         if self.GetAlgorithmSelected() == "ca_smoothing":
             options = {
                 "angle": self.ca_options.angle.GetValue(),
@@ -2276,7 +2300,7 @@ class SurfaceMethodPanel(wx.Panel):
             options = {}
         return options
 
-    def GetValue(self) -> Dict[str, Union[str, Dict[str, float]]]:
+    def GetValue(self) -> dict[str, str | dict[str, float]]:
         algorithm = self.GetAlgorithmSelected()
         options = self.GetOptions()
 
@@ -2301,7 +2325,7 @@ class SurfaceMethodPanel(wx.Panel):
 
 class ClutImagedataDialog(wx.Dialog):
     def __init__(
-        self, histogram: np.ndarray, init: float, end: float, nodes: Optional[List["Node"]] = None
+        self, histogram: np.ndarray, init: float, end: float, nodes: list["Node"] | None = None
     ):
         wx.Dialog.__init__(
             self,
@@ -2466,7 +2490,7 @@ class WatershedOptionsDialog(wx.Dialog):
 class MaskBooleanDialog(wx.Dialog):
     def __init__(
         self,
-        masks: Dict[int, "Mask"],
+        masks: dict[int, "Mask"],
         ID: int = -1,
         title: str = _("Boolean operations"),
         style: int = wx.DEFAULT_DIALOG_STYLE | wx.FRAME_FLOAT_ON_PARENT,
@@ -2476,7 +2500,7 @@ class MaskBooleanDialog(wx.Dialog):
         self._init_gui(masks)
         self.CenterOnScreen()
 
-    def _init_gui(self, masks: Dict[int, "Mask"]) -> None:
+    def _init_gui(self, masks: dict[int, "Mask"]) -> None:
         mask_choices = [(masks[i].name, masks[i]) for i in sorted(masks)]
         self.mask1 = wx.ComboBox(self, -1, mask_choices[0][0], choices=[])
         self.mask2 = wx.ComboBox(self, -1, mask_choices[0][0], choices=[])
@@ -2631,7 +2655,7 @@ class ReorientImageDialog(wx.Dialog):
         self.btnapply.Bind(wx.EVT_BUTTON, self.apply_reorientation)
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
-    def _update_angles(self, angles: Tuple[float, float, float]) -> None:
+    def _update_angles(self, angles: tuple[float, float, float]) -> None:
         anglex, angley, anglez = angles
         self.anglex.SetValue(f"{np.rad2deg(anglex):.3f}")
         self.angley.SetValue(f"{np.rad2deg(angley):.3f}")
@@ -3737,7 +3761,7 @@ class CropOptionsDialog(wx.Dialog):
         Publisher.sendMessage("Disable style", style=const.SLICE_STATE_CROP_MASK)
         evt.Skip()
 
-    def OnClose(self, evt: Union[wx.CommandEvent, wx.CloseEvent]) -> None:
+    def OnClose(self, evt: wx.CommandEvent | wx.CloseEvent) -> None:
         self.config.dlg_visible = False
         Publisher.sendMessage("Disable style", style=const.SLICE_STATE_CROP_MASK)
         evt.Skip()
@@ -4021,8 +4045,8 @@ class ObjectCalibrationDialog(wx.Dialog):
 
         # Initialize list of buttons and txtctrls for wx objects
         self.btns_coord = [None] * 4
-        self.text_actors: List[Optional[vtkFollower]] = [None] * 4
-        self.ball_actors: List[Optional[vtkActor]] = [None] * 4
+        self.text_actors: list[vtkFollower | None] = [None] * 4
+        self.ball_actors: list[vtkActor | None] = [None] * 4
         self.txt_coord = [list(), list(), list(), list()]
 
         # ComboBox for object index in coord_raw (0 for static, 2 for dynamic, 3, 4, ... for multiple coils)
@@ -4257,7 +4281,7 @@ class ObjectCalibrationDialog(wx.Dialog):
             self.polydata = pu.LoadPolydata(path=object_path)
             self.ShowObject(polydata=self.polydata)
 
-    def OnCreateObjectText(self, name: str, coord: Sequence[float]) -> Tuple[vtkActor, vtkFollower]:
+    def OnCreateObjectText(self, name: str, coord: Sequence[float]) -> tuple[vtkActor, vtkFollower]:
         ball_source = vtkSphereSource()
         ball_source.SetRadius(3)
         mapper = vtkPolyDataMapper()
@@ -4389,7 +4413,7 @@ class ObjectCalibrationDialog(wx.Dialog):
 
     def GetValue(
         self,
-    ) -> Tuple[np.ndarray, np.ndarray, int, Optional[bytes], Optional[vtkPolyData]]:
+    ) -> tuple[np.ndarray, np.ndarray, int, bytes | None, vtkPolyData | None]:
         if self.n_coils > 1:
             coil_name = self.name_box.GetValue().strip()
         else:
@@ -4605,12 +4629,12 @@ class ICPCorregistrationDialog(wx.Dialog):
         self.collect_points.SetValue(str(int(self.collect_points.GetValue()) - 1))
         self.interactor.Render()
 
-    def GetCurrentCoord(self) -> Tuple[Tuple, List[bool]]:
+    def GetCurrentCoord(self) -> tuple[tuple, list[bool]]:
         coord_raw, marker_visibilities = self.tracker.TrackerCoordinates.GetCoordinates()
         coord, _ = dcr.corregistrate_probe(self.m_change, None, coord_raw, const.DEFAULT_REF_MODE)
         return coord[:3], marker_visibilities
 
-    def AddMarker(self, size: int, colour: Tuple[int, int, int], coord: np.ndarray) -> None:
+    def AddMarker(self, size: int, colour: tuple[int, int, int], coord: np.ndarray) -> None:
         """
         Points are rendered into the scene. These points give visual information about the registration.
         :param size: value of the marker size
@@ -4701,7 +4725,7 @@ class ICPCorregistrationDialog(wx.Dialog):
         self.interactor.Render()
 
     def CheckTransformedPointsDistribution(
-        self, points: Union[Sequence[float], np.ndarray]
+        self, points: Sequence[float] | np.ndarray
     ) -> np.floating:
         from scipy.spatial.distance import pdist
 
@@ -4780,7 +4804,7 @@ class ICPCorregistrationDialog(wx.Dialog):
         self.icp_mode = evt.GetSelection()
 
     def OnContinuousAcquisitionButton(
-        self, evt: Optional[wx.CommandEvent] = None, btn: Optional[wx.ToggleButton] = None
+        self, evt: wx.CommandEvent | None = None, btn: wx.ToggleButton | None = None
     ) -> None:
         assert btn is not None, "btn must be provided"
         value = btn.GetValue()
@@ -4792,7 +4816,7 @@ class ICPCorregistrationDialog(wx.Dialog):
     def HandleContinuousAcquisition(self, evt: wx.TimerEvent) -> None:
         self.CreatePoint()
 
-    def CreatePoint(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def CreatePoint(self, evt: wx.CommandEvent | None = None) -> None:
         current_coord, marker_visibilities = self.GetCurrentCoord()
 
         probe_visible, head_visible, *coils_visible = marker_visibilities
@@ -5011,12 +5035,12 @@ class EfieldConfiguration(wx.Dialog):
         self.SetSizer(main_sizer)
         main_sizer.Fit(self)
 
-    def OnComboNameBrainSurface(self, evt: wx.CommandEvent) -> Union[str, vtkPolyData]:
+    def OnComboNameBrainSurface(self, evt: wx.CommandEvent) -> str | vtkPolyData:
         surface_index = evt.GetSelection()
         self.brain_surface = self.proj.surface_dict[surface_index].polydata
         return self.brain_surface
 
-    def OnComboNameScalpSurface(self, evt: wx.CommandEvent) -> Union[str, vtkPolyData]:
+    def OnComboNameScalpSurface(self, evt: wx.CommandEvent) -> str | vtkPolyData:
         surface_index = evt.GetSelection()
         self.scalp_surface = self.proj.surface_dict[surface_index].polydata
         return self.scalp_surface
@@ -5035,7 +5059,7 @@ class CreateBrainTargetDialog(wx.Dialog):
         marker,
         mTMS: Optional["mTMS"] = None,
         brain_target: bool = False,
-        brain_actor: Optional[vtkActor] = None,
+        brain_actor: vtkActor | None = None,
     ):
         import invesalius.project as prj
 
@@ -5269,7 +5293,7 @@ class CreateBrainTargetDialog(wx.Dialog):
         self.SetSizer(main_sizer)
         main_sizer.Fit(self)
 
-    def get_vtk_mouse_position(self) -> Tuple[int, int]:
+    def get_vtk_mouse_position(self) -> tuple[int, int]:
         """
         Get Mouse position inside a wxVTKRenderWindowInteractorself. Return a
         tuple with X and Y position.
@@ -5369,17 +5393,17 @@ class CreateBrainTargetDialog(wx.Dialog):
                 self.peel_brain_actor.PickableOff()
             self.interactor.Render()
 
-    def OnCheckBoxScalp(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def OnCheckBoxScalp(self, evt: wx.CommandEvent | None = None) -> None:
         status = self.chk_show_surface.GetValue()
         self.obj_actor.SetVisibility(status)
         self.interactor.Render()
 
-    def OnCheckBoxBrain(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def OnCheckBoxBrain(self, evt: wx.CommandEvent | None = None) -> None:
         status = self.chk_show_brain_surface.GetValue()
         self.brain_actor.SetVisibility(status)
         self.interactor.Render()
 
-    def OnResetOrientation(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def OnResetOrientation(self, evt: wx.CommandEvent | None = None) -> None:
         self.rotationX = self.rotationY = self.rotationZ = 0
         self.slider_rotation_x.SetValue(0)
         self.slider_rotation_y.SetValue(0)
@@ -5462,8 +5486,8 @@ class CreateBrainTargetDialog(wx.Dialog):
 
     def LoadCenterBrainTarget(
         self,
-        coil_target_position: Union[Sequence, np.ndarray],
-        coil_target_orientation: Union[Sequence, np.ndarray],
+        coil_target_position: Sequence | np.ndarray,
+        coil_target_orientation: Sequence | np.ndarray,
     ) -> None:
         m_coil = dco.coordinates_to_transformation_matrix(
             position=coil_target_position,
@@ -5563,7 +5587,7 @@ class CreateBrainTargetDialog(wx.Dialog):
         coord_flip: Sequence[float],
         colour: MutableSequence[float] = [0.0, 0.0, 1.0],
         scale: float = 10,
-    ) -> Tuple[vtkActor, Tuple[float, float, float, float, float, float]]:
+    ) -> tuple[vtkActor, tuple[float, float, float, float, float, float]]:
         rx, ry, rz = coord_flip[3:]
         if rx is None:
             coord = self.Versor(self.CenterOfMass(self.brain_surface), coord_flip[:3])
@@ -5676,7 +5700,7 @@ class CreateBrainTargetDialog(wx.Dialog):
 
     def ICP(
         self, coord: Sequence[float], center: Sequence, surface: vtkPolyData
-    ) -> Tuple[int, int, int, None, None, None]:
+    ) -> tuple[int, int, int, None, None, None]:
         """
         Apply ICP transforms to fit the spiral points to the surface
         Args:
@@ -5773,7 +5797,7 @@ class CreateBrainTargetDialog(wx.Dialog):
 
         return point.GetOutput()
 
-    def CreateGrid(self, resolution: int, space_x: float, space_y: float) -> List[np.ndarray]:
+    def CreateGrid(self, resolution: int, space_x: float, space_y: float) -> list[np.ndarray]:
         minX, maxX, minY, maxY = -space_x, space_x, -space_y, space_y
         # create one-dimensional arrays for x and y
         x = np.linspace(minX, maxX, resolution)
@@ -5925,7 +5949,7 @@ class CreateBrainTargetDialog(wx.Dialog):
                 self.brain_target_actor_list.append(brain_target_actor)
                 print("Adding brain markers")
 
-    def OnSendMtms(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def OnSendMtms(self, evt: wx.CommandEvent | None = None) -> None:
         vtkmat = self.marker_actor.GetMatrix()
         narray = np.eye(4)
         vtkmat.DeepCopy(narray.ravel(), vtkmat)
@@ -5940,7 +5964,7 @@ class CreateBrainTargetDialog(wx.Dialog):
         direction: "Sequence[float] | np.ndarray",
         orientation: "Sequence[float] | np.ndarray",
         new_target: bool,
-    ) -> Tuple[vtkMatrix4x4, float, float, float]:
+    ) -> tuple[vtkMatrix4x4, float, float, float]:
         m_img = dco.coordinates_to_transformation_matrix(
             position=direction,
             orientation=orientation,
@@ -6003,7 +6027,7 @@ class CreateBrainTargetDialog(wx.Dialog):
 
         return np.rad2deg(tr.euler_from_matrix(rot_mat, axes="sxyz"))
 
-    def CenterOfMass(self, surface: vtkPolyData) -> List[float]:
+    def CenterOfMass(self, surface: vtkPolyData) -> list[float]:
         barycenter = [0.0, 0.0, 0.0]
         n = surface.GetNumberOfPoints()
         for i in range(n):
@@ -6022,9 +6046,9 @@ class CreateBrainTargetDialog(wx.Dialog):
 
     def Versor(
         self,
-        init_point: Union[Sequence[float], np.ndarray],
-        final_point: Union[Sequence[float], np.ndarray],
-    ) -> List[float]:
+        init_point: Sequence[float] | np.ndarray,
+        final_point: Sequence[float] | np.ndarray,
+    ) -> list[float]:
         init_point = np.array(init_point)
         final_point = np.array(final_point)
         norm = (sum((final_point - init_point) ** 2)) ** 0.5
@@ -6040,17 +6064,17 @@ class CreateBrainTargetDialog(wx.Dialog):
 
     def GetValue(
         self,
-    ) -> Tuple[List[List[np.float64]], List[np.ndarray], List[List[np.float64]], List[np.ndarray]]:
+    ) -> tuple[list[list[np.float64]], list[np.ndarray], list[list[np.float64]], list[np.ndarray]]:
         self.ren.RemoveActor(self.peel_brain_actor)
         vtkmat = self.coil_pose_actor.GetMatrix()
         narray = np.eye(4)
         vtkmat.DeepCopy(narray.ravel(), vtkmat)
-        position: List[np.float64] = [narray[0][-1], -narray[1][-1], narray[2][-1]]
+        position: list[np.float64] = [narray[0][-1], -narray[1][-1], narray[2][-1]]
         m_rotation = [narray[0][:3], narray[1][:3], narray[2][:3]]
         coil_target_position = [position]
         coil_target_orientation = [np.rad2deg(tr.euler_from_matrix(m_rotation, axes="sxyz"))]
 
-        brain_target_position: List[List[np.float64]] = []
+        brain_target_position: list[list[np.float64]] = []
         brain_target_orientation = []
         for coil_target_actor in self.coil_target_actor_list:
             vtkmat = coil_target_actor.GetMatrix()
@@ -6079,7 +6103,7 @@ class CreateBrainTargetDialog(wx.Dialog):
             brain_target_orientation,
         )
 
-    def GetValueBrainTarget(self) -> Tuple[List[List[np.float64]], List[np.ndarray]]:
+    def GetValueBrainTarget(self) -> tuple[list[list[np.float64]], list[np.ndarray]]:
         import invesalius.data.transformations as tr
 
         brain_target_position = []
@@ -6088,7 +6112,7 @@ class CreateBrainTargetDialog(wx.Dialog):
             vtkmat = brain_target_actor.GetMatrix()
             narray = np.eye(4)
             vtkmat.DeepCopy(narray.ravel(), vtkmat)
-            position: List[np.float64] = [narray[0][-1], -narray[1][-1], narray[2][-1]]
+            position: list[np.float64] = [narray[0][-1], -narray[1][-1], narray[2][-1]]
             m_rotation = [narray[0][:3], narray[1][:3], narray[2][:3]]
             orientation = np.rad2deg(tr.euler_from_matrix(m_rotation, axes="sxyz"))
             brain_target_position.append(position)
@@ -6110,7 +6134,7 @@ class TractographyProgressWindow:
     def WasCancelled(self) -> bool:
         return self.dlg.WasCancelled()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -6130,7 +6154,7 @@ class BrainSurfaceLoadingProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if value:
             self.dlg.Update(int(value), msg)
         elif msg:
@@ -6152,7 +6176,7 @@ class SurfaceSmoothingProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -6177,7 +6201,7 @@ class SurfaceProgressWindow:
         #  print("Cancelled?", self.dlg.WasCancelled())
         return self.dlg.WasCancelled()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -6678,7 +6702,7 @@ class ConfigureOptitrackDialog(wx.Dialog):
 
         self.CenterOnParent()
 
-    def GetValue(self) -> Tuple[str, str]:
+    def GetValue(self) -> tuple[str, str]:
         fn_cal = self.dir_cal.GetPath()
         fn_userprofile = self.dir_UserProfile.GetPath()
 
@@ -6820,7 +6844,7 @@ class SetRobotIP(wx.Dialog):
     def OnChoiceIP(self, evt: wx.CommandEvent, ctrl: wx.ComboBox) -> None:
         self.robot_ip = ctrl.GetStringSelection()
 
-    def GetValue(self) -> Optional[str]:
+    def GetValue(self) -> str | None:
         return self.robot_ip
 
 
@@ -6977,7 +7001,7 @@ class RobotCoregistrationDialog(wx.Dialog):
         )
 
     def OnContinuousAcquisitionButton(
-        self, evt: Optional[wx.CommandEvent] = None, btn: Optional[wx.ToggleButton] = None
+        self, evt: wx.CommandEvent | None = None, btn: wx.ToggleButton | None = None
     ) -> None:
         assert btn is not None, "btn must be provided"
         value = btn.GetValue()
@@ -6994,7 +7018,7 @@ class RobotCoregistrationDialog(wx.Dialog):
     def HandleContinuousAcquisition(self, evt: wx.TimerEvent) -> None:
         self.CreatePoint()
 
-    def CreatePoint(self, evt: Optional[wx.CommandEvent] = None) -> None:
+    def CreatePoint(self, evt: wx.CommandEvent | None = None) -> None:
         Publisher.sendMessage(
             "Neuronavigation to Robot: Collect coordinates for the robot transformation matrix",
             data=None,
@@ -7092,7 +7116,7 @@ class RobotCoregistrationDialog(wx.Dialog):
         if self.robot.IsConnected():
             self.btn_ok.Enable(True)
 
-    def GetValue(self) -> Optional[Union[np.ndarray, List]]:
+    def GetValue(self) -> np.ndarray | list | None:
         return self.matrix_tracker_to_robot
 
 
@@ -7112,14 +7136,14 @@ class ConfigurePolarisDialog(wx.Dialog):
         )
         self._init_gui()
 
-    def serial_ports(self) -> Tuple[List[str], List[int]]:
+    def serial_ports(self) -> tuple[list[str], list[int]]:
         """
         Lists serial port names and pre-select the description containing NDI
         """
         import serial.tools.list_ports
 
-        port_list: List[str] = []
-        desc_list: List[str] = []
+        port_list: list[str] = []
+        desc_list: list[str] = []
         ports = serial.tools.list_ports.comports()
         if sys.platform.startswith("win"):
             for port, desc, hwid in sorted(ports):
@@ -7244,7 +7268,7 @@ class ConfigurePolarisDialog(wx.Dialog):
     def OnChoicePort(self, evt: wx.CommandEvent, ctrl: wx.ComboBox) -> None:
         self.btn_ok.Enable(True)
 
-    def GetValue(self) -> Tuple[str, str, str, str]:
+    def GetValue(self) -> tuple[str, str, str, str]:
         fn_probe = self.dir_probe.GetPath()
         fn_ref = self.dir_ref.GetPath()
         fn_objs = [dir_obj.GetPath() for dir_obj in self.dir_objs]
@@ -7273,7 +7297,7 @@ class SetCOMPort(wx.Dialog):
         self.select_baud_rate = select_baud_rate
         self._init_gui()
 
-    def serial_ports(self) -> List[str]:
+    def serial_ports(self) -> list[str]:
         """
         Lists serial port names
         """
@@ -7352,7 +7376,7 @@ class SetCOMPort(wx.Dialog):
             return
         return com_port
 
-    def GetBaudRate(self) -> Optional[str]:
+    def GetBaudRate(self) -> str | None:
         if not self.select_baud_rate:
             return None
 
@@ -7757,7 +7781,7 @@ class ProgressBarHandler(wx.ProgressDialog):
         parent: wx.Window,
         title: str = "Progress Dialog",
         msg: str = "Initializing...",
-        max_value: Optional[float] = None,
+        max_value: float | None = None,
     ):
         super().__init__(title, msg, parent=parent, style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE)
 
@@ -7784,7 +7808,7 @@ class ProgressBarHandler(wx.ProgressDialog):
     def was_cancelled(self) -> bool:
         return super().WasCancelled()
 
-    def update(self, value: float, msg: Optional[str] = None) -> None:
+    def update(self, value: float, msg: str | None = None) -> None:
         if self.was_cancelled():
             return
 
@@ -7800,7 +7824,7 @@ class ProgressBarHandler(wx.ProgressDialog):
         if self.IsShown():
             self.Destroy()
 
-    def pulse(self, msg: Optional[str] = None) -> None:
+    def pulse(self, msg: str | None = None) -> None:
         # if self.IsShown():
         if msg is None:
             super().Pulse()


### PR DESCRIPTION
This PR fixes crashes in the 3D surface creation workflow when no surfaces exist.

Issues addressed:

1. Closes #1284
2. May also help with #11 


Changes made:

- Added checks in `OnSeedSurface` and `OnSplitSurface` to ensure `proj.surface_dict` exists and `last_surface_index` is valid before accessing it.
- If no surfaces exist, the function exits safely and prints a message.
- Prevents `KeyError` and `AttributeError` crashes when no surfaces are present.

Steps to reproduce the issues (before fix):

1. Delete all existing surfaces.
2. Try to select regions of interest by manually seeding surfaces → crash occurs.
3. Try to split disconnected surfaces → crash occurs.

Notes:

- This is a temporary fix to prevent crashes. Ideally, UI should disable seeding or splitting buttons when no surfaces exist.
- This PR only handles the “no surfaces exist” case; other errors (like `GetItemImage AttributeError`) are not addressed here.