### PR TITLE
Fix crash due to missing GetItemImage in SurfacesListCtrlPanel

### DIFF
--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1554,6 +1554,7 @@ class SurfacesListCtrlPanel(InvListCtrl):
         self.current_transparency = 0
         self.surface_list_index = {}
         self.surface_bmp_idx_to_name = {}
+        self.item_images = {}  # maps row index -> image index (0 or 1)
 
     def __init_evt(self):
         pass
@@ -1898,6 +1899,23 @@ class SurfacesListCtrlPanel(InvListCtrl):
             if image_index != -1:
                 self.imagelist.Replace(image_index, image)
                 self.RefreshItem(local_pos)
+
+    def GetItemImage(self, idx):
+        """
+        Return the image index (0 = hidden, 1 = visible) for the given row.
+        Defaults to 0 if not set.
+        """
+        return self.item_images.get(idx, 0)
+    
+    def SetItemImage(self, idx, img_idx):
+        """
+        Set the image index for a row and store it internally.
+        """
+        # Call parent method (actual UI update)
+        super().SetItemImage(idx, img_idx)
+        # Store the state (0 or 1)
+        self.item_images[idx] = img_idx
+
 
 
 # -------------------------------------------------

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1906,7 +1906,7 @@ class SurfacesListCtrlPanel(InvListCtrl):
         Defaults to 0 if not set.
         """
         return self.item_images.get(idx, 0)
-    
+
     def SetItemImage(self, idx, img_idx):
         """
         Set the image index for a row and store it internally.
@@ -1915,7 +1915,6 @@ class SurfacesListCtrlPanel(InvListCtrl):
         super().SetItemImage(idx, img_idx)
         # Store the state (0 or 1)
         self.item_images[idx] = img_idx
-
 
 
 # -------------------------------------------------


### PR DESCRIPTION
This PR fixes a crash occurring when splitting disconnected surfaces, caused by a missing `GetItemImage` method in `SurfacesListCtrlPanel`.

### Issue addressed

1. Closes #1285
2. Related to #11 

### Problem

The application calls `listctrl.GetItemImage(local_idx)`

However, `wx.ListCtrl` (in virtual mode) does not provide a `GetItemImage` method.
Instead, it expects `OnGetItemImage` to be implemented.

Since `SurfacesListCtrlPanel` does not define `GetItemImage`, this results in:

`AttributeError: 'SurfacesListCtrlPanel' object has no attribute 'GetItemImage'
`


### Steps to reproduce (before fix)

1. Create a 3D surface
2. Split disconnected surfaces
4. Application crashes with AttributeError

### Solution

This PR introduces a compatibility layer:

Adds internal storage for item image states (`self.item_images`)
Overrides `SetItemImage` to store image values
Implements `GetItemImage` to return stored values
```
self.item_images = {}

def GetItemImage(self, idx):
    return self.item_images.get(idx, 0)

def SetItemImage(self, idx, img_idx):
    super().SetItemImage(idx, img_idx)
    self.item_images[idx] = img_idx
```
### Why this approach

- Prevents crash without breaking existing logic
- Maintains compatibility with current calls to GetItemImage
- Avoids large refactor to fully virtual list pattern (OnGetItemImage)

### Notes

- This fix preserves current behavior but does not fully migrate to wx virtual list best practices
- A future improvement could refactor the control to rely on OnGetItemImage instead

