### PR TITLE
Surface Texture Export from Volume Rendering (OBJ/VRML Integration)

### DIFF
--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -682,7 +682,8 @@ class WWWLInteractorStyle(DefaultInteractorStyle):
         self.viewer.on_wl = False
         Publisher.sendMessage("Toggle toolbar item", _id=self.state_code, value=False)
         if self.viewer.wl_text is not None:
-            self.viewer.canvas.draw_list.remove(self.viewer.wl_text)
+            if self.viewer.wl_text in self.viewer.canvas.draw_list:
+                self.viewer.canvas.draw_list.remove(self.viewer.wl_text)
             self.viewer.UpdateCanvas()
 
     def OnWindowLevelMove(self, obj, evt):

--- a/invesalius/data/surface_texture.py
+++ b/invesalius/data/surface_texture.py
@@ -56,7 +56,6 @@ from invesalius.pubsub import pub as Publisher
 # Import the Rust texture generation module
 try:
     import invesalius_rs
-
     import invesalius_rs._native as _native
 
     HAS_NATIVE = True

--- a/invesalius/data/surface_texture.py
+++ b/invesalius/data/surface_texture.py
@@ -55,8 +55,9 @@ from invesalius.pubsub import pub as Publisher
 
 # Import the Rust texture generation module
 try:
-    import invesalius_rs
     import invesalius_rs._native as _native
+
+    import invesalius_rs
 
     HAS_NATIVE = True
 except ImportError:
@@ -569,14 +570,196 @@ def generate_surface_texture(
     return st
 
 
-def _export_textured_surface_worker(surface_index, format, filename):
+def get_opacity_curve_from_preset(config, ww=None, wl=None):
+    """
+    Extract the full VR opacity transfer function from a preset.
+
+    For advanced 16-bit presets, collects all (HU, opacity) points from
+    every opacity curve. For simple 8-bit presets, creates a linear ramp
+    from WW/WL bounds.
+
+    Parameters
+    ----------
+    config : dict
+        The raycasting preset dictionary (project.raycasting_preset).
+    ww : float, optional
+        Window width (used for simple presets).
+    wl : float, optional
+        Window level (used for simple presets).
+
+    Returns
+    -------
+    numpy.ndarray
+        Nx2 float64 array where column 0 = HU value, column 1 = opacity.
+        Sorted by HU ascending.
+    """
+    points = []
+
+    if config.get("advancedCLUT"):
+        for curve in config.get("16bitClutCurves", []):
+            for point in curve:
+                points.append((float(point["x"]), float(point["y"])))
+    else:
+        # Simple preset: linear ramp from window bounds
+        if ww is None:
+            ww = config.get("ww", DEFAULT_WW)
+        if wl is None:
+            wl = config.get("wl", DEFAULT_WL)
+        half_ww = float(ww) / 2.0
+        points.append((float(wl) - half_ww, 0.0))
+        points.append((float(wl) + half_ww, 1.0))
+
+    if not points:
+        # Fallback: fully opaque everywhere
+        points = [(-1024.0, 0.0), (3071.0, 1.0)]
+
+    # Sort by HU value and deduplicate
+    points.sort(key=lambda p: p[0])
+    return np.array(points, dtype="float64")
+
+
+def get_isovalues_from_preset(config):
+    """
+    Extract HU isosurface thresholds from a Volume Rendering preset.
+
+    For advanced 16-bit presets, finds the first HU value where opacity
+    exceeds a significance threshold (0.1). This captures all visible
+    anatomy including thin ribs, rather than only the densest bone.
+    For multi-curve presets, uses the highest such threshold to avoid
+    boxy skin envelopes.
+    For simple 8-bit presets, uses the WW/WL midpoint.
+
+    Parameters
+    ----------
+    config : dict
+        The raycasting preset dictionary (project.raycasting_preset).
+
+    Returns
+    -------
+    list of float
+        HU isovalues where opacity first becomes significant.
+    """
+    isovalues = []
+    if config.get("advancedCLUT"):
+        for curve in config.get("16bitClutCurves", []):
+            # Find the first point where opacity exceeds 0.1
+            for i, point in enumerate(curve):
+                if point["y"] > 0.1:
+                    if i > 0:
+                        prev = curve[i - 1]
+                        dy = point["y"] - prev["y"]
+                        if abs(dy) > 1e-9:
+                            # Interpolate where opacity crosses 0.1
+                            t = (0.1 - prev["y"]) / dy
+                            isovalue = prev["x"] + t * (point["x"] - prev["x"])
+                        else:
+                            isovalue = point["x"]
+                    else:
+                        isovalue = point["x"]
+                    isovalues.append(isovalue)
+                    break
+        # For multi-curve presets (e.g. Skin+Bone), use only the highest
+        # threshold to avoid capturing the skin envelope
+        if len(isovalues) > 1:
+            isovalues = [max(isovalues)]
+    else:
+        # For simple presets, use the window midpoint (WL) as isovalue
+        wl = config.get("wl", DEFAULT_WL)
+        isovalues.append(float(wl))
+    return isovalues
+
+
+def generate_surface_from_volume(imagedata, isovalues):
+    """
+    Generate an isosurface mesh from volume data using VR-derived thresholds.
+
+    Uses vtkFlyingEdges3D for fast parallel isosurface extraction at each
+    opacity-derived HU threshold, then merges multi-curve surfaces.
+
+    Parameters
+    ----------
+    imagedata : vtkImageData
+        The volume image data.
+    isovalues : list of float
+        HU isovalues from get_isovalues_from_preset().
+
+    Returns
+    -------
+    vtkPolyData
+        The generated surface mesh with computed normals.
+    """
+    from vtkmodules.vtkFiltersCore import (
+        vtkAppendPolyData,
+        vtkCleanPolyData,
+        vtkPolyDataNormals,
+        vtkQuadricDecimation,
+        vtkSmoothPolyDataFilter,
+    )
+
+    try:
+        from vtkmodules.vtkFiltersCore import vtkFlyingEdges3D
+
+        ContourClass = vtkFlyingEdges3D
+    except ImportError:
+        from vtkmodules.vtkFiltersCore import vtkContourFilter
+
+        ContourClass = vtkContourFilter
+
+    if len(isovalues) == 1:
+        contour = ContourClass()
+        contour.SetInputData(imagedata)
+        contour.SetValue(0, isovalues[0])
+        contour.Update()
+        polydata = contour.GetOutput()
+    else:
+        appender = vtkAppendPolyData()
+        for iso in isovalues:
+            contour = ContourClass()
+            contour.SetInputData(imagedata)
+            contour.SetValue(0, iso)
+            contour.Update()
+            appender.AddInputData(contour.GetOutput())
+        appender.Update()
+        polydata = appender.GetOutput()
+
+    # Clean duplicate points
+    cleaner = vtkCleanPolyData()
+    cleaner.SetInputData(polydata)
+    cleaner.Update()
+
+    # Light smoothing to reduce staircase artifacts while preserving detail
+    smoother = vtkSmoothPolyDataFilter()
+    smoother.SetInputData(cleaner.GetOutput())
+    smoother.SetNumberOfIterations(50)
+    smoother.SetRelaxationFactor(0.1)
+    smoother.FeatureEdgeSmoothingOff()
+    smoother.BoundarySmoothingOn()
+    smoother.Update()
+
+    # Gentle decimation to reduce polygon count (keep 70% of triangles)
+    decimator = vtkQuadricDecimation()
+    decimator.SetInputData(smoother.GetOutput())
+    decimator.SetTargetReduction(0.3)
+    decimator.Update()
+
+    # Recompute normals for proper shading after smoothing/decimation
+    normals_filter = vtkPolyDataNormals()
+    normals_filter.SetInputData(decimator.GetOutput())
+    normals_filter.SetFeatureAngle(80)
+    normals_filter.AutoOrientNormalsOn()
+    normals_filter.Update()
+
+    return normals_filter.GetOutput()
+
+
+def _export_textured_surface_worker(format, filename):
     import logging
 
     from invesalius.i18n import tr as _
     from invesalius.pubsub import pub as Publisher
 
     try:
-        _export_textured_surface_worker_inner(surface_index, format, filename)
+        _export_textured_surface_worker_inner(format, filename)
     except Exception as e:
         logger = logging.getLogger("invesalius")
         logger.error(f"Error in export worker: {e}", exc_info=True)
@@ -585,72 +768,134 @@ def _export_textured_surface_worker(surface_index, format, filename):
         )
 
 
-def _export_textured_surface_worker_inner(surface_index, format, filename):
+def _export_textured_surface_worker_inner(format, filename):
     import wx
 
     from invesalius import inv_paths
-    from invesalius.data.volume import Volume
     from invesalius.i18n import tr as _
     from invesalius.project import Project
 
     Publisher.sendMessage(
-        "Update texture export progress", progress=5, status=_("Preparing mesh and volume...")
+        "Update texture export progress",
+        progress=5,
+        status=_("Reading volume rendering preset..."),
     )
 
     project = Project()
-    if surface_index not in project.surface_dict:
+
+    # Get Volume instance (without creating a new one)
+    app = wx.GetApp()
+    if app and hasattr(app, "control"):
+        vol = app.control.volume
+    else:
+        from invesalius.data.volume import Volume
+
+        vol = Volume()
+
+    if not vol or not vol.exist:
         Publisher.sendMessage(
-            "Update texture export progress", progress=100, status=_("Error: Surface not found")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: Volume Rendering is not active"),
         )
         return
 
-    surface = project.surface_dict[surface_index]
-    polydata = surface.polydata
-    if polydata is None:
+    config = project.raycasting_preset
+    if not config:
         Publisher.sendMessage(
-            "Update texture export progress", progress=15, status=_("Processing mesh...")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: No raycasting preset loaded"),
         )
+        return
 
-    vertices, normals, faces = polydata_to_numpy(polydata)
+    ww = vol.ww if vol.ww is not None else DEFAULT_WW
+    wl = vol.wl if vol.wl is not None else DEFAULT_WL
 
     Publisher.sendMessage(
-        "Update texture export progress", progress=20, status=_("Reading raycasting preset...")
+        "Update texture export progress",
+        progress=10,
+        status=_("Extracting isosurface thresholds from VR preset..."),
     )
 
+    # Step 1: Extract isovalues from opacity curves
+    isovalues = get_isovalues_from_preset(config)
+    if not isovalues:
+        Publisher.sendMessage(
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: Could not extract thresholds from preset"),
+        )
+        return
+
+    # Step 1b: Extract full opacity transfer function for raycaster
+    opacity_curve = get_opacity_curve_from_preset(config, ww=ww, wl=wl)
+
+    logger.info(f"Extracted isovalues from VR preset: {isovalues}")
+    logger.info(f"Opacity curve: {opacity_curve.shape[0]} points")
+
+    Publisher.sendMessage(
+        "Update texture export progress",
+        progress=15,
+        status=_("Generating surface from volume rendering..."),
+    )
+
+    # Step 2: Generate isosurface from volume data
+    imagedata = vol.image
+    if imagedata is None:
+        Publisher.sendMessage(
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: Volume image data not available"),
+        )
+        return
+
+    polydata = generate_surface_from_volume(imagedata, isovalues)
+    n_points = polydata.GetNumberOfPoints()
+    n_cells = polydata.GetNumberOfCells()
+
+    if n_points == 0 or n_cells == 0:
+        Publisher.sendMessage(
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: No surface generated (try different VR preset)"),
+        )
+        return
+
+    logger.info(f"Auto-generated surface: {n_points} vertices, {n_cells} faces")
+
+    Publisher.sendMessage(
+        "Update texture export progress",
+        progress=25,
+        status=_("Preparing mesh data..."),
+    )
+
+    # Step 3: Convert to numpy arrays
+    vertices, normals, faces = polydata_to_numpy(polydata)
+
+    # Step 4: Load volume matrix and spacing
     from invesalius.data.slice_ import Slice
 
     sl = Slice()
     matrix = sl.matrix
     if matrix is None:
         Publisher.sendMessage(
-            "Update texture export progress", progress=100, status=_("Error: No volume data loaded")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error: No volume data loaded"),
         )
         return
 
     spacing = np.array(sl.spacing, dtype="float64")
 
     Publisher.sendMessage(
-        "Update texture export progress", progress=25, status=_("Reading raycasting preset...")
+        "Update texture export progress",
+        progress=30,
+        status=_("Reading color lookup table..."),
     )
 
-    # 1. Read WW/WL and 2. Read CLUT
-    # Do NOT instantiate Volume(), as it would register a ghost pubsub listener
-    # and crash the UI. Use the global Controller's instance instead.
-    app = wx.GetApp()
-    if app and hasattr(app, "control"):
-        vol = app.control.volume
-    else:
-        # Fallback if somehow run headless
-        from invesalius.data.volume import Volume
-
-        vol = Volume()
-
-    ww = vol.ww if vol.ww is not None else DEFAULT_WW
-    wl = vol.wl if vol.wl is not None else DEFAULT_WL
-
-    config = project.raycasting_preset
+    # Step 5: Load CLUT
     clut_name = config.get("CLUT", "No CLUT") if config else "No CLUT"
-
     clut_path = None
     if clut_name != "No CLUT":
         clut_path = os.path.join(
@@ -660,26 +905,22 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
 
     texture_dim = DEFAULT_TEXTURE_DIM
 
-    # 4. Y-axis alignment
-    # InVesalius meshes often have a negative Y axis due to VTK image flips.
-    # Shifting Y to positive space (subtracting the negative min) maps it to matrix indices.
-    # Because this shift acts as an inversion of the Y-axis, we MUST also invert the Y-normals
-    # so that rays cast inward into the tissue rather than outward into empty air (black patches).
+    # Step 6: Y-axis alignment
+    # Shift vertices to positive Y-space for matrix coordinate mapping.
+    # NOTE: Do NOT flip Y-normals — the auto-generated mesh from vtkPolyDataNormals
+    # already has correctly-oriented outward normals. This is just a translation.
     aligned_vertices = vertices.copy()
-    aligned_normals = normals.copy()
     y_min = aligned_vertices[:, 1].min()
     if y_min < 0:
         aligned_vertices[:, 1] -= y_min
-        aligned_normals[:, 1] = -aligned_normals[:, 1]
 
     Publisher.sendMessage(
         "Update texture export progress",
-        progress=30,
+        progress=35,
         status=_("Generating texture (this may take a few minutes)..."),
     )
 
-    # 5. Call Rust API
-    # Return types: tcoords (M, 6), image_rgb (H, W, 3), tnormals (H, W, 3)
+    # Step 7: Call Rust raycaster with VR opacity transfer function
     try:
         tcoords, image_rgb, tnormals = invesalius_rs.generate_surface_texture(
             aligned_vertices.astype("float64"),
@@ -690,12 +931,15 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
             int(ww),
             int(wl),
             clut,
+            opacity_curve,
             texture_dim,
         )
     except Exception as e:
         logger.error(f"Error calling rust generate_surface_texture: {e}")
         Publisher.sendMessage(
-            "Update texture export progress", progress=100, status=_("Error generating texture")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error generating texture"),
         )
         return
 
@@ -703,22 +947,23 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
         "Update texture export progress", progress=80, status=_("Saving files...")
     )
 
+    # Step 8: Save texture PNG
     base_dir = os.path.dirname(filename)
     base_name = os.path.basename(filename)
     name_without_ext = os.path.splitext(base_name)[0]
 
-    # Replace spaces with underscores for the texture filename to prevent MTL parsing errors in external software
     safe_name = name_without_ext.replace(" ", "_").replace("-", "_")
     texture_filename = safe_name + "_texture.png"
     texture_filepath = os.path.join(base_dir, texture_filename)
 
-    # 6. Save texture PNG
     try:
         imsave(texture_filepath, image_rgb)
     except Exception as e:
         logger.error(f"Error saving texture PNG: {e}")
         Publisher.sendMessage(
-            "Update texture export progress", progress=100, status=_("Error saving texture PNG")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error saving texture PNG"),
         )
         return
 
@@ -726,12 +971,12 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
         "Update texture export progress", progress=90, status=_("Writing 3D format...")
     )
 
+    # Step 9: Write OBJ or VRML
     try:
         if format == "OBJ":
             mtl_filename = name_without_ext + ".mtl"
             mtl_filepath = os.path.join(base_dir, mtl_filename)
 
-            # Write MTL
             with open(mtl_filepath, "w") as f:
                 f.write("newmtl material_0\n")
                 f.write("Ka 1.000000 1.000000 1.000000\n")
@@ -739,13 +984,12 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
                 f.write("Ks 0.000000 0.000000 0.000000\n")
                 f.write(f"map_Kd {texture_filename}\n")
 
-            # Write OBJ
             with open(filename, "w") as f:
                 f.write(f"mtllib {mtl_filename}\n")
                 for v in vertices:
-                    f.write(f"v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}\n")
+                    f.write(f"v {v[0]:.6f} {-v[1]:.6f} {v[2]:.6f}\n")
                 for vn in normals:
-                    f.write(f"vn {vn[0]:.6f} {vn[1]:.6f} {vn[2]:.6f}\n")
+                    f.write(f"vn {vn[0]:.6f} {-vn[1]:.6f} {vn[2]:.6f}\n")
 
                 for i in range(len(faces)):
                     vt1 = (tcoords[i, 0], tcoords[i, 1])
@@ -759,7 +1003,6 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
 
                 vt_idx = 1
                 for i in range(len(faces)):
-                    # OBJ is 1-indexed
                     v1 = faces[i, 0] + 1
                     v2 = faces[i, 1] + 1
                     v3 = faces[i, 2] + 1
@@ -781,9 +1024,9 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
                 f.write("  geometry IndexedFaceSet {\n")
                 f.write("    coord Coordinate {\n")
                 f.write("      point [\n")
-                for i, v in enumerate(aligned_vertices):
-                    sep = "," if i < len(aligned_vertices) - 1 else ""
-                    f.write(f"        {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}{sep}\n")
+                for i, v in enumerate(vertices):
+                    sep = "," if i < len(vertices) - 1 else ""
+                    f.write(f"        {v[0]:.6f} {-v[1]:.6f} {v[2]:.6f}{sep}\n")
                 f.write("      ]\n")
                 f.write("    }\n")
 
@@ -817,7 +1060,9 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
     except Exception as e:
         logger.error(f"Error writing 3D format {format}: {e}")
         Publisher.sendMessage(
-            "Update texture export progress", progress=100, status=_("Error writing 3D file")
+            "Update texture export progress",
+            progress=100,
+            status=_("Error writing 3D file"),
         )
         return
 
@@ -826,337 +1071,43 @@ def _export_textured_surface_worker_inner(surface_index, format, filename):
     )
 
 
-def _start_export_textured_surface(surface_index, format, filename, parent):
+def _start_export_textured_surface(format, filename, parent):
+    import os
     import threading
 
-    from invesalius.gui.dialog_export_texture import ExportTextureProgressDialog
+    import wx
 
-    # Show progress dialog
+    from invesalius.gui.dialog_export_texture import ExportTextureProgressDialog
+    from invesalius.i18n import tr as _
+
+    # Show progress dialog immediately
     dlg = ExportTextureProgressDialog(parent)
 
-    # Start thread
-    thread = threading.Thread(
-        target=_export_textured_surface_worker, args=(surface_index, format, filename)
-    )
-    thread.daemon = True
-    thread.start()
+    def _launch_worker():
+        """Start the background thread after the dialog is fully visible."""
+        thread = threading.Thread(target=_export_textured_surface_worker, args=(format, filename))
+        thread.daemon = True
+        thread.start()
 
+    # Delay thread start by 100ms so the dialog is fully rendered first
+    wx.CallLater(100, _launch_worker)
+
+    # Block until the export finishes (dialog EndModal's itself)
     dlg.ShowModal()
+    export_success = dlg._export_success
     dlg.Destroy()
+
+    # Show success or error dialog
+    if export_success:
+        base_name = os.path.basename(filename)
+        msg_dlg = wx.MessageDialog(
+            parent,
+            _("File saved successfully!\n\n") + base_name,
+            _("Export Complete"),
+            wx.OK | wx.ICON_INFORMATION,
+        )
+        msg_dlg.ShowModal()
+        msg_dlg.Destroy()
 
 
 Publisher.subscribe(_start_export_textured_surface, "Export textured surface")
-
-
-def export_textured_surface(surface_index, output_path, export_format="obj"):
-    """
-    Export a textured 3D surface to OBJ or VRML format.
-
-    This function generates a texture from volume rendering data and exports
-    the mesh with texture coordinates to the specified format.
-
-    Parameters
-    ----------
-    surface_index : int
-        Index of the surface in Project().surface_dict.
-    output_path : str
-        Output file path (without extension).
-    export_format : str
-        Export format: "obj" (default) or "vrml".
-
-    Raises
-    ------
-    RuntimeError
-        If native texture generation is unavailable.
-    ValueError
-        If surface index is invalid or volume data is not loaded.
-    """
-    if not HAS_NATIVE:
-        raise RuntimeError(
-            "invesalius_rs._native module not available. Please rebuild invesalius_rs."
-        )
-
-    # Import required modules
-    import invesalius.project as prj
-    from invesalius import inv_paths
-    from invesalius.data.slice_ import Slice
-    from invesalius.i18n import tr as _
-
-    # Get project
-    project = prj.Project()
-
-    # Validate surface index
-    if surface_index not in project.surface_dict:
-        raise ValueError(f"Surface index {surface_index} not found in project.")
-
-    surface = project.surface_dict[surface_index]
-    if surface.polydata is None:
-        raise ValueError(f"Surface {surface_index} has no polydata.")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=10, status=_("Loading mesh data...")
-    )
-
-    # Get mesh data
-    vertices, normals, faces = polydata_to_numpy(surface.polydata)
-    logger.info(f"Mesh loaded: {len(vertices)} vertices, {len(faces)} faces")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=20, status=_("Loading volume data...")
-    )
-
-    # Get volume data from Slice
-    sl = Slice()
-    matrix = sl.matrix
-    if matrix is None:
-        raise ValueError("No volume data loaded in InVesalius.")
-    spacing = np.array(sl.spacing, dtype="float64")
-    logger.info(f"Volume: shape={matrix.shape}, spacing={spacing}")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=30, status=_("Loading CLUT...")
-    )
-
-    # Get WW/WL and CLUT from raycasting preset
-    try:
-        config = project.raycasting_preset
-        ww = int(config.get("WW", DEFAULT_WW))
-        wl = int(config.get("WL", DEFAULT_WL))
-        clut_name = config.get("CLUT", "HotMetal")
-        clut_path = os.path.join(
-            str(inv_paths.RAYCASTING_PRESETS_DIRECTORY), "color_list", clut_name + ".plist"
-        )
-        clut = load_clut(str(clut_path), config=config, ww=ww, wl=wl)
-        logger.info(f"Using WW={ww}, WL={wl}, CLUT={clut_name}")
-    except Exception:
-        # Fallback to defaults
-        ww = DEFAULT_WW
-        wl = DEFAULT_WL
-        clut = load_clut(ww=ww, wl=wl)
-        logger.warning("Could not load preset CLUT, using default.")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=40, status=_("Applying spatial alignment...")
-    )
-
-    # Apply spatial alignment (mentor spec: mesh_min - [10, 10, 10])
-    mesh_min = np.min(vertices, axis=0)
-    dynamic_origin = mesh_min - np.array([10.0, 10.0, 10.0])
-    vertices = vertices - dynamic_origin
-    logger.info(f"Applied origin offset: {dynamic_origin}")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=50, status=_("Generating surface texture...")
-    )
-
-    # Call Rust generate_surface_texture
-    # Returns (tcoords, texture_image, tnormals)
-    result = _native.generate_surface_texture(
-        vertices, normals, faces, matrix, spacing, ww, wl, clut, DEFAULT_TEXTURE_DIM
-    )
-
-    tcoords, texture_image, tnormals = result
-    logger.info(f"Texture generated: {texture_image.shape}")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=70, status=_("Saving texture PNG...")
-    )
-
-    # Save texture PNG (Y-flip)
-    base_path = os.path.splitext(output_path)[0]
-    texture_filename = base_path + ".png"
-    imsave(texture_filename, texture_image[::-1, :])
-    logger.info(f"Texture saved to: {texture_filename}")
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=80, status=_("Writing mesh file...")
-    )
-
-    # Write OBJ or VRML based on format
-    if export_format.lower() == "obj":
-        _write_obj_with_texture(
-            output_path + ".obj",
-            vertices + dynamic_origin,  # Restore original position for export
-            normals,
-            faces,
-            tcoords,
-            texture_filename,
-        )
-    else:  # VRML
-        _write_vrml_with_texture(
-            output_path + ".vrml",
-            vertices + dynamic_origin,  # Restore original position for export
-            normals,
-            faces,
-            tcoords,
-            texture_filename,
-        )
-
-    Publisher.sendMessage(
-        "Update texture export progress", progress=100, status=_("Export complete!")
-    )
-
-    logger.info(f"Textured surface exported to: {output_path}")
-
-
-def _write_obj_with_texture(obj_path, vertices, normals, faces, tcoords, texture_path):
-    """
-    Write a Wavefront OBJ file with MTL and texture coordinates.
-
-    Parameters
-    ----------
-    obj_path : str
-        Path to output OBJ file.
-    vertices : numpy.ndarray
-        Vertex positions (N, 3).
-    normals : numpy.ndarray
-        Vertex normals (N, 3).
-    faces : numpy.ndarray
-        Face indices (M, 3).
-    tcoords : numpy.ndarray
-        Per-face texture coordinates (M, 6).
-    texture_path : str
-        Path to texture PNG file.
-    """
-    # Get base name for MTL file
-    import os
-
-    obj_dir = os.path.dirname(obj_path)
-    obj_base = os.path.splitext(os.path.basename(obj_path))[0]
-    mtl_path = obj_base + ".mtl"
-
-    # Write OBJ file
-    with open(obj_path, "w") as f:
-        # MTL library reference
-        f.write(f"mtllib {mtl_path}\n\n")
-        f.write(f"# Vertices: {len(vertices)}\n")
-        f.write(f"# Faces: {len(faces)}\n\n")
-
-        # Vertices
-        for v in vertices:
-            f.write(f"v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}\n")
-        f.write("\n")
-
-        # Normals
-        for n in normals:
-            f.write(f"vn {n[0]:.6f} {n[1]:.6f} {n[2]:.6f}\n")
-        f.write("\n")
-
-        # Texture coordinates (per face, so duplicate for each vertex)
-        for tc in tcoords:
-            f.write(f"vt {tc[0]:.6f} {tc[1]:.6f}\n")
-            f.write(f"vt {tc[2]:.6f} {tc[3]:.6f}\n")
-            f.write(f"vt {tc[4]:.6f} {tc[5]:.6f}\n")
-        f.write("\n")
-
-        # Material
-        f.write("usemtl texture_material\n")
-
-        # Faces with texture coordinates (vt indices are sequential per face)
-        for i in range(len(faces)):
-            base_vt = i * 3 + 1  # OBJ is 1-indexed, and we have 3 vt per face
-            f.write(
-                f"f {faces[i][0] + 1}/{base_vt}/{faces[i][0] + 1} "
-                f"{faces[i][1] + 1}/{base_vt + 1}/{faces[i][1] + 1} "
-                f"{faces[i][2] + 1}/{base_vt + 2}/{faces[i][2] + 1}\n"
-            )
-
-    # Write MTL file
-    mtl_full_path = os.path.join(obj_dir, mtl_path)
-    with open(mtl_full_path, "w") as f:
-        f.write("newmtl texture_material\n")
-        f.write("Ka 1.0 1.0 1.0\n")  # Ambient
-        f.write("Kd 1.0 1.0 1.0\n")  # Diffuse
-        f.write("Ks 0.0 0.0 0.0\n")  # Specular
-        f.write("d 1.0\n")  # Opacity
-        f.write("illum 2\n")  # Lighting model
-        texture_rel = os.path.basename(texture_path)
-        f.write(f"map_Kd {texture_rel}\n")  # Diffuse texture map
-
-    logger.info(f"OBJ/MTL written to: {obj_path}")
-
-
-def _write_vrml_with_texture(vrml_path, vertices, normals, faces, tcoords, texture_path):
-    """
-    Write a VRML file with embedded texture coordinates.
-
-    Parameters
-    ----------
-    vrml_path : str
-        Path to output VRML file.
-    vertices : numpy.ndarray
-        Vertex positions (N, 3).
-    normals : numpy.ndarray
-        Vertex normals (N, 3).
-    faces : numpy.ndarray
-        Face indices (M, 3).
-    tcoords : numpy.ndarray
-        Per-face texture coordinates (M, 6).
-    texture_path : str
-        Path to texture PNG file.
-    """
-    import os
-
-    # Get relative texture path
-    vrml_dir = os.path.dirname(vrml_path)
-    texture_rel_path = os.path.relpath(texture_path, vrml_dir)
-
-    with open(vrml_path, "w") as f:
-        f.write("#VRML V2.0 utf8\n\n")
-        f.write("# Exported by InVesalius3\n")
-        f.write(f"# Vertices: {len(vertices)}, Faces: {len(faces)}\n\n")
-
-        # Shape node
-        f.write("Shape {\n")
-        f.write("  appearance Appearance {\n")
-        f.write("    texture ImageTexture {\n")
-        f.write(f'      url [ "{texture_rel_path}" ]\n')
-        f.write("    }\n")
-        f.write("    material Material {\n")
-        f.write("      diffuseColor 1 1 1\n")
-        f.write("      specularColor 0 0 0\n")
-        f.write("      ambientIntensity 1\n")
-        f.write("    }\n")
-        f.write("  }\n")
-
-        # IndexedFaceSet
-        f.write("  geometry IndexedFaceSet {\n")
-        f.write("      point [\n")
-
-        # Vertices as commas-separated values internally, but no trailing
-        for i, v in enumerate(vertices):
-            sep = "," if i < len(vertices) - 1 else ""
-            f.write(f"        {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}{sep}\n")
-        f.write("      ]\n")
-        f.write("    }\n")
-
-        # Coordinate indices
-        f.write("    coordIndex [\n")
-        for i, face in enumerate(faces):
-            sep = "," if i < len(faces) - 1 else ""
-            f.write(f"      {face[0]}, {face[1]}, {face[2]}, -1{sep}\n")
-        f.write("    ]\n")
-
-        # Texture coordinates
-        f.write("    texCoord TextureCoordinate {\n")
-        f.write("      point [\n")
-        # Each face needs 3 UV pairs
-        for i, tc in enumerate(tcoords):
-            sep = "," if i < len(tcoords) - 1 else ""
-            f.write(f"        {tc[0]:.6f} {tc[1]:.6f},\n")
-            f.write(f"        {tc[2]:.6f} {tc[3]:.6f},\n")
-            f.write(f"        {tc[4]:.6f} {tc[5]:.6f}{sep}\n")
-        f.write("      ]\n")
-        f.write("    }\n")
-
-        # Texture coordinate indices
-        f.write("    texCoordIndex [\n")
-        for i in range(len(faces)):
-            base = i * 3
-            sep = "," if i < len(faces) - 1 else ""
-            f.write(f"      {base}, {base + 1}, {base + 2}, -1{sep}\n")
-        f.write("    ]\n")
-        f.write("  }\n")
-        f.write("}\n")
-
-    logger.info(f"VRML written to: {vrml_path}")

--- a/invesalius/data/surface_texture.py
+++ b/invesalius/data/surface_texture.py
@@ -1,0 +1,1162 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------------
+
+"""
+surface_texture.py
+==================
+Surface texture generation for InVesalius3.
+
+This module ports the medical_triangle_texture algorithm (by Thiago Franco
+de Moraes) into InVesalius, using the Rust implementation in invesalius_rs.
+
+The algorithm:
+1. Takes an existing 3D surface mesh (from marching cubes)
+2. For each triangle, shoots rays along surface normals into the CT/MRI volume
+3. Samples volume HU values at multiple depths (multi-slice raycasting)
+4. Maps HU values to RGB colors via Window/Level + Color Lookup Table
+5. Packs all triangle textures into a 2D atlas image
+6. Assigns UV coordinates to mesh vertices
+
+Reference:
+    Moraes et al. (2016). Isosurface rendering of medical images improved
+    by automatic texture mapping. Computer Methods in Biomechanics and
+    Biomedical Engineering: Imaging & Visualization.
+    https://doi.org/10.1080/21681163.2016.1254069
+"""
+
+import logging
+import os
+import plistlib
+
+import numpy as np
+import vtk
+from skimage.io import imsave
+from vtk.util import numpy_support
+
+from invesalius.pubsub import pub as Publisher
+
+# Import the Rust texture generation module
+try:
+    import invesalius_rs
+    import invesalius_rs._native as _native
+
+    HAS_NATIVE = True
+except ImportError:
+    try:
+        import _native
+
+        HAS_NATIVE = True
+    except ImportError:
+        HAS_NATIVE = False
+        logging.warning("invesalius_rs._native not found. Surface texture generation unavailable.")
+
+logger = logging.getLogger(__name__)
+
+# Default parameters matching Thiago's reference dataset (0543.txt)
+DEFAULT_WW = 500
+DEFAULT_WL = 100
+DEFAULT_TEXTURE_DIM = 5000
+DEFAULT_NSLICES = 10
+
+# Path to InVesalius color presets
+PRESETS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "presets",
+    "raycasting",
+    "color_list",
+)
+DEFAULT_CLUT = os.path.join(PRESETS_DIR, "HotMetal.plist")
+
+
+def load_clut(clut_path=None, config=None, ww=None, wl=None):
+    """
+    Load a Color Lookup Table from a .plist file or a 16-bit CLUT config dict.
+
+    Parameters
+    ----------
+    clut_path : str, optional
+        Path to .plist CLUT file. Defaults to HotMetal.plist.
+    config : dict, optional
+        The raycasting preset dictionary. If this contains 16-bit curves,
+        they will be used instead of the CLUT file.
+    ww : int, optional
+        Window width (required for 16-bit CLUT interpolation to 8-bit).
+    wl : int, optional
+        Window level (required for 16-bit CLUT interpolation to 8-bit).
+
+    Returns
+    -------
+    clut : numpy.ndarray, shape (256, 3), dtype uint8
+        RGB color lookup table.
+    """
+    if config and "16bitClutColors" in config and "16bitClutCurves" in config:
+        import vtk
+
+        color_transfer = vtk.vtkColorTransferFunction()
+        curve_table = config["16bitClutCurves"]
+        color_table = config["16bitClutColors"]
+
+        for i, element in enumerate(curve_table):
+            for j, lopacity in enumerate(element):
+                try:
+                    gray_level = lopacity["x"]
+                    r = color_table[i][j]["red"]
+                    g = color_table[i][j]["green"]
+                    b = color_table[i][j]["blue"]
+                    color_transfer.AddRGBPoint(gray_level, r, g, b)
+                except (IndexError, KeyError):
+                    continue
+
+        # Resample to 256 colors based on WW/WL
+        if ww is not None and wl is not None:
+            wl_min = wl - ww / 2.0
+        else:
+            # Fallback range if WW/WL not provided
+            wl_min, ww = -1000, 2000
+
+        clut = np.zeros((256, 3), dtype="uint8")
+        for i in range(256):
+            val = wl_min + (i / 255.0) * ww
+            rgb = color_transfer.GetColor(val)
+            clut[i] = [int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255)]
+        return clut
+
+    if clut_path is None:
+        clut_path = DEFAULT_CLUT
+
+    if not os.path.exists(clut_path):
+        # Fallback: grayscale CLUT
+        logger.warning(f"CLUT file not found: {clut_path}. Using grayscale.")
+        clut = np.zeros((256, 3), dtype="uint8")
+        for i in range(256):
+            clut[i] = [i, i, i]
+        return clut
+
+    with open(clut_path, "rb") as fp:
+        p = plistlib.load(fp)
+    clut = np.array(list(zip(p["Red"], p["Green"], p["Blue"])), dtype="uint8")
+    return clut
+
+
+def apply_wwwl_and_clut(image_hf, ww, wl, clut):
+    """
+    Convert raw HU multi-slice image to RGB using WW/WL + CLUT.
+
+    Parameters
+    ----------
+    image_hf : numpy.ndarray, shape (nslices, H, W), dtype int16
+        Raw HU values from generate_tcoords_hf.
+    ww : int
+        Window width.
+    wl : int
+        Window level.
+    clut : numpy.ndarray, shape (256, 3), dtype uint8
+        Color lookup table.
+
+    Returns
+    -------
+    image_rgb : numpy.ndarray, shape (H, W, 3), dtype uint8
+        RGB texture atlas.
+    """
+    # Take max intensity projection across all slices
+    # Ignore NULL_VALUE (-32768) sentinel
+    image_max = np.where(image_hf == -32768, -32768, image_hf).max(axis=0).astype("float64")
+
+    # Apply Window/Level mapping
+    wl_f = float(wl)
+    ww_f = float(ww)
+    min_val = wl_f - 0.5 - (ww_f - 1.0) / 2.0
+    max_val = wl_f - 0.5 + (ww_f - 1.0) / 2.0
+
+    gv = np.where(
+        image_max <= min_val,
+        0.0,
+        np.where(
+            image_max >= max_val, 255.0, ((image_max - (wl_f - 0.5)) / (ww_f - 1.0) + 0.5) * 255.0
+        ),
+    )
+
+    # Map through CLUT
+    gv_idx = np.clip(gv.astype("int32"), 0, 255)
+    image_rgb = clut[gv_idx].astype("uint8")
+
+    return image_rgb
+
+
+def polydata_to_numpy(polydata):
+    """
+    Convert VTK PolyData to numpy arrays.
+
+    Parameters
+    ----------
+    polydata : vtk.vtkPolyData
+        Input mesh.
+
+    Returns
+    -------
+    vertices : numpy.ndarray, shape (N, 3), dtype float64
+    normals : numpy.ndarray, shape (N, 3), dtype float64
+    faces : numpy.ndarray, shape (M, 3), dtype int32
+    """
+    # Ensure normals are computed
+    if polydata.GetPointData().GetNormals() is None:
+        normal_filter = vtk.vtkPolyDataNormals()
+        normal_filter.SetInputData(polydata)
+        normal_filter.ComputePointNormalsOn()
+        normal_filter.Update()
+        polydata = normal_filter.GetOutput()
+
+    vertices = numpy_support.vtk_to_numpy(polydata.GetPoints().GetData()).astype("float64")
+
+    normals = numpy_support.vtk_to_numpy(polydata.GetPointData().GetNormals()).astype("float64")
+
+    faces_vtk = numpy_support.vtk_to_numpy(polydata.GetPolys().GetData())
+    faces_vtk = faces_vtk.reshape(-1, 4)
+    faces = faces_vtk[:, 1:].astype("int32")
+
+    return vertices, normals, faces
+
+
+def apply_texture_to_actor(actor, polydata, tcoords, image_rgb):
+    """
+    Apply UV texture coordinates and texture image to a VTK actor.
+
+    Parameters
+    ----------
+    actor : vtk.vtkActor
+        The surface actor to texture.
+    polydata : vtk.vtkPolyData
+        The surface mesh polydata.
+    tcoords : numpy.ndarray, shape (M, 6), dtype float64
+        Per-face UV coordinates from generate_tcoords_hf.
+    image_rgb : numpy.ndarray, shape (H, W, 3), dtype uint8
+        RGB texture atlas image.
+    """
+    n_faces = tcoords.shape[0]
+    n_verts = polydata.GetNumberOfPoints()
+
+    # Build per-vertex UV from per-face UV
+    # Each face has 3 UV pairs (u0,v0, u1,v1, u2,v2)
+    # We use face centroid UV mapped to each vertex
+    uv_per_vertex = np.zeros((n_verts, 2), dtype="float64")
+    uv_count = np.zeros(n_verts, dtype="int32")
+
+    faces_vtk = numpy_support.vtk_to_numpy(polydata.GetPolys().GetData())
+    faces_vtk = faces_vtk.reshape(-1, 4)
+    faces = faces_vtk[:, 1:]
+
+    for i in range(n_faces):
+        v0, v1, v2 = faces[i]
+        # Average UV for each vertex in this face
+        uv_per_vertex[v0] += [tcoords[i, 0], tcoords[i, 1]]
+        uv_per_vertex[v1] += [tcoords[i, 2], tcoords[i, 3]]
+        uv_per_vertex[v2] += [tcoords[i, 4], tcoords[i, 5]]
+        uv_count[v0] += 1
+        uv_count[v1] += 1
+        uv_count[v2] += 1
+
+    # Average overlapping UVs
+    mask = uv_count > 0
+    uv_per_vertex[mask] /= uv_count[mask, np.newaxis]
+
+    # Apply UV coordinates to polydata
+    vtk_tcoords = numpy_support.numpy_to_vtk(uv_per_vertex.astype("float32"), deep=True)
+    vtk_tcoords.SetNumberOfComponents(2)
+    vtk_tcoords.SetName("TextureCoordinates")
+    polydata.GetPointData().SetTCoords(vtk_tcoords)
+
+    # Create VTK texture from RGB image
+    h, w = image_rgb.shape[:2]
+    img_flat = image_rgb[::-1, :, :].flatten()  # flip Y for VTK
+
+    img_import = vtk.vtkImageImport()
+    img_import.CopyImportVoidPointer(img_flat, img_flat.nbytes)
+    img_import.SetDataScalarTypeToUnsignedChar()
+    img_import.SetNumberOfScalarComponents(3)
+    img_import.SetDataExtent(0, w - 1, 0, h - 1, 0, 0)
+    img_import.SetWholeExtent(0, w - 1, 0, h - 1, 0, 0)
+    img_import.Update()
+
+    texture = vtk.vtkTexture()
+    texture.SetInputConnection(img_import.GetOutputPort())
+    texture.InterpolateOn()
+
+    actor.SetTexture(texture)
+    actor.GetMapper().SetInputData(polydata)
+    actor.GetMapper().ScalarVisibilityOff()
+
+    logger.info("Texture applied to actor successfully.")
+
+
+class SurfaceTexture:
+    """
+    Surface texture generator for InVesalius3.
+
+    Generates a texture atlas from CT/MRI volume data and applies it
+    to an existing surface mesh using multi-slice surface raycasting.
+
+    Parameters
+    ----------
+    surface_index : int
+        Index of the surface in Project().surface_dict.
+    ww : int
+        Window width for HU mapping (default 500).
+    wl : int
+        Window level for HU mapping (default 100).
+    texture_dim : int
+        Texture atlas size in pixels (default 5000).
+    nslices : int
+        Number of raycasting slices (default 10).
+    clut_path : str, optional
+        Path to .plist CLUT file.
+    """
+
+    def __init__(
+        self,
+        surface_index,
+        ww=DEFAULT_WW,
+        wl=DEFAULT_WL,
+        texture_dim=DEFAULT_TEXTURE_DIM,
+        nslices=DEFAULT_NSLICES,
+        clut_path=None,
+    ):
+        self.surface_index = surface_index
+        self.ww = ww
+        self.wl = wl
+        self.texture_dim = texture_dim
+        self.nslices = nslices
+        self.clut_path = clut_path
+
+        # Results
+        self.tcoords = None
+        self.image_hf = None
+        self.tnormals = None
+        self.image_rgb = None
+
+    def get_numpy_mesh(self):
+        """
+        Extract mesh data from InVesalius Project surface.
+
+        Returns
+        -------
+        vertices : numpy.ndarray (N, 3) float64
+        normals : numpy.ndarray (N, 3) float64
+        faces : numpy.ndarray (M, 3) int32
+        polydata : vtk.vtkPolyData
+        """
+        import invesalius.project as prj
+
+        proj = prj.Project()
+
+        if self.surface_index not in proj.surface_dict:
+            raise ValueError(f"Surface index {self.surface_index} not found in project.")
+
+        surface = proj.surface_dict[self.surface_index]
+        polydata = surface.polydata
+
+        if polydata is None:
+            raise ValueError(f"Surface {self.surface_index} has no polydata.")
+
+        vertices, normals, faces = polydata_to_numpy(polydata)
+
+        logger.info(f"Mesh loaded: {len(vertices)} vertices, {len(faces)} faces")
+        return vertices, normals, faces, polydata
+
+    def get_volume_data(self):
+        """
+        Get CT/MRI volume and spacing from InVesalius Slice singleton.
+
+        Returns
+        -------
+        matrix : numpy.ndarray (Z, Y, X) int16
+        spacing : numpy.ndarray [sx, sy, sz] float64
+        """
+        from invesalius.data.slice_ import Slice
+
+        sl = Slice()
+        matrix = sl.matrix
+
+        if matrix is None:
+            raise ValueError("No volume data loaded in InVesalius.")
+
+        spacing = np.array(sl.spacing, dtype="float64")
+
+        logger.info(f"Volume loaded: shape={matrix.shape}, spacing={spacing}")
+        return matrix, spacing
+
+    def generate(self):
+        """
+        Generate texture atlas from volume data.
+
+        Returns
+        -------
+        image_rgb : numpy.ndarray (H, W, 3) uint8
+            RGB texture atlas.
+        tcoords : numpy.ndarray (M, 6) float64
+            Per-face UV coordinates.
+        tnormals : numpy.ndarray (H, W, 3) uint8
+            Normal map atlas.
+        """
+        if not HAS_NATIVE:
+            raise RuntimeError(
+                "invesalius_rs._native module not available. Please rebuild invesalius_rs."
+            )
+
+        Publisher.sendMessage("Update status text in GUI", label="Loading mesh and volume data...")
+
+        # ── Load mesh ────────────────────────────────────────────────────
+        vertices, normals, faces, polydata = self.get_numpy_mesh()
+
+        # ── Load volume ──────────────────────────────────────────────────
+        matrix, spacing = self.get_volume_data()
+
+        # ── Load CLUT ────────────────────────────────────────────────────
+        clut = load_clut(self.clut_path)
+
+        # ── Y-axis alignment ─────────────────────────────────────────────
+        # InVesalius PLY meshes export with negative Y axis.
+        # Shift Y to start from 0 so raycasting hits the volume correctly.
+        y_min = vertices[:, 1].min()
+        if y_min < 0:
+            vertices[:, 1] -= y_min
+            logger.info(f"Y-axis shifted by {-y_min:.2f} mm for alignment.")
+
+        Publisher.sendMessage(
+            "Update status text in GUI",
+            label="Generating surface texture (this may take a few minutes)...",
+        )
+
+        logger.info(
+            f"Starting texture generation: "
+            f"faces={len(faces)}, dim={self.texture_dim}, "
+            f"nslices={self.nslices}, ww={self.ww}, wl={self.wl}"
+        )
+
+        # ── Run Rust texture engine ──────────────────────────────────────
+        self.tcoords, self.image_hf, self.tnormals = _native.generate_tcoords_hf(
+            vertices.astype("float64"),
+            normals.astype("float64"),
+            faces.astype("int32"),
+            matrix,
+            spacing,
+            self.ww,
+            self.wl,
+            clut,
+            self.texture_dim,
+            self.nslices,
+        )
+
+        logger.info(
+            f"Texture generated: "
+            f"image_shape={self.image_hf.shape}, "
+            f"nonzero={np.count_nonzero(self.image_hf != -32768)}"
+        )
+
+        # ── Convert HU → RGB ─────────────────────────────────────────────
+        Publisher.sendMessage("Update status text in GUI", label="Applying color mapping...")
+
+        self.image_rgb = apply_wwwl_and_clut(self.image_hf, self.ww, self.wl, clut)
+
+        Publisher.sendMessage("Update status text in GUI", label="Texture generation complete.")
+
+        logger.info("Texture generation complete.")
+        return self.image_rgb, self.tcoords, self.tnormals
+
+    def apply_to_actor(self, actor):
+        """
+        Apply generated texture to a VTK actor.
+
+        Parameters
+        ----------
+        actor : vtk.vtkActor
+            The surface actor to texture.
+        """
+        if self.tcoords is None or self.image_rgb is None:
+            raise RuntimeError("Texture not generated yet. Call generate() first.")
+
+        _, _, _, polydata = self.get_numpy_mesh()
+        apply_texture_to_actor(actor, polydata, self.tcoords, self.image_rgb)
+
+    def save_texture(self, filepath):
+        """
+        Save the RGB texture atlas as a PNG file.
+
+        Parameters
+        ----------
+        filepath : str
+            Output path for texture PNG.
+        """
+        if self.image_rgb is None:
+            raise RuntimeError("Texture not generated yet. Call generate() first.")
+
+        imsave(filepath, self.image_rgb)
+        logger.info(f"Texture saved to: {filepath}")
+
+    def save_normal_map(self, filepath):
+        """
+        Save the normal map atlas as a PNG file.
+
+        Parameters
+        ----------
+        filepath : str
+            Output path for normal map PNG.
+        """
+        if self.tnormals is None:
+            raise RuntimeError("Texture not generated yet. Call generate() first.")
+
+        imsave(filepath, self.tnormals)
+        logger.info(f"Normal map saved to: {filepath}")
+
+
+def generate_surface_texture(
+    surface_index,
+    ww=DEFAULT_WW,
+    wl=DEFAULT_WL,
+    texture_dim=DEFAULT_TEXTURE_DIM,
+    nslices=DEFAULT_NSLICES,
+    clut_path=None,
+):
+    """
+    Convenience function — generate and apply texture to a surface.
+
+    Parameters
+    ----------
+    surface_index : int
+        Index of the surface in Project().surface_dict.
+    ww : int
+        Window width (default 500).
+    wl : int
+        Window level (default 100).
+    texture_dim : int
+        Texture atlas size in pixels (default 5000).
+    nslices : int
+        Number of raycasting slices (default 10).
+    clut_path : str, optional
+        Path to .plist CLUT file.
+
+    Returns
+    -------
+    st : SurfaceTexture
+        The SurfaceTexture object with generated results.
+    """
+    st = SurfaceTexture(
+        surface_index=surface_index,
+        ww=ww,
+        wl=wl,
+        texture_dim=texture_dim,
+        nslices=nslices,
+        clut_path=clut_path,
+    )
+    st.generate()
+    return st
+
+
+def _export_textured_surface_worker(surface_index, format, filename):
+    import logging
+
+    from invesalius.i18n import tr as _
+    from invesalius.pubsub import pub as Publisher
+
+    try:
+        _export_textured_surface_worker_inner(surface_index, format, filename)
+    except Exception as e:
+        logger = logging.getLogger("invesalius")
+        logger.error(f"Error in export worker: {e}", exc_info=True)
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error during export")
+        )
+
+
+def _export_textured_surface_worker_inner(surface_index, format, filename):
+    import wx
+
+    from invesalius import inv_paths
+    from invesalius.data.volume import Volume
+    from invesalius.i18n import tr as _
+    from invesalius.project import Project
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=5, status=_("Preparing mesh and volume...")
+    )
+
+    project = Project()
+    if surface_index not in project.surface_dict:
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error: Surface not found")
+        )
+        return
+
+    surface = project.surface_dict[surface_index]
+    polydata = surface.polydata
+    if polydata is None:
+        Publisher.sendMessage(
+            "Update texture export progress", progress=15, status=_("Processing mesh...")
+        )
+
+    vertices, normals, faces = polydata_to_numpy(polydata)
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=20, status=_("Reading raycasting preset...")
+    )
+
+    from invesalius.data.slice_ import Slice
+
+    sl = Slice()
+    matrix = sl.matrix
+    if matrix is None:
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error: No volume data loaded")
+        )
+        return
+
+    spacing = np.array(sl.spacing, dtype="float64")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=25, status=_("Reading raycasting preset...")
+    )
+
+    # 1. Read WW/WL and 2. Read CLUT
+    # Do NOT instantiate Volume(), as it would register a ghost pubsub listener
+    # and crash the UI. Use the global Controller's instance instead.
+    app = wx.GetApp()
+    if app and hasattr(app, "control"):
+        vol = app.control.volume
+    else:
+        # Fallback if somehow run headless
+        from invesalius.data.volume import Volume
+
+        vol = Volume()
+
+    ww = vol.ww if vol.ww is not None else DEFAULT_WW
+    wl = vol.wl if vol.wl is not None else DEFAULT_WL
+
+    config = project.raycasting_preset
+    clut_name = config.get("CLUT", "No CLUT") if config else "No CLUT"
+
+    clut_path = None
+    if clut_name != "No CLUT":
+        clut_path = os.path.join(
+            inv_paths.RAYCASTING_PRESETS_DIRECTORY, "color_list", clut_name + ".plist"
+        )
+    clut = load_clut(clut_path)
+
+    texture_dim = DEFAULT_TEXTURE_DIM
+
+    # 4. Y-axis alignment
+    # InVesalius meshes often have a negative Y axis due to VTK image flips.
+    # Shifting Y to positive space (subtracting the negative min) maps it to matrix indices.
+    # Because this shift acts as an inversion of the Y-axis, we MUST also invert the Y-normals
+    # so that rays cast inward into the tissue rather than outward into empty air (black patches).
+    aligned_vertices = vertices.copy()
+    aligned_normals = normals.copy()
+    y_min = aligned_vertices[:, 1].min()
+    if y_min < 0:
+        aligned_vertices[:, 1] -= y_min
+        aligned_normals[:, 1] = -aligned_normals[:, 1]
+
+    Publisher.sendMessage(
+        "Update texture export progress",
+        progress=30,
+        status=_("Generating texture (this may take a few minutes)..."),
+    )
+
+    # 5. Call Rust API
+    # Return types: tcoords (M, 6), image_rgb (H, W, 3), tnormals (H, W, 3)
+    try:
+        tcoords, image_rgb, tnormals = invesalius_rs.generate_surface_texture(
+            aligned_vertices.astype("float64"),
+            normals.astype("float64"),
+            faces.astype("int32"),
+            matrix,
+            spacing,
+            int(ww),
+            int(wl),
+            clut,
+            texture_dim,
+        )
+    except Exception as e:
+        logger.error(f"Error calling rust generate_surface_texture: {e}")
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error generating texture")
+        )
+        return
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=80, status=_("Saving files...")
+    )
+
+    base_dir = os.path.dirname(filename)
+    base_name = os.path.basename(filename)
+    name_without_ext = os.path.splitext(base_name)[0]
+
+    # Replace spaces with underscores for the texture filename to prevent MTL parsing errors in external software
+    safe_name = name_without_ext.replace(" ", "_").replace("-", "_")
+    texture_filename = safe_name + "_texture.png"
+    texture_filepath = os.path.join(base_dir, texture_filename)
+
+    # 6. Save texture PNG
+    try:
+        imsave(texture_filepath, image_rgb)
+    except Exception as e:
+        logger.error(f"Error saving texture PNG: {e}")
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error saving texture PNG")
+        )
+        return
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=90, status=_("Writing 3D format...")
+    )
+
+    try:
+        if format == "OBJ":
+            mtl_filename = name_without_ext + ".mtl"
+            mtl_filepath = os.path.join(base_dir, mtl_filename)
+
+            # Write MTL
+            with open(mtl_filepath, "w") as f:
+                f.write("newmtl material_0\n")
+                f.write("Ka 1.000000 1.000000 1.000000\n")
+                f.write("Kd 1.000000 1.000000 1.000000\n")
+                f.write("Ks 0.000000 0.000000 0.000000\n")
+                f.write(f"map_Kd {texture_filename}\n")
+
+            # Write OBJ
+            with open(filename, "w") as f:
+                f.write(f"mtllib {mtl_filename}\n")
+                for v in vertices:
+                    f.write(f"v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}\n")
+                for vn in normals:
+                    f.write(f"vn {vn[0]:.6f} {vn[1]:.6f} {vn[2]:.6f}\n")
+
+                for i in range(len(faces)):
+                    vt1 = (tcoords[i, 0], tcoords[i, 1])
+                    vt2 = (tcoords[i, 2], tcoords[i, 3])
+                    vt3 = (tcoords[i, 4], tcoords[i, 5])
+                    f.write(f"vt {vt1[0]:.6f} {vt1[1]:.6f}\n")
+                    f.write(f"vt {vt2[0]:.6f} {vt2[1]:.6f}\n")
+                    f.write(f"vt {vt3[0]:.6f} {vt3[1]:.6f}\n")
+
+                f.write("usemtl material_0\n")
+
+                vt_idx = 1
+                for i in range(len(faces)):
+                    # OBJ is 1-indexed
+                    v1 = faces[i, 0] + 1
+                    v2 = faces[i, 1] + 1
+                    v3 = faces[i, 2] + 1
+                    f.write(f"f {v1}/{vt_idx}/{v1} {v2}/{vt_idx + 1}/{v2} {v3}/{vt_idx + 2}/{v3}\n")
+                    vt_idx += 3
+
+        elif format == "VRML":
+            with open(filename, "w") as f:
+                f.write("#VRML V2.0 utf8\n")
+                f.write("Shape {\n")
+                f.write("  appearance Appearance {\n")
+                f.write("    material Material {\n")
+                f.write("      diffuseColor 1.0 1.0 1.0\n")
+                f.write("    }\n")
+                f.write("    texture ImageTexture {\n")
+                f.write(f'      url [ "{texture_filename}" ]\n')
+                f.write("    }\n")
+                f.write("  }\n")
+                f.write("  geometry IndexedFaceSet {\n")
+                f.write("    coord Coordinate {\n")
+                f.write("      point [\n")
+                for i, v in enumerate(aligned_vertices):
+                    sep = "," if i < len(aligned_vertices) - 1 else ""
+                    f.write(f"        {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}{sep}\n")
+                f.write("      ]\n")
+                f.write("    }\n")
+
+                f.write("    coordIndex [\n")
+                for i, face in enumerate(faces):
+                    sep = "," if i < len(faces) - 1 else ""
+                    f.write(f"      {face[0]}, {face[1]}, {face[2]}, -1{sep}\n")
+                f.write("    ]\n")
+
+                f.write("    texCoord TextureCoordinate {\n")
+                f.write("      point [\n")
+                for i in range(len(faces)):
+                    sep = "," if i < len(faces) - 1 else ""
+                    f.write(f"        {tcoords[i, 0]:.6f} {tcoords[i, 1]:.6f},\n")
+                    f.write(f"        {tcoords[i, 2]:.6f} {tcoords[i, 3]:.6f},\n")
+                    f.write(f"        {tcoords[i, 4]:.6f} {tcoords[i, 5]:.6f}{sep}\n")
+                f.write("      ]\n")
+                f.write("    }\n")
+
+                f.write("    texCoordIndex [\n")
+                vt_idx = 0
+                for i in range(len(faces)):
+                    sep = "," if i < len(faces) - 1 else ""
+                    f.write(f"      {vt_idx}, {vt_idx + 1}, {vt_idx + 2}, -1{sep}\n")
+                    vt_idx += 3
+                f.write("    ]\n")
+
+                f.write("    solid FALSE\n")
+                f.write("  }\n")
+                f.write("}\n")
+    except Exception as e:
+        logger.error(f"Error writing 3D format {format}: {e}")
+        Publisher.sendMessage(
+            "Update texture export progress", progress=100, status=_("Error writing 3D file")
+        )
+        return
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=100, status=_("Export complete")
+    )
+
+
+def _start_export_textured_surface(surface_index, format, filename, parent):
+    import threading
+
+    from invesalius.gui.dialog_export_texture import ExportTextureProgressDialog
+
+    # Show progress dialog
+    dlg = ExportTextureProgressDialog(parent)
+
+    # Start thread
+    thread = threading.Thread(
+        target=_export_textured_surface_worker, args=(surface_index, format, filename)
+    )
+    thread.daemon = True
+    thread.start()
+
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+Publisher.subscribe(_start_export_textured_surface, "Export textured surface")
+
+
+def export_textured_surface(surface_index, output_path, export_format="obj"):
+    """
+    Export a textured 3D surface to OBJ or VRML format.
+
+    This function generates a texture from volume rendering data and exports
+    the mesh with texture coordinates to the specified format.
+
+    Parameters
+    ----------
+    surface_index : int
+        Index of the surface in Project().surface_dict.
+    output_path : str
+        Output file path (without extension).
+    export_format : str
+        Export format: "obj" (default) or "vrml".
+
+    Raises
+    ------
+    RuntimeError
+        If native texture generation is unavailable.
+    ValueError
+        If surface index is invalid or volume data is not loaded.
+    """
+    if not HAS_NATIVE:
+        raise RuntimeError(
+            "invesalius_rs._native module not available. Please rebuild invesalius_rs."
+        )
+
+    # Import required modules
+    import invesalius.project as prj
+    from invesalius import inv_paths
+    from invesalius.data.slice_ import Slice
+    from invesalius.i18n import tr as _
+
+    # Get project
+    project = prj.Project()
+
+    # Validate surface index
+    if surface_index not in project.surface_dict:
+        raise ValueError(f"Surface index {surface_index} not found in project.")
+
+    surface = project.surface_dict[surface_index]
+    if surface.polydata is None:
+        raise ValueError(f"Surface {surface_index} has no polydata.")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=10, status=_("Loading mesh data...")
+    )
+
+    # Get mesh data
+    vertices, normals, faces = polydata_to_numpy(surface.polydata)
+    logger.info(f"Mesh loaded: {len(vertices)} vertices, {len(faces)} faces")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=20, status=_("Loading volume data...")
+    )
+
+    # Get volume data from Slice
+    sl = Slice()
+    matrix = sl.matrix
+    if matrix is None:
+        raise ValueError("No volume data loaded in InVesalius.")
+    spacing = np.array(sl.spacing, dtype="float64")
+    logger.info(f"Volume: shape={matrix.shape}, spacing={spacing}")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=30, status=_("Loading CLUT...")
+    )
+
+    # Get WW/WL and CLUT from raycasting preset
+    try:
+        config = project.raycasting_preset
+        ww = int(config.get("WW", DEFAULT_WW))
+        wl = int(config.get("WL", DEFAULT_WL))
+        clut_name = config.get("CLUT", "HotMetal")
+        clut_path = os.path.join(
+            str(inv_paths.RAYCASTING_PRESETS_DIRECTORY), "color_list", clut_name + ".plist"
+        )
+        clut = load_clut(str(clut_path), config=config, ww=ww, wl=wl)
+        logger.info(f"Using WW={ww}, WL={wl}, CLUT={clut_name}")
+    except Exception:
+        # Fallback to defaults
+        ww = DEFAULT_WW
+        wl = DEFAULT_WL
+        clut = load_clut(ww=ww, wl=wl)
+        logger.warning("Could not load preset CLUT, using default.")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=40, status=_("Applying spatial alignment...")
+    )
+
+    # Apply spatial alignment (mentor spec: mesh_min - [10, 10, 10])
+    mesh_min = np.min(vertices, axis=0)
+    dynamic_origin = mesh_min - np.array([10.0, 10.0, 10.0])
+    vertices = vertices - dynamic_origin
+    logger.info(f"Applied origin offset: {dynamic_origin}")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=50, status=_("Generating surface texture...")
+    )
+
+    # Call Rust generate_surface_texture
+    # Returns (tcoords, texture_image, tnormals)
+    result = _native.generate_surface_texture(
+        vertices, normals, faces, matrix, spacing, ww, wl, clut, DEFAULT_TEXTURE_DIM
+    )
+
+    tcoords, texture_image, tnormals = result
+    logger.info(f"Texture generated: {texture_image.shape}")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=70, status=_("Saving texture PNG...")
+    )
+
+    # Save texture PNG (Y-flip)
+    base_path = os.path.splitext(output_path)[0]
+    texture_filename = base_path + ".png"
+    imsave(texture_filename, texture_image[::-1, :])
+    logger.info(f"Texture saved to: {texture_filename}")
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=80, status=_("Writing mesh file...")
+    )
+
+    # Write OBJ or VRML based on format
+    if export_format.lower() == "obj":
+        _write_obj_with_texture(
+            output_path + ".obj",
+            vertices + dynamic_origin,  # Restore original position for export
+            normals,
+            faces,
+            tcoords,
+            texture_filename,
+        )
+    else:  # VRML
+        _write_vrml_with_texture(
+            output_path + ".vrml",
+            vertices + dynamic_origin,  # Restore original position for export
+            normals,
+            faces,
+            tcoords,
+            texture_filename,
+        )
+
+    Publisher.sendMessage(
+        "Update texture export progress", progress=100, status=_("Export complete!")
+    )
+
+    logger.info(f"Textured surface exported to: {output_path}")
+
+
+def _write_obj_with_texture(obj_path, vertices, normals, faces, tcoords, texture_path):
+    """
+    Write a Wavefront OBJ file with MTL and texture coordinates.
+
+    Parameters
+    ----------
+    obj_path : str
+        Path to output OBJ file.
+    vertices : numpy.ndarray
+        Vertex positions (N, 3).
+    normals : numpy.ndarray
+        Vertex normals (N, 3).
+    faces : numpy.ndarray
+        Face indices (M, 3).
+    tcoords : numpy.ndarray
+        Per-face texture coordinates (M, 6).
+    texture_path : str
+        Path to texture PNG file.
+    """
+    # Get base name for MTL file
+    import os
+
+    obj_dir = os.path.dirname(obj_path)
+    obj_base = os.path.splitext(os.path.basename(obj_path))[0]
+    mtl_path = obj_base + ".mtl"
+
+    # Write OBJ file
+    with open(obj_path, "w") as f:
+        # MTL library reference
+        f.write(f"mtllib {mtl_path}\n\n")
+        f.write(f"# Vertices: {len(vertices)}\n")
+        f.write(f"# Faces: {len(faces)}\n\n")
+
+        # Vertices
+        for v in vertices:
+            f.write(f"v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}\n")
+        f.write("\n")
+
+        # Normals
+        for n in normals:
+            f.write(f"vn {n[0]:.6f} {n[1]:.6f} {n[2]:.6f}\n")
+        f.write("\n")
+
+        # Texture coordinates (per face, so duplicate for each vertex)
+        for tc in tcoords:
+            f.write(f"vt {tc[0]:.6f} {tc[1]:.6f}\n")
+            f.write(f"vt {tc[2]:.6f} {tc[3]:.6f}\n")
+            f.write(f"vt {tc[4]:.6f} {tc[5]:.6f}\n")
+        f.write("\n")
+
+        # Material
+        f.write("usemtl texture_material\n")
+
+        # Faces with texture coordinates (vt indices are sequential per face)
+        for i in range(len(faces)):
+            base_vt = i * 3 + 1  # OBJ is 1-indexed, and we have 3 vt per face
+            f.write(
+                f"f {faces[i][0] + 1}/{base_vt}/{faces[i][0] + 1} "
+                f"{faces[i][1] + 1}/{base_vt + 1}/{faces[i][1] + 1} "
+                f"{faces[i][2] + 1}/{base_vt + 2}/{faces[i][2] + 1}\n"
+            )
+
+    # Write MTL file
+    mtl_full_path = os.path.join(obj_dir, mtl_path)
+    with open(mtl_full_path, "w") as f:
+        f.write("newmtl texture_material\n")
+        f.write("Ka 1.0 1.0 1.0\n")  # Ambient
+        f.write("Kd 1.0 1.0 1.0\n")  # Diffuse
+        f.write("Ks 0.0 0.0 0.0\n")  # Specular
+        f.write("d 1.0\n")  # Opacity
+        f.write("illum 2\n")  # Lighting model
+        texture_rel = os.path.basename(texture_path)
+        f.write(f"map_Kd {texture_rel}\n")  # Diffuse texture map
+
+    logger.info(f"OBJ/MTL written to: {obj_path}")
+
+
+def _write_vrml_with_texture(vrml_path, vertices, normals, faces, tcoords, texture_path):
+    """
+    Write a VRML file with embedded texture coordinates.
+
+    Parameters
+    ----------
+    vrml_path : str
+        Path to output VRML file.
+    vertices : numpy.ndarray
+        Vertex positions (N, 3).
+    normals : numpy.ndarray
+        Vertex normals (N, 3).
+    faces : numpy.ndarray
+        Face indices (M, 3).
+    tcoords : numpy.ndarray
+        Per-face texture coordinates (M, 6).
+    texture_path : str
+        Path to texture PNG file.
+    """
+    import os
+
+    # Get relative texture path
+    vrml_dir = os.path.dirname(vrml_path)
+    texture_rel_path = os.path.relpath(texture_path, vrml_dir)
+
+    with open(vrml_path, "w") as f:
+        f.write("#VRML V2.0 utf8\n\n")
+        f.write("# Exported by InVesalius3\n")
+        f.write(f"# Vertices: {len(vertices)}, Faces: {len(faces)}\n\n")
+
+        # Shape node
+        f.write("Shape {\n")
+        f.write("  appearance Appearance {\n")
+        f.write("    texture ImageTexture {\n")
+        f.write(f'      url [ "{texture_rel_path}" ]\n')
+        f.write("    }\n")
+        f.write("    material Material {\n")
+        f.write("      diffuseColor 1 1 1\n")
+        f.write("      specularColor 0 0 0\n")
+        f.write("      ambientIntensity 1\n")
+        f.write("    }\n")
+        f.write("  }\n")
+
+        # IndexedFaceSet
+        f.write("  geometry IndexedFaceSet {\n")
+        f.write("      point [\n")
+
+        # Vertices as commas-separated values internally, but no trailing
+        for i, v in enumerate(vertices):
+            sep = "," if i < len(vertices) - 1 else ""
+            f.write(f"        {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}{sep}\n")
+        f.write("      ]\n")
+        f.write("    }\n")
+
+        # Coordinate indices
+        f.write("    coordIndex [\n")
+        for i, face in enumerate(faces):
+            sep = "," if i < len(faces) - 1 else ""
+            f.write(f"      {face[0]}, {face[1]}, {face[2]}, -1{sep}\n")
+        f.write("    ]\n")
+
+        # Texture coordinates
+        f.write("    texCoord TextureCoordinate {\n")
+        f.write("      point [\n")
+        # Each face needs 3 UV pairs
+        for i, tc in enumerate(tcoords):
+            sep = "," if i < len(tcoords) - 1 else ""
+            f.write(f"        {tc[0]:.6f} {tc[1]:.6f},\n")
+            f.write(f"        {tc[2]:.6f} {tc[3]:.6f},\n")
+            f.write(f"        {tc[4]:.6f} {tc[5]:.6f}{sep}\n")
+        f.write("      ]\n")
+        f.write("    }\n")
+
+        # Texture coordinate indices
+        f.write("    texCoordIndex [\n")
+        for i in range(len(faces)):
+            base = i * 3
+            sep = "," if i < len(faces) - 1 else ""
+            f.write(f"      {base}, {base + 1}, {base + 2}, -1{sep}\n")
+        f.write("    ]\n")
+        f.write("  }\n")
+        f.write("}\n")
+
+    logger.info(f"VRML written to: {vrml_path}")

--- a/invesalius/data/surface_texture.py
+++ b/invesalius/data/surface_texture.py
@@ -55,9 +55,9 @@ from invesalius.pubsub import pub as Publisher
 
 # Import the Rust texture generation module
 try:
-    import invesalius_rs._native as _native
-
     import invesalius_rs
+
+    import invesalius_rs._native as _native
 
     HAS_NATIVE = True
 except ImportError:

--- a/invesalius/gui/dialog_export_texture.py
+++ b/invesalius/gui/dialog_export_texture.py
@@ -1,0 +1,108 @@
+import wx
+
+import invesalius.project as prj
+from invesalius.i18n import tr as _
+from invesalius.pubsub import pub as Publisher
+
+
+class ExportTextureFormatDialog(wx.Dialog):
+    def __init__(self, parent):
+        super().__init__(
+            parent,
+            title=_("Export 3D Surface from Volume Rendering"),
+            style=wx.DEFAULT_DIALOG_STYLE,
+        )
+
+        self.surface_index = None
+        self.format = "OBJ"
+        self._init_ui()
+        self._populate_surfaces()
+
+    def _init_ui(self):
+        panel = wx.Panel(self)
+        vbox = wx.BoxSizer(wx.VERTICAL)
+
+        # Surface selection
+        hbox_surface = wx.BoxSizer(wx.HORIZONTAL)
+        st_surface = wx.StaticText(panel, label=_("Surface:"))
+        self.cb_surface = wx.ComboBox(panel, style=wx.CB_READONLY)
+        hbox_surface.Add(st_surface, flag=wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, border=8)
+        hbox_surface.Add(self.cb_surface, proportion=1)
+        vbox.Add(hbox_surface, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=10)
+
+        # Format selection
+        self.rb_format = wx.RadioBox(
+            panel,
+            label=_("Format:"),
+            choices=[_("Wavefront OBJ"), _("VRML")],
+            majorDimension=1,
+            style=wx.RA_SPECIFY_COLS,
+        )
+        self.rb_format.SetSelection(0)
+        vbox.Add(self.rb_format, flag=wx.EXPAND | wx.ALL, border=10)
+
+        # Buttons
+        btn_sizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
+
+        panel.SetSizer(vbox)
+        vbox.Fit(panel)
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(panel, 1, wx.EXPAND | wx.ALL, 5)
+        main_sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.BOTTOM, 10)
+
+        self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
+        self.Layout()
+
+    def _populate_surfaces(self):
+        project = prj.Project()
+        for index in project.surface_dict:
+            surface = project.surface_dict[index]
+            self.cb_surface.Append(f"Surface {index} - {surface.name}", index)
+
+        if self.cb_surface.GetCount() > 0:
+            self.cb_surface.SetSelection(0)
+
+    def GetValues(self):
+        if self.cb_surface.GetSelection() == wx.NOT_FOUND:
+            return None, None
+
+        index = self.cb_surface.GetClientData(self.cb_surface.GetSelection())
+        fmt = "OBJ" if self.rb_format.GetSelection() == 0 else "VRML"
+        return index, fmt
+
+
+class ExportTextureProgressDialog(wx.Dialog):
+    def __init__(self, parent, title=_("Generating Surface Texture")):
+        super().__init__(parent, title=title, style=wx.DEFAULT_DIALOG_STYLE)
+        self._init_ui()
+        self._bind_events()
+
+    def _init_ui(self):
+        panel = wx.Panel(self)
+        vbox = wx.BoxSizer(wx.VERTICAL)
+
+        self.st_status = wx.StaticText(panel, label=_("Initializing..."))
+        vbox.Add(self.st_status, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=15)
+
+        self.gauge = wx.Gauge(panel, range=100, size=(300, 20))
+        vbox.Add(self.gauge, flag=wx.EXPAND | wx.ALL, border=15)
+
+        panel.SetSizer(vbox)
+        vbox.Fit(self)
+        self.Layout()
+
+    def _bind_events(self):
+        Publisher.subscribe(self.OnUpdateProgress, "Update texture export progress")
+
+    def OnUpdateProgress(self, progress, status=""):
+        wx.CallAfter(self._update_progress_threadsafe, progress, status)
+
+    def _update_progress_threadsafe(self, progress, status=""):
+        if status:
+            self.st_status.SetLabel(status)
+        self.gauge.SetValue(progress)
+
+        if progress >= 100:
+            self.EndModal(wx.ID_OK)

--- a/invesalius/gui/dialog_export_texture.py
+++ b/invesalius/gui/dialog_export_texture.py
@@ -1,6 +1,7 @@
+import time
+
 import wx
 
-import invesalius.project as prj
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
 
@@ -16,19 +17,10 @@ class ExportTextureFormatDialog(wx.Dialog):
         self.surface_index = None
         self.format = "OBJ"
         self._init_ui()
-        self._populate_surfaces()
 
     def _init_ui(self):
         panel = wx.Panel(self)
         vbox = wx.BoxSizer(wx.VERTICAL)
-
-        # Surface selection
-        hbox_surface = wx.BoxSizer(wx.HORIZONTAL)
-        st_surface = wx.StaticText(panel, label=_("Surface:"))
-        self.cb_surface = wx.ComboBox(panel, style=wx.CB_READONLY)
-        hbox_surface.Add(st_surface, flag=wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, border=8)
-        hbox_surface.Add(self.cb_surface, proportion=1)
-        vbox.Add(hbox_surface, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=10)
 
         # Format selection
         self.rb_format = wx.RadioBox(
@@ -55,43 +47,66 @@ class ExportTextureFormatDialog(wx.Dialog):
         main_sizer.Fit(self)
         self.Layout()
 
-    def _populate_surfaces(self):
-        project = prj.Project()
-        for index in project.surface_dict:
-            surface = project.surface_dict[index]
-            self.cb_surface.Append(f"Surface {index} - {surface.name}", index)
-
-        if self.cb_surface.GetCount() > 0:
-            self.cb_surface.SetSelection(0)
-
     def GetValues(self):
-        if self.cb_surface.GetSelection() == wx.NOT_FOUND:
-            return None, None
-
-        index = self.cb_surface.GetClientData(self.cb_surface.GetSelection())
         fmt = "OBJ" if self.rb_format.GetSelection() == 0 else "VRML"
-        return index, fmt
+        return None, fmt
 
 
 class ExportTextureProgressDialog(wx.Dialog):
     def __init__(self, parent, title=_("Generating Surface Texture")):
         super().__init__(parent, title=title, style=wx.DEFAULT_DIALOG_STYLE)
+        self._start_time = time.time()
+        self._export_filename = None
+        self._export_success = False
         self._init_ui()
         self._bind_events()
+        self._start_timer()
 
     def _init_ui(self):
         panel = wx.Panel(self)
         vbox = wx.BoxSizer(wx.VERTICAL)
 
-        self.st_status = wx.StaticText(panel, label=_("Initializing..."))
+        self.st_status = wx.StaticText(panel, label=_("Starting export..."))
+        font = self.st_status.GetFont()
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        self.st_status.SetFont(font)
         vbox.Add(self.st_status, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=15)
 
-        self.gauge = wx.Gauge(panel, range=100, size=(300, 20))
-        vbox.Add(self.gauge, flag=wx.EXPAND | wx.ALL, border=15)
+        self.gauge = wx.Gauge(panel, range=100, size=(350, 22))
+        vbox.Add(self.gauge, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=15)
+
+        # Timer label
+        self.st_timer = wx.StaticText(panel, label=_("Elapsed: 0:00"))
+        timer_font = self.st_timer.GetFont()
+        timer_font.SetPointSize(timer_font.GetPointSize() - 1)
+        self.st_timer.SetFont(timer_font)
+        self.st_timer.SetForegroundColour(wx.Colour(120, 120, 120))
+        vbox.Add(self.st_timer, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border=15)
 
         panel.SetSizer(vbox)
-        vbox.Fit(self)
+        vbox.Fit(panel)
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(panel, 1, wx.EXPAND)
+        self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
         self.Layout()
+
+        # Force minimum width
+        self.SetMinSize(wx.Size(380, -1))
+        self.Fit()
+        self.CentreOnParent()
+
+    def _start_timer(self):
+        self._timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_timer, self._timer)
+        self._timer.Start(1000)  # Update every second
+
+    def _on_timer(self, event):
+        elapsed = time.time() - self._start_time
+        minutes = int(elapsed) // 60
+        seconds = int(elapsed) % 60
+        self.st_timer.SetLabel(_(f"Elapsed: {minutes}:{seconds:02d}"))
 
     def _bind_events(self):
         Publisher.subscribe(self.OnUpdateProgress, "Update texture export progress")
@@ -102,7 +117,21 @@ class ExportTextureProgressDialog(wx.Dialog):
     def _update_progress_threadsafe(self, progress, status=""):
         if status:
             self.st_status.SetLabel(status)
-        self.gauge.SetValue(progress)
+        self.gauge.SetValue(min(progress, 100))
 
         if progress >= 100:
+            self._timer.Stop()
+            elapsed = time.time() - self._start_time
+            minutes = int(elapsed) // 60
+            seconds = int(elapsed) % 60
+            self.st_timer.SetLabel(_(f"Completed in {minutes}:{seconds:02d}"))
+
+            # Check if export was successful (not an error status)
+            is_error = "error" in status.lower() if status else False
+            self._export_success = not is_error
             self.EndModal(wx.ID_OK)
+
+    def Destroy(self):
+        self._timer.Stop()
+        Publisher.unsubscribe(self.OnUpdateProgress, "Update texture export progress")
+        super().Destroy()

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -441,16 +441,15 @@ class InnerTaskPanel(wx.Panel):
             self.OnLinkExportMask()
 
     def OnLinkExportTexturedSurface(self, evt=None):
-        project = proj.Project()
-        visible_surfaces = []
-        for index in project.surface_dict:
-            if project.surface_dict[index].is_shown:
-                visible_surfaces.append(index)
+        import invesalius.data.surface_texture  # noqa: F401
 
-        if not visible_surfaces:
+        # Check if Volume Rendering is active
+        project = proj.Project()
+        config = project.raycasting_preset
+        if not config:
             dlg = wx.MessageDialog(
                 None,
-                _("You need to create a surface and make it ") + _("visible before exporting it."),
+                _("You need to enable Volume Rendering before exporting a textured surface."),
                 "InVesalius 3",
                 wx.OK | wx.ICON_INFORMATION,
             )
@@ -460,12 +459,7 @@ class InnerTaskPanel(wx.Panel):
                 dlg.Destroy()
             return
 
-        import invesalius.data.surface_texture  # noqa: F401
-
-        # Select the first visible surface
-        surface_index = visible_surfaces[0]
-
-        # 2. Show File Save Dialog with Format choice in the type dropdown
+        # Show File Save Dialog with Format choice in the type dropdown
         session = ses.Session()
         last_directory = session.GetConfig("last_directory_3d_surface", "")
         project_name = pathlib.Path(project.name).stem
@@ -498,10 +492,10 @@ class InnerTaskPanel(wx.Panel):
 
             dlg_save.Destroy()
 
-            # 3. Trigger export via pubsub (caught in surface_texture.py)
+            # Trigger export via pubsub (caught in surface_texture.py)
+            # No surface_index needed - Pipeline 2 auto-generates from VR
             Publisher.sendMessage(
                 "Export textured surface",
-                surface_index=surface_index,
                 format=export_format,
                 filename=filename,
                 parent=self.GetTopLevelParent(),

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -42,6 +42,7 @@ from invesalius.pubsub import pub as Publisher
 BTN_MASK = wx.NewIdRef()
 BTN_PICTURE = wx.NewIdRef()
 BTN_SURFACE = wx.NewIdRef()
+BTN_TEXTURE = wx.NewIdRef()
 BTN_REPORT = wx.NewIdRef()
 BTN_REQUEST_RP = wx.NewIdRef()
 
@@ -147,6 +148,20 @@ class InnerTaskPanel(wx.Panel):
         link_export_surface.UpdateLink()
         link_export_surface.Bind(hl.EVT_HYPERLINK_LEFT, self.OnLinkExportSurface)
 
+        tooltip = _("Export 3D surface from volume rendering...")
+        link_export_textured_surface = hl.HyperLinkCtrl(
+            self, -1, _("Export 3D surface from volume rendering...")
+        )
+        self.link_export_textured_surface = link_export_textured_surface
+        link_export_textured_surface.SetUnderlines(False, False, False)
+        link_export_textured_surface.SetBold(True)
+        link_export_textured_surface.SetColours("BLACK", "BLACK", "BLACK")
+        link_export_textured_surface.SetBackgroundColour(self.GetBackgroundColour())
+        link_export_textured_surface.SetToolTip(tooltip)
+        link_export_textured_surface.AutoBrowse(False)
+        link_export_textured_surface.UpdateLink()
+        link_export_textured_surface.Bind(hl.EVT_HYPERLINK_LEFT, self.OnLinkExportTexturedSurface)
+
         # tooltip = _("Export 3D mask (voxels)")
         # link_export_mask = hl.HyperLinkCtrl(self, -1,_("Export mask..."))
         # link_export_mask.SetUnderlines(False, False, False)
@@ -206,6 +221,13 @@ class InnerTaskPanel(wx.Panel):
             self, BTN_SURFACE, "", BMP_EXPORT_SURFACE, style=button_style
         )
         button_surface.SetBackgroundColour(self.GetBackgroundColour())
+        self.button_surface = button_surface
+
+        button_textured_surface = pbtn.PlateButton(
+            self, BTN_TEXTURE, "", BMP_EXPORT_SURFACE, style=button_style
+        )
+        button_textured_surface.SetBackgroundColour(self.GetBackgroundColour())
+        self.button_textured_surface = button_textured_surface
         # button_mask = pbtn.PlateButton(self, BTN_MASK, "",
         #                                BMP_EXPORT_MASK,
         #                                style=button_style)
@@ -222,7 +244,7 @@ class InnerTaskPanel(wx.Panel):
         flag_link = wx.EXPAND | wx.GROW | wx.LEFT | wx.TOP
         flag_button = wx.EXPAND | wx.GROW
 
-        fixed_sizer = wx.FlexGridSizer(rows=2, cols=2, hgap=2, vgap=0)
+        fixed_sizer = wx.FlexGridSizer(rows=3, cols=2, hgap=2, vgap=0)
         fixed_sizer.AddGrowableCol(0, 1)
         fixed_sizer.AddMany(
             [
@@ -230,6 +252,8 @@ class InnerTaskPanel(wx.Panel):
                 (button_picture, 0, flag_button),
                 (link_export_surface, 1, flag_link, 3),
                 (button_surface, 0, flag_button),
+                (link_export_textured_surface, 1, flag_link, 3),
+                (button_textured_surface, 0, flag_button),
             ]
         )
         # (link_export_mask, 1, flag_link, 3),
@@ -248,6 +272,11 @@ class InnerTaskPanel(wx.Panel):
         self.Fit()
         self.sizer = main_sizer
         self.__init_menu()
+
+        session = ses.Session()
+        if session.GetConfig("mode") == const.MODE_NAVIGATOR:
+            self.link_export_textured_surface.Hide()
+            self.button_textured_surface.Hide()
 
     def __init_menu(self):
         menu = wx.Menu()
@@ -402,9 +431,80 @@ class InnerTaskPanel(wx.Panel):
             self.OnLinkExportPicture()
         elif id == BTN_SURFACE:
             self.OnLinkExportSurface()
+        elif id == BTN_TEXTURE:
+            self.OnLinkExportTexturedSurface()
         elif id == BTN_REPORT:
             self.OnLinkReport()
         elif id == BTN_REQUEST_RP:
             self.OnLinkRequestRP()
         else:  # id == BTN_MASK:
             self.OnLinkExportMask()
+
+    def OnLinkExportTexturedSurface(self, evt=None):
+        project = proj.Project()
+        visible_surfaces = []
+        for index in project.surface_dict:
+            if project.surface_dict[index].is_shown:
+                visible_surfaces.append(index)
+
+        if not visible_surfaces:
+            dlg = wx.MessageDialog(
+                None,
+                _("You need to create a surface and make it ") + _("visible before exporting it."),
+                "InVesalius 3",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            try:
+                dlg.ShowModal()
+            finally:
+                dlg.Destroy()
+            return
+
+        import invesalius.data.surface_texture  # noqa: F401
+
+        # Select the first visible surface
+        surface_index = visible_surfaces[0]
+
+        # 2. Show File Save Dialog with Format choice in the type dropdown
+        session = ses.Session()
+        last_directory = session.GetConfig("last_directory_3d_surface", "")
+        project_name = pathlib.Path(project.name).stem
+
+        wildcard_choices = ["Wavefront OBJ (*.obj)|*.obj", "VRML (*.wrl)|*.wrl"]
+        wildcard = "|".join(wildcard_choices)
+
+        dlg_save = wx.FileDialog(
+            None,
+            _("Save textured 3D surface as..."),
+            last_directory,
+            project_name,
+            wildcard,
+            wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+        )
+        dlg_save.SetFilterIndex(0)  # Default OBJ
+
+        if dlg_save.ShowModal() == wx.ID_OK:
+            filename = dlg_save.GetPath()
+            format_index = dlg_save.GetFilterIndex()
+            export_format = "OBJ" if format_index == 0 else "VRML"
+            ext = "obj" if format_index == 0 else "wrl"
+
+            if sys.platform != "win32":
+                if filename.split(".")[-1].lower() != ext:
+                    filename = filename + "." + ext
+
+            last_directory = os.path.split(filename)[0]
+            session.SetConfig("last_directory_3d_surface", last_directory)
+
+            dlg_save.Destroy()
+
+            # 3. Trigger export via pubsub (caught in surface_texture.py)
+            Publisher.sendMessage(
+                "Export textured surface",
+                surface_index=surface_index,
+                format=export_format,
+                filename=filename,
+                parent=self.GetTopLevelParent(),
+            )
+        else:
+            dlg_save.Destroy()

--- a/invesalius_rs/__init__.py
+++ b/invesalius_rs/__init__.py
@@ -109,8 +109,10 @@ def count_regions(image: np.ndarray, number_regions: int) -> np.ndarray:
     return out
 
 
-# Texture generation function
+# Texture generation functions
 generate_surface_texture = _native.generate_surface_texture
+generate_tcoords = _native.generate_tcoords
+generate_tcoords_hf = _native.generate_tcoords_hf
 
 
 class Mesh:
@@ -150,8 +152,6 @@ class Mesh:
             _normals = numpy_support.vtk_to_numpy(pd.GetCellData().GetArray("Normals")).reshape(
                 -1, 3
             )
-
-            print(f"{_vertices.dtype=} {_faces.dtype=} {_normals.dtype=}")
 
             self._vertices = _vertices
             self._faces = _faces
@@ -300,4 +300,6 @@ __all__ = [
     "count_regions",
     # Texture generation
     "generate_surface_texture",
+    "generate_tcoords",
+    "generate_tcoords_hf",
 ]

--- a/invesalius_rs/__init__.py
+++ b/invesalius_rs/__init__.py
@@ -109,6 +109,10 @@ def count_regions(image: np.ndarray, number_regions: int) -> np.ndarray:
     return out
 
 
+# Texture generation function
+generate_surface_texture = _native.generate_surface_texture
+
+
 class Mesh:
     """
     Mesh wrapper class compatible with the original cy_mesh.Mesh interface.
@@ -294,4 +298,6 @@ __all__ = [
     "ca_smoothing",
     # Count regions
     "count_regions",
+    # Texture generation
+    "generate_surface_texture",
 ]

--- a/invesalius_rs/src/interpolation.rs
+++ b/invesalius_rs/src/interpolation.rs
@@ -2,36 +2,19 @@ use ndarray::ArrayView3;
 use num_traits::NumCast;
 use std::f64::consts::PI;
 
-// Helper function to get value with boundary wrapping
+// Helper function to get value with boundary clamping (prevents edge bleeding)
 fn get_value<T: Copy + Into<f64>>(v: ArrayView3<T>, x: isize, y: isize, z: isize) -> T {
     let dims = v.shape();
     let dz = dims[0] as isize;
     let dy = dims[1] as isize;
     let dx = dims[2] as isize;
 
-    let mut z_idx = z;
-    let mut y_idx = y;
-    let mut x_idx = x;
+    // FIX: Clamp indices to the boundaries instead of wrapping them
+    let z_idx = z.clamp(0, dz - 1) as usize;
+    let y_idx = y.clamp(0, dy - 1) as usize;
+    let x_idx = x.clamp(0, dx - 1) as usize;
 
-    if x_idx < 0 {
-        x_idx += dx;
-    } else if x_idx >= dx {
-        x_idx -= dx;
-    }
-
-    if y_idx < 0 {
-        y_idx += dy;
-    } else if y_idx >= dy {
-        y_idx -= dy;
-    }
-
-    if z_idx < 0 {
-        z_idx += dz;
-    } else if z_idx >= dz {
-        z_idx -= dz;
-    }
-
-    v[[z_idx as usize, y_idx as usize, x_idx as usize]]
+    v[[z_idx, y_idx, x_idx]]
 }
 
 fn cubic_interpolate(p: [f64; 4], x: f64) -> f64 {

--- a/invesalius_rs/src/lib.rs
+++ b/invesalius_rs/src/lib.rs
@@ -14,6 +14,8 @@ mod transforms_py;
 mod types;
 mod count_regions;
 mod count_regions_py;
+mod texture;
+mod texture_py;
 
 /// InVesalius Rust extension module
 #[pymodule]
@@ -52,6 +54,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Count regions function
     m.add_function(wrap_pyfunction!(count_regions_py::count_regions, m)?)?;
+
+    // Texture generation function
+    m.add_function(wrap_pyfunction!(texture_py::generate_surface_texture, m)?)?;
 
     Ok(())
 }

--- a/invesalius_rs/src/lib.rs
+++ b/invesalius_rs/src/lib.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+mod count_regions;
+mod count_regions_py;
 mod floodfill;
 mod floodfill_py;
 mod interpolation;
@@ -9,13 +11,11 @@ mod mesh;
 mod mesh_py;
 mod mips;
 mod mips_py;
+mod texture;
+mod texture_py;
 mod transforms;
 mod transforms_py;
 mod types;
-mod count_regions;
-mod count_regions_py;
-mod texture;
-mod texture_py;
 
 /// InVesalius Rust extension module
 #[pymodule]
@@ -32,7 +32,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(floodfill_py::jump_flooding, m)?)?;
 
     // Floodfill voronoi function
-    m.add_function(wrap_pyfunction!(floodfill_py::floodfill_voronoi_inplace, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        floodfill_py::floodfill_voronoi_inplace,
+        m
+    )?)?;
 
     // MIPS functions
     m.add_function(wrap_pyfunction!(mips_py::mida, m)?)?;
@@ -55,8 +58,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Count regions function
     m.add_function(wrap_pyfunction!(count_regions_py::count_regions, m)?)?;
 
-    // Texture generation function
+    // Texture generation functions
     m.add_function(wrap_pyfunction!(texture_py::generate_surface_texture, m)?)?;
+    m.add_function(wrap_pyfunction!(texture_py::generate_tcoords, m)?)?;
+    m.add_function(wrap_pyfunction!(texture_py::generate_tcoords_hf, m)?)?;
 
     Ok(())
 }

--- a/invesalius_rs/src/texture.rs
+++ b/invesalius_rs/src/texture.rs
@@ -11,41 +11,28 @@ use crate::interpolation::trilinear_interpolate_internal;
 /// Calculate barycentric coordinates for UV mapping
 #[inline]
 fn uv_to_barycentric(
-    u0: f64, v0: f64,
-    u1: f64, v1: f64,
-    u2: f64, v2: f64,
-    u: f64, v: f64,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    x3: f64,
+    y3: f64,
+    x: f64,
+    y: f64,
 ) -> [f64; 3] {
-    let denom = (v2 - v0) * (u1 - u0) + (u2 - u0) * (v1 - v0);
+    let denom = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
     if denom.abs() < 1e-10 {
         return [1.0, 0.0, 0.0];
     }
-    
-    let bar0 = ((v2 - v0) * (u - u0) + (u2 - u0) * (v - v0)) / denom;
-    let bar1 = ((v0 - v1) * (u - u0) + (u0 - u1) * (v - v0)) / denom;
+
+    let bar0 = ((y2 - y3) * (x - x3) + (x3 - x2) * (y - y3)) / denom;
+    let bar1 = ((y3 - y1) * (x - x3) + (x1 - x3) * (y - y3)) / denom;
     let bar2 = 1.0 - bar0 - bar1;
-    
+
     [bar0, bar1, bar2]
 }
 
 /// Generate texture coordinates and texture image from mesh and volume data
-/// 
-/// This is the main function that creates a texture atlas from a 3D mesh.
-/// It lays out all triangles in a 2D grid and samples volume data at each position.
-///
-/// # Arguments
-/// * `vertices` - Mesh vertices (N x 3)
-/// * `normals` - Vertex normals (N x 3)
-/// * `faces` - Face indices (M x 3)
-/// * `volume` - 3D volume data (D x H x W)
-/// * `spacing` - Volume spacing (3)
-/// * `window_width` - Window width for visualization
-/// * `window_level` - Window level for visualization
-/// * `clut` - Color lookup table (256 x 3)
-/// * `texture_dim` - Texture atlas dimension (default 5000)
-///
-/// # Returns
-/// * `(tcoords, texture_image, texture_normals)` - UV coordinates, texture image, and normals
 pub fn generate_surface_texture_internal<V, F, T>(
     vertices: ArrayView2<V>,
     normals: ArrayView2<V>,
@@ -63,27 +50,33 @@ where
     T: Copy + Into<f64> + Send + Sync + NumCast,
 {
     let n_faces = faces.shape()[0];
-    
+
     // Calculate grid dimensions for texture atlas
     let nx = (n_faces as f64).sqrt() as usize;
     let ny = (n_faces as f64 / nx as f64).ceil() as usize;
-    
+
     let d = texture_dim;
     let dtx = d as f64 / nx as f64;
     let dty = d as f64 / ny as f64;
-    
+
     // Output arrays
     let mut tcoords = Array2::<f64>::zeros((n_faces, 6));
     let mut texture_image = Array3::<u8>::zeros((d, d, 3));
     let mut texture_normals = Array3::<u8>::zeros((d, d, 3));
-    
+
     let offset = 2;
-    
+
+    // Apply window/level parameters
+    let wl = window_level as f64;
+    let ww = window_width as f64;
+    let min_val = wl - 0.5 - (ww - 1.0) / 2.0;
+    let max_val = wl - 0.5 + (ww - 1.0) / 2.0;
+
     // Process each triangle
     for tc in 0..n_faces {
         let i = tc % nx;
         let j = tc / nx;
-        
+
         // Calculate UV coordinates for the triangle corners
         let c0x = (i as f64 * dtx + offset as f64) as usize;
         let c0y = (j as f64 * dty + offset as f64) as usize;
@@ -91,88 +84,83 @@ where
         let c1y = c0y;
         let c2x = ((c0x as f64 + c1x as f64) / 2.0) as usize;
         let c2y = (c0y as f64 + dty - offset as f64) as usize;
-        
-        // Store UV coordinates (6 values per triangle: u0,v0,u1,v1,u2,v2)
+
+        // Store UV coordinates
         tcoords[[tc, 0]] = c0x as f64 / d as f64;
         tcoords[[tc, 1]] = 1.0 - c0y as f64 / d as f64;
         tcoords[[tc, 2]] = c1x as f64 / d as f64;
         tcoords[[tc, 3]] = 1.0 - c1y as f64 / d as f64;
         tcoords[[tc, 4]] = c2x as f64 / d as f64;
         tcoords[[tc, 5]] = 1.0 - c2y as f64 / d as f64;
-        
+
         // Get vertex and normal indices for this face
         let v0_idx = faces[[tc, 0]].try_into().unwrap_or(0);
         let v1_idx = faces[[tc, 1]].try_into().unwrap_or(0);
         let v2_idx = faces[[tc, 2]].try_into().unwrap_or(0);
-        
-        // Get vertex positions
+
         let v0 = vertices.row(v0_idx);
         let v1 = vertices.row(v1_idx);
         let v2 = vertices.row(v2_idx);
-        
-        // Get vertex normals
+
         let n0 = normals.row(v0_idx);
         let n1 = normals.row(v1_idx);
         let n2 = normals.row(v2_idx);
-        
+
         // Sample volume data for each pixel in the triangle
         for y in (c0y.saturating_sub(1))..(c2y + 1).min(d) {
             for x in (c0x.saturating_sub(1))..(c1x + 1).min(d) {
                 // Calculate barycentric coordinates
                 let bar = uv_to_barycentric(
-                    tcoords[[tc, 0]], tcoords[[tc, 1]],
-                    tcoords[[tc, 2]], tcoords[[tc, 3]],
-                    tcoords[[tc, 4]], tcoords[[tc, 5]],
+                    tcoords[[tc, 0]],
+                    tcoords[[tc, 1]],
+                    tcoords[[tc, 2]],
+                    tcoords[[tc, 3]],
+                    tcoords[[tc, 4]],
+                    tcoords[[tc, 5]],
                     x as f64 / d as f64,
                     1.0 - y as f64 / d as f64,
                 );
-                
-                // Interpolate vertex positions using barycentric coordinates
+
                 let vx = bar[0] * v0[0].into() + bar[1] * v1[0].into() + bar[2] * v2[0].into();
                 let vy = bar[0] * v0[1].into() + bar[1] * v1[1].into() + bar[2] * v2[1].into();
                 let vz = bar[0] * v0[2].into() + bar[1] * v1[2].into() + bar[2] * v2[2].into();
-                
-                // Convert to volume coordinates
+
+                // Convert to volume coordinates (FIX: Added spacing division)
                 let px = vx / spacing[0];
                 let py = vy / spacing[1];
                 let pz = vz / spacing[2];
-                
+
                 // Interpolate normal
                 let inx = bar[0] * n0[0].into() + bar[1] * n1[0].into() + bar[2] * n2[0].into();
                 let iny = bar[0] * n0[1].into() + bar[1] * n1[1].into() + bar[2] * n2[1].into();
                 let inz = bar[0] * n0[2].into() + bar[1] * n1[2].into() + bar[2] * n2[2].into();
-                
+
                 // Normalize
                 let inn = (inx * inx + iny * iny + inz * inz).sqrt();
                 let inx = if inn > 1e-10 { inx / inn } else { 0.0 };
                 let iny = if inn > 1e-10 { iny / inn } else { 0.0 };
                 let inz = if inn > 1e-10 { inz / inn } else { 0.0 };
-                
+
                 // Sample volume data at this position
                 let volume_val = trilinear_interpolate_internal(volume, px, py, pz);
-                
-                // Apply window/level
-                let wl = window_level as f64;
-                let ww = window_width as f64;
-                let min_val = wl - ww / 2.0;
-                let max_val = wl + ww / 2.0;
-                
+
+                // Apply window/level logic
                 let gv = if volume_val.into() <= min_val {
                     0.0
                 } else if volume_val.into() >= max_val {
                     255.0
                 } else {
-                    ((volume_val.into() - min_val) / ww + 0.5) * 255.0
+                    ((volume_val.into() - (wl - 0.5)) / (ww - 1.0) + 0.5) * 255.0
                 };
-                
+
                 let gv_idx = (gv as usize).min(255);
-                
+
                 // Apply color from CLUT
                 texture_image[[y, x, 0]] = clut[[gv_idx, 0]];
                 texture_image[[y, x, 1]] = clut[[gv_idx, 1]];
                 texture_image[[y, x, 2]] = clut[[gv_idx, 2]];
-                
-                // Calculate gradient for texture normals (simplified)
+
+                // Calculate gradient for texture normals
                 let h = 1.0;
                 let gx1 = trilinear_interpolate_internal(volume, px - h, py, pz);
                 let gx2 = trilinear_interpolate_internal(volume, px + h, py, pz);
@@ -180,13 +168,191 @@ where
                 let gy2 = trilinear_interpolate_internal(volume, px, py + h, pz);
                 let gz1 = trilinear_interpolate_internal(volume, px, py, pz - h);
                 let gz2 = trilinear_interpolate_internal(volume, px, py, pz + h);
-                
+
                 let tnx = (gx2.into() - gx1.into()) / (2.0 * h);
                 let tny = (gy2.into() - gy1.into()) / (2.0 * h);
                 let tnz = (gz2.into() - gz1.into()) / (2.0 * h);
-                
+
                 let tnn = (tnx * tnx + tny * tny + tnz * tnz).sqrt();
-                
+
+                if tnn > 1e-10 {
+                    texture_normals[[y, x, 0]] = (((tnx / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 1]] = (((tny / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 2]] = (((tnz / tnn) + 1.0) * 127.5) as u8;
+                }
+
+                // MIDA Raycasting (FIX: Corrected offset, steps, and ray init)
+                let ray_offset = 50.0;
+                let nsteps = 50;
+                let step = ray_offset / nsteps as f64;
+
+                let ray_init_x = px + (ray_offset / 2.0) * inx;
+                let ray_init_y = py + (ray_offset / 2.0) * iny;
+                let ray_init_z = pz + (ray_offset / 2.0) * inz;
+
+                let mut alphai = 0.0;
+
+                // Keep track of floated colors during compositing
+                let mut cr = texture_image[[y, x, 0]] as f64;
+                let mut cg = texture_image[[y, x, 1]] as f64;
+                let mut cb = texture_image[[y, x, 2]] as f64;
+
+                let dx = volume.shape()[2] as f64;
+                let dy = volume.shape()[1] as f64;
+                let dz = volume.shape()[0] as f64;
+
+                for s in 0..=nsteps {
+                    // FIX: Step backwards into the volume
+                    let ray_px = ray_init_x - inx * step * s as f64;
+                    let ray_py = ray_init_y - iny * step * s as f64;
+                    let ray_pz = ray_init_z - inz * step * s as f64;
+
+                    if ray_px >= 0.0
+                        && ray_px <= (dx - 1.0)
+                        && ray_py >= 0.0
+                        && ray_py <= (dy - 1.0)
+                        && ray_pz >= 0.0
+                        && ray_pz <= (dz - 1.0)
+                    {
+                        let ray_val =
+                            trilinear_interpolate_internal(volume, ray_px, ray_py, ray_pz);
+                        let val = ray_val.into() as f64;
+
+                        // FIX: Restore dynamic WW/WL
+                        let ray_gv = if val <= min_val {
+                            0.0
+                        } else if val >= max_val {
+                            255.0
+                        } else {
+                            ((val - (wl - 0.5)) / (ww - 1.0) + 0.5) * 255.0
+                        };
+
+                        let ray_gv_idx = (ray_gv as usize).min(255);
+                        let alpha = ray_gv / 255.0; // FIX: Removed the 0.15 hack
+
+                        cr += clut[[ray_gv_idx, 0]] as f64 * alpha * (1.0 - alphai);
+                        cg += clut[[ray_gv_idx, 1]] as f64 * alpha * (1.0 - alphai);
+                        cb += clut[[ray_gv_idx, 2]] as f64 * alpha * (1.0 - alphai);
+
+                        alphai = (1.0 - alphai) * alpha + alphai;
+                        if alphai >= 1.0 {
+                            break;
+                        }
+                    }
+                }
+
+                texture_image[[y, x, 0]] = cr.min(255.0) as u8;
+                texture_image[[y, x, 1]] = cg.min(255.0) as u8;
+                texture_image[[y, x, 2]] = cb.min(255.0) as u8;
+            }
+        }
+    }
+
+    (tcoords, texture_image, texture_normals)
+}
+
+/// Generate UV coordinates and texture from volume (without color mapping)
+pub fn generate_tcoords_internal<V, F, T>(
+    vertices: ArrayView2<V>,
+    faces: ArrayView2<F>,
+    volume: ArrayView3<T>,
+    spacing: &[f64; 3],
+    texture_dim: usize,
+) -> (Array2<f64>, Array2<i16>, Array3<u8>)
+where
+    V: Copy + Into<f64> + Send + Sync,
+    F: Copy + TryInto<usize> + Send + Sync,
+    T: Copy + Into<f64> + Send + Sync + NumCast,
+{
+    let n_faces = faces.shape()[0];
+
+    let nx = (n_faces as f64).sqrt() as usize;
+    let ny = (n_faces as f64 / nx as f64).ceil() as usize;
+
+    let d = texture_dim;
+    let dtx = d as f64 / nx as f64;
+    let dty = d as f64 / ny as f64;
+
+    let offset = 2;
+
+    let mut tcoords = Array2::<f64>::zeros((n_faces, 6));
+    let mut texture_image = Array2::<i16>::zeros((d, d)); // 2D grayscale
+    let mut texture_normals = Array3::<u8>::zeros((d, d, 3));
+
+    let h = 1.0;
+
+    for tc in 0..n_faces {
+        let i = tc % nx;
+        let j = tc / nx;
+
+        let c0x = (i as f64 * dtx + offset as f64) as usize;
+        let c0y = (j as f64 * dty + offset as f64) as usize;
+        let c1x = (c0x as f64 + dtx - offset as f64) as usize;
+        let c1y = c0y;
+        let c2x = ((c0x as f64 + c1x as f64) / 2.0) as usize;
+        let c2y = (c0y as f64 + dty - offset as f64) as usize;
+
+        tcoords[[tc, 0]] = c0x as f64 / d as f64;
+        tcoords[[tc, 1]] = 1.0 - c0y as f64 / d as f64;
+        tcoords[[tc, 2]] = c1x as f64 / d as f64;
+        tcoords[[tc, 3]] = 1.0 - c1y as f64 / d as f64;
+        tcoords[[tc, 4]] = c2x as f64 / d as f64;
+        tcoords[[tc, 5]] = 1.0 - c2y as f64 / d as f64;
+
+        let v0_idx = faces[[tc, 0]].try_into().unwrap_or(0);
+        let v1_idx = faces[[tc, 1]].try_into().unwrap_or(0);
+        let v2_idx = faces[[tc, 2]].try_into().unwrap_or(0);
+
+        let v0 = vertices.row(v0_idx);
+        let v1 = vertices.row(v1_idx);
+        let v2 = vertices.row(v2_idx);
+
+        for y in c0y.saturating_sub(1)..(c2y + 1).min(d) {
+            for x in c0x.saturating_sub(1)..(c1x + 1).min(d) {
+                let bar = uv_to_barycentric(
+                    tcoords[[tc, 0]],
+                    tcoords[[tc, 1]],
+                    tcoords[[tc, 2]],
+                    tcoords[[tc, 3]],
+                    tcoords[[tc, 4]],
+                    tcoords[[tc, 5]],
+                    x as f64 / d as f64,
+                    1.0 - y as f64 / d as f64,
+                );
+
+                let vx = bar[0] * v0[0].into() + bar[1] * v1[0].into() + bar[2] * v2[0].into();
+                let vy = bar[0] * v0[1].into() + bar[1] * v1[1].into() + bar[2] * v2[1].into();
+                let vz = bar[0] * v0[2].into() + bar[1] * v1[2].into() + bar[2] * v2[2].into();
+
+                let px = vx / spacing[0];
+                let py = vy / spacing[1];
+                let pz = vz / spacing[2];
+
+                // Sample volume at multiple points for averaging
+                let gv = (trilinear_interpolate_internal(volume, px, py, pz).into()
+                    + trilinear_interpolate_internal(volume, px + h, py, pz).into()
+                    + trilinear_interpolate_internal(volume, px - h, py, pz).into()
+                    + trilinear_interpolate_internal(volume, px, py + h, pz).into()
+                    + trilinear_interpolate_internal(volume, px, py - h, pz).into()
+                    + trilinear_interpolate_internal(volume, px, py, pz + h).into()
+                    + trilinear_interpolate_internal(volume, px, py, pz - h).into())
+                    / 7.0;
+
+                // Compute gradient for texture normals
+                let tnx = (trilinear_interpolate_internal(volume, px + h, py, pz).into()
+                    - trilinear_interpolate_internal(volume, px - h, py, pz).into())
+                    / (2.0 * h);
+                let tny = (trilinear_interpolate_internal(volume, px, py + h, pz).into()
+                    - trilinear_interpolate_internal(volume, px, py - h, pz).into())
+                    / (2.0 * h);
+                let tnz = (trilinear_interpolate_internal(volume, px, py, pz + h).into()
+                    - trilinear_interpolate_internal(volume, px, py, pz - h).into())
+                    / (2.0 * h);
+
+                let tnn = (tnx * tnx + tny * tny + tnz * tnz).sqrt();
+
+                texture_image[[y, x]] = gv as i16; // 2D indexing
+
                 if tnn > 1e-10 {
                     texture_normals[[y, x, 0]] = (((tnx / tnn) + 1.0) * 127.5) as u8;
                     texture_normals[[y, x, 1]] = (((tny / tnn) + 1.0) * 127.5) as u8;
@@ -195,6 +361,160 @@ where
             }
         }
     }
-    
+
+    (tcoords, texture_image, texture_normals)
+}
+
+/// High-frequency surface texture using multi-slice raycasting
+pub fn generate_tcoords_hf_internal<V, F, T>(
+    vertices: ArrayView2<V>,
+    normals: ArrayView2<V>,
+    faces: ArrayView2<F>,
+    volume: ArrayView3<T>,
+    spacing: &[f64; 3],
+    window_width: i32,
+    window_level: i32,
+    clut: ArrayView2<u8>,
+    texture_dim: usize,
+    n_slices: usize,
+) -> (Array2<f64>, Array3<i16>, Array3<u8>)
+where
+    V: Copy + Into<f64> + Send + Sync,
+    F: Copy + TryInto<usize> + Send + Sync,
+    T: Copy + Into<f64> + Send + Sync + NumCast,
+{
+    let n_faces = faces.shape()[0];
+
+    let nx = (n_faces as f64).sqrt() as usize;
+    let ny = (n_faces as f64 / nx as f64).ceil() as usize;
+
+    let d = texture_dim;
+    let dtx = d as f64 / nx as f64;
+    let dty = d as f64 / ny as f64;
+
+    let offset = 2;
+    let ray_offset = 5.0;
+
+    let mut tcoords = Array2::<f64>::zeros((n_faces, 6));
+    let mut texture_image = Array3::<i16>::from_elem((n_slices, d, d), -32768);
+    let mut texture_normals = Array3::<u8>::zeros((d, d, 3));
+
+    for tc in 0..n_faces {
+        let i = tc % nx;
+        let j = tc / nx;
+
+        let c0x = (i as f64 * dtx + offset as f64) as usize;
+        let c0y = (j as f64 * dty + offset as f64) as usize;
+        let c1x = (c0x as f64 + dtx - offset as f64) as usize;
+        let c1y = c0y;
+        let c2x = ((c0x as f64 + c1x as f64) / 2.0) as usize;
+        let c2y = (c0y as f64 + dty - offset as f64) as usize;
+
+        tcoords[[tc, 0]] = c0x as f64 / d as f64;
+        tcoords[[tc, 1]] = 1.0 - c0y as f64 / d as f64;
+        tcoords[[tc, 2]] = c1x as f64 / d as f64;
+        tcoords[[tc, 3]] = 1.0 - c1y as f64 / d as f64;
+        tcoords[[tc, 4]] = c2x as f64 / d as f64;
+        tcoords[[tc, 5]] = 1.0 - c2y as f64 / d as f64;
+
+        let v0_idx = faces[[tc, 0]].try_into().unwrap_or(0);
+        let v1_idx = faces[[tc, 1]].try_into().unwrap_or(0);
+        let v2_idx = faces[[tc, 2]].try_into().unwrap_or(0);
+
+        let v0 = vertices.row(v0_idx);
+        let v1 = vertices.row(v1_idx);
+        let v2 = vertices.row(v2_idx);
+
+        let n0 = normals.row(v0_idx);
+        let n1 = normals.row(v1_idx);
+        let n2 = normals.row(v2_idx);
+
+        for y in c0y.saturating_sub(1)..(c2y + 1).min(d) {
+            for x in c0x.saturating_sub(1)..(c1x + 1).min(d) {
+                let bar = uv_to_barycentric(
+                    tcoords[[tc, 0]],
+                    tcoords[[tc, 1]],
+                    tcoords[[tc, 2]],
+                    tcoords[[tc, 3]],
+                    tcoords[[tc, 4]],
+                    tcoords[[tc, 5]],
+                    x as f64 / d as f64,
+                    1.0 - y as f64 / d as f64,
+                );
+
+                let vx = bar[0] * v0[0].into() + bar[1] * v1[0].into() + bar[2] * v2[0].into();
+                let vy = bar[0] * v0[1].into() + bar[1] * v1[1].into() + bar[2] * v2[1].into();
+                let vz = bar[0] * v0[2].into() + bar[1] * v1[2].into() + bar[2] * v2[2].into();
+
+                let px = vx;
+                let py = vy;
+                let pz = vz;
+
+                // Interpolate normal
+                let inx = bar[0] * n0[0].into() + bar[1] * n1[0].into() + bar[2] * n2[0].into();
+                let iny = bar[0] * n0[1].into() + bar[1] * n1[1].into() + bar[2] * n2[1].into();
+                let inz = bar[0] * n0[2].into() + bar[1] * n1[2].into() + bar[2] * n2[2].into();
+
+                let inn = (inx * inx + iny * iny + inz * inz).sqrt();
+                let inx = if inn > 1e-10 { inx / inn } else { 0.0 };
+                let iny = if inn > 1e-10 { iny / inn } else { 0.0 };
+                let inz = if inn > 1e-10 { inz / inn } else { 0.0 };
+
+                // Multi-slice raycasting (negative normal direction)
+                let step = ray_offset / n_slices as f64;
+
+                for s in 0..n_slices {
+                    let ray_px = (px - inx * step * s as f64) / spacing[0];
+                    let ray_py = (py - iny * step * s as f64) / spacing[1];
+                    let ray_pz = (pz - inz * step * s as f64) / spacing[2];
+
+                    let dx = volume.shape()[2] as f64;
+                    let dy = volume.shape()[1] as f64;
+                    let dz = volume.shape()[0] as f64;
+
+                    if ray_px >= 0.0
+                        && ray_px <= (dx - 1.0)
+                        && ray_py >= 0.0
+                        && ray_py <= (dy - 1.0)
+                        && ray_pz >= 0.0
+                        && ray_pz <= (dz - 1.0)
+                    {
+                        let vol_val = crate::interpolation::tricubic_interpolate_internal(
+                            volume, ray_px, ray_py, ray_pz,
+                        );
+                        texture_image[[s, y, x]] = <i16 as NumCast>::from(vol_val).unwrap_or(0);
+                    } else {
+                        texture_image[[s, y, x]] = -32768; // NULL_VALUE
+                    }
+                }
+
+                let px = px / spacing[0];
+                let py = py / spacing[1];
+                let pz = pz / spacing[2];
+
+                // Compute gradient normals
+                let h = 1.0;
+                let gx1 = trilinear_interpolate_internal(volume, px - h, py, pz);
+                let gx2 = trilinear_interpolate_internal(volume, px + h, py, pz);
+                let gy1 = trilinear_interpolate_internal(volume, px, py - h, pz);
+                let gy2 = trilinear_interpolate_internal(volume, px, py + h, pz);
+                let gz1 = trilinear_interpolate_internal(volume, px, py, pz - h);
+                let gz2 = trilinear_interpolate_internal(volume, px, py, pz + h);
+
+                let tnx = (gx2.into() - gx1.into()) / (2.0 * h);
+                let tny = (gy2.into() - gy1.into()) / (2.0 * h);
+                let tnz = (gz2.into() - gz1.into()) / (2.0 * h);
+
+                let tnn = (tnx * tnx + tny * tny + tnz * tnz).sqrt();
+
+                if tnn > 1e-10 {
+                    texture_normals[[y, x, 0]] = (((tnx / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 1]] = (((tny / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 2]] = (((tnz / tnn) + 1.0) * 127.5) as u8;
+                }
+            }
+        }
+    }
+
     (tcoords, texture_image, texture_normals)
 }

--- a/invesalius_rs/src/texture.rs
+++ b/invesalius_rs/src/texture.rs
@@ -32,6 +32,40 @@ fn uv_to_barycentric(
     [bar0, bar1, bar2]
 }
 
+/// Linearly interpolate the VR opacity transfer function curve.
+/// `opacity_curve` is an Nx2 array where column 0 = HU value, column 1 = opacity (0..1).
+/// The rows must be sorted by HU (ascending).
+#[inline]
+fn lookup_opacity(hu: f64, opacity_curve: &ArrayView2<f64>) -> f64 {
+    let n = opacity_curve.shape()[0];
+    if n == 0 {
+        return 0.0;
+    }
+    // Clamp to curve bounds
+    if hu <= opacity_curve[[0, 0]] {
+        return opacity_curve[[0, 1]];
+    }
+    if hu >= opacity_curve[[n - 1, 0]] {
+        return opacity_curve[[n - 1, 1]];
+    }
+    // Linear interpolation between surrounding points
+    for i in 1..n {
+        if hu <= opacity_curve[[i, 0]] {
+            let x0 = opacity_curve[[i - 1, 0]];
+            let x1 = opacity_curve[[i, 0]];
+            let y0 = opacity_curve[[i - 1, 1]];
+            let y1 = opacity_curve[[i, 1]];
+            let dx = x1 - x0;
+            if dx.abs() < 1e-10 {
+                return y1;
+            }
+            let t = (hu - x0) / dx;
+            return y0 + t * (y1 - y0);
+        }
+    }
+    opacity_curve[[n - 1, 1]]
+}
+
 /// Generate texture coordinates and texture image from mesh and volume data
 pub fn generate_surface_texture_internal<V, F, T>(
     vertices: ArrayView2<V>,
@@ -42,6 +76,7 @@ pub fn generate_surface_texture_internal<V, F, T>(
     window_width: i32,
     window_level: i32,
     clut: ArrayView2<u8>,
+    opacity_curve: ArrayView2<f64>,
     texture_dim: usize,
 ) -> (Array2<f64>, Array3<u8>, Array3<u8>)
 where
@@ -143,22 +178,26 @@ where
 
                 // Sample volume data at this position
                 let volume_val = trilinear_interpolate_internal(volume, px, py, pz);
+                let surface_hu = volume_val.into() as f64;
 
-                // Apply window/level logic
-                let gv = if volume_val.into() <= min_val {
+                // Apply window/level logic for CLUT index
+                let gv = if surface_hu <= min_val {
                     0.0
-                } else if volume_val.into() >= max_val {
+                } else if surface_hu >= max_val {
                     255.0
                 } else {
-                    ((volume_val.into() - (wl - 0.5)) / (ww - 1.0) + 0.5) * 255.0
+                    ((surface_hu - (wl - 0.5)) / (ww - 1.0) + 0.5) * 255.0
                 };
 
                 let gv_idx = (gv as usize).min(255);
 
-                // Apply color from CLUT
-                texture_image[[y, x, 0]] = clut[[gv_idx, 0]];
-                texture_image[[y, x, 1]] = clut[[gv_idx, 1]];
-                texture_image[[y, x, 2]] = clut[[gv_idx, 2]];
+                // Look up opacity from the VR transfer function
+                let surface_alpha = lookup_opacity(surface_hu, &opacity_curve);
+
+                // Apply color from CLUT, weighted by opacity
+                texture_image[[y, x, 0]] = (clut[[gv_idx, 0]] as f64 * surface_alpha) as u8;
+                texture_image[[y, x, 1]] = (clut[[gv_idx, 1]] as f64 * surface_alpha) as u8;
+                texture_image[[y, x, 2]] = (clut[[gv_idx, 2]] as f64 * surface_alpha) as u8;
 
                 // Calculate gradient for texture normals
                 let h = 1.0;
@@ -218,7 +257,7 @@ where
                             trilinear_interpolate_internal(volume, ray_px, ray_py, ray_pz);
                         let val = ray_val.into() as f64;
 
-                        // FIX: Restore dynamic WW/WL
+                        // Map raw HU to CLUT index via WW/WL
                         let ray_gv = if val <= min_val {
                             0.0
                         } else if val >= max_val {
@@ -228,7 +267,8 @@ where
                         };
 
                         let ray_gv_idx = (ray_gv as usize).min(255);
-                        let alpha = ray_gv / 255.0; // FIX: Removed the 0.15 hack
+                        // Use VR opacity transfer function instead of linear ramp
+                        let alpha = lookup_opacity(val, &opacity_curve);
 
                         cr += clut[[ray_gv_idx, 0]] as f64 * alpha * (1.0 - alphai);
                         cg += clut[[ray_gv_idx, 1]] as f64 * alpha * (1.0 - alphai);

--- a/invesalius_rs/src/texture.rs
+++ b/invesalius_rs/src/texture.rs
@@ -1,0 +1,200 @@
+// Surface texture generation for medical imaging
+// Ported from Cython to Rust for InVesalius3 integration
+
+use ndarray::prelude::*;
+use ndarray::ArrayView3;
+use num_traits::NumCast;
+
+// Re-use interpolation from the existing module
+use crate::interpolation::trilinear_interpolate_internal;
+
+/// Calculate barycentric coordinates for UV mapping
+#[inline]
+fn uv_to_barycentric(
+    u0: f64, v0: f64,
+    u1: f64, v1: f64,
+    u2: f64, v2: f64,
+    u: f64, v: f64,
+) -> [f64; 3] {
+    let denom = (v2 - v0) * (u1 - u0) + (u2 - u0) * (v1 - v0);
+    if denom.abs() < 1e-10 {
+        return [1.0, 0.0, 0.0];
+    }
+    
+    let bar0 = ((v2 - v0) * (u - u0) + (u2 - u0) * (v - v0)) / denom;
+    let bar1 = ((v0 - v1) * (u - u0) + (u0 - u1) * (v - v0)) / denom;
+    let bar2 = 1.0 - bar0 - bar1;
+    
+    [bar0, bar1, bar2]
+}
+
+/// Generate texture coordinates and texture image from mesh and volume data
+/// 
+/// This is the main function that creates a texture atlas from a 3D mesh.
+/// It lays out all triangles in a 2D grid and samples volume data at each position.
+///
+/// # Arguments
+/// * `vertices` - Mesh vertices (N x 3)
+/// * `normals` - Vertex normals (N x 3)
+/// * `faces` - Face indices (M x 3)
+/// * `volume` - 3D volume data (D x H x W)
+/// * `spacing` - Volume spacing (3)
+/// * `window_width` - Window width for visualization
+/// * `window_level` - Window level for visualization
+/// * `clut` - Color lookup table (256 x 3)
+/// * `texture_dim` - Texture atlas dimension (default 5000)
+///
+/// # Returns
+/// * `(tcoords, texture_image, texture_normals)` - UV coordinates, texture image, and normals
+pub fn generate_surface_texture_internal<V, F, T>(
+    vertices: ArrayView2<V>,
+    normals: ArrayView2<V>,
+    faces: ArrayView2<F>,
+    volume: ArrayView3<T>,
+    spacing: &[f64; 3],
+    window_width: i32,
+    window_level: i32,
+    clut: ArrayView2<u8>,
+    texture_dim: usize,
+) -> (Array2<f64>, Array3<u8>, Array3<u8>)
+where
+    V: Copy + Into<f64> + Send + Sync,
+    F: Copy + TryInto<usize> + Send + Sync,
+    T: Copy + Into<f64> + Send + Sync + NumCast,
+{
+    let n_faces = faces.shape()[0];
+    
+    // Calculate grid dimensions for texture atlas
+    let nx = (n_faces as f64).sqrt() as usize;
+    let ny = (n_faces as f64 / nx as f64).ceil() as usize;
+    
+    let d = texture_dim;
+    let dtx = d as f64 / nx as f64;
+    let dty = d as f64 / ny as f64;
+    
+    // Output arrays
+    let mut tcoords = Array2::<f64>::zeros((n_faces, 6));
+    let mut texture_image = Array3::<u8>::zeros((d, d, 3));
+    let mut texture_normals = Array3::<u8>::zeros((d, d, 3));
+    
+    let offset = 2;
+    
+    // Process each triangle
+    for tc in 0..n_faces {
+        let i = tc % nx;
+        let j = tc / nx;
+        
+        // Calculate UV coordinates for the triangle corners
+        let c0x = (i as f64 * dtx + offset as f64) as usize;
+        let c0y = (j as f64 * dty + offset as f64) as usize;
+        let c1x = (c0x as f64 + dtx - offset as f64) as usize;
+        let c1y = c0y;
+        let c2x = ((c0x as f64 + c1x as f64) / 2.0) as usize;
+        let c2y = (c0y as f64 + dty - offset as f64) as usize;
+        
+        // Store UV coordinates (6 values per triangle: u0,v0,u1,v1,u2,v2)
+        tcoords[[tc, 0]] = c0x as f64 / d as f64;
+        tcoords[[tc, 1]] = 1.0 - c0y as f64 / d as f64;
+        tcoords[[tc, 2]] = c1x as f64 / d as f64;
+        tcoords[[tc, 3]] = 1.0 - c1y as f64 / d as f64;
+        tcoords[[tc, 4]] = c2x as f64 / d as f64;
+        tcoords[[tc, 5]] = 1.0 - c2y as f64 / d as f64;
+        
+        // Get vertex and normal indices for this face
+        let v0_idx = faces[[tc, 0]].try_into().unwrap_or(0);
+        let v1_idx = faces[[tc, 1]].try_into().unwrap_or(0);
+        let v2_idx = faces[[tc, 2]].try_into().unwrap_or(0);
+        
+        // Get vertex positions
+        let v0 = vertices.row(v0_idx);
+        let v1 = vertices.row(v1_idx);
+        let v2 = vertices.row(v2_idx);
+        
+        // Get vertex normals
+        let n0 = normals.row(v0_idx);
+        let n1 = normals.row(v1_idx);
+        let n2 = normals.row(v2_idx);
+        
+        // Sample volume data for each pixel in the triangle
+        for y in (c0y.saturating_sub(1))..(c2y + 1).min(d) {
+            for x in (c0x.saturating_sub(1))..(c1x + 1).min(d) {
+                // Calculate barycentric coordinates
+                let bar = uv_to_barycentric(
+                    tcoords[[tc, 0]], tcoords[[tc, 1]],
+                    tcoords[[tc, 2]], tcoords[[tc, 3]],
+                    tcoords[[tc, 4]], tcoords[[tc, 5]],
+                    x as f64 / d as f64,
+                    1.0 - y as f64 / d as f64,
+                );
+                
+                // Interpolate vertex positions using barycentric coordinates
+                let vx = bar[0] * v0[0].into() + bar[1] * v1[0].into() + bar[2] * v2[0].into();
+                let vy = bar[0] * v0[1].into() + bar[1] * v1[1].into() + bar[2] * v2[1].into();
+                let vz = bar[0] * v0[2].into() + bar[1] * v1[2].into() + bar[2] * v2[2].into();
+                
+                // Convert to volume coordinates
+                let px = vx / spacing[0];
+                let py = vy / spacing[1];
+                let pz = vz / spacing[2];
+                
+                // Interpolate normal
+                let inx = bar[0] * n0[0].into() + bar[1] * n1[0].into() + bar[2] * n2[0].into();
+                let iny = bar[0] * n0[1].into() + bar[1] * n1[1].into() + bar[2] * n2[1].into();
+                let inz = bar[0] * n0[2].into() + bar[1] * n1[2].into() + bar[2] * n2[2].into();
+                
+                // Normalize
+                let inn = (inx * inx + iny * iny + inz * inz).sqrt();
+                let inx = if inn > 1e-10 { inx / inn } else { 0.0 };
+                let iny = if inn > 1e-10 { iny / inn } else { 0.0 };
+                let inz = if inn > 1e-10 { inz / inn } else { 0.0 };
+                
+                // Sample volume data at this position
+                let volume_val = trilinear_interpolate_internal(volume, px, py, pz);
+                
+                // Apply window/level
+                let wl = window_level as f64;
+                let ww = window_width as f64;
+                let min_val = wl - ww / 2.0;
+                let max_val = wl + ww / 2.0;
+                
+                let gv = if volume_val.into() <= min_val {
+                    0.0
+                } else if volume_val.into() >= max_val {
+                    255.0
+                } else {
+                    ((volume_val.into() - min_val) / ww + 0.5) * 255.0
+                };
+                
+                let gv_idx = (gv as usize).min(255);
+                
+                // Apply color from CLUT
+                texture_image[[y, x, 0]] = clut[[gv_idx, 0]];
+                texture_image[[y, x, 1]] = clut[[gv_idx, 1]];
+                texture_image[[y, x, 2]] = clut[[gv_idx, 2]];
+                
+                // Calculate gradient for texture normals (simplified)
+                let h = 1.0;
+                let gx1 = trilinear_interpolate_internal(volume, px - h, py, pz);
+                let gx2 = trilinear_interpolate_internal(volume, px + h, py, pz);
+                let gy1 = trilinear_interpolate_internal(volume, px, py - h, pz);
+                let gy2 = trilinear_interpolate_internal(volume, px, py + h, pz);
+                let gz1 = trilinear_interpolate_internal(volume, px, py, pz - h);
+                let gz2 = trilinear_interpolate_internal(volume, px, py, pz + h);
+                
+                let tnx = (gx2.into() - gx1.into()) / (2.0 * h);
+                let tny = (gy2.into() - gy1.into()) / (2.0 * h);
+                let tnz = (gz2.into() - gz1.into()) / (2.0 * h);
+                
+                let tnn = (tnx * tnx + tny * tny + tnz * tnz).sqrt();
+                
+                if tnn > 1e-10 {
+                    texture_normals[[y, x, 0]] = (((tnx / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 1]] = (((tny / tnn) + 1.0) * 127.5) as u8;
+                    texture_normals[[y, x, 2]] = (((tnz / tnn) + 1.0) * 127.5) as u8;
+                }
+            }
+        }
+    }
+    
+    (tcoords, texture_image, texture_normals)
+}

--- a/invesalius_rs/src/texture_py.rs
+++ b/invesalius_rs/src/texture_py.rs
@@ -26,6 +26,7 @@ use crate::types::{FaceArray, ImageTypes3, VertexArray};
 /// * window_width - Window width for visualization
 /// * window_level - Window level for visualization
 /// * clut - Color lookup table (256 x 3) - uint8
+/// * opacity_curve - VR opacity transfer function (Nx2, col0=HU, col1=opacity) - float64
 /// * texture_dim - Texture atlas dimension (default 5000)
 ///
 /// Returns tuple of (tcoords, texture_image, texture_normals)
@@ -43,6 +44,7 @@ pub fn generate_surface_texture(
     window_width: i32,
     window_level: i32,
     clut: numpy::PyReadonlyArray2<'_, u8>,
+    opacity_curve: numpy::PyReadonlyArray2<'_, f64>,
     texture_dim: usize,
 ) -> PyResult<Py<pyo3::PyAny>> {
     let spacing_arr = spacing.as_array();
@@ -68,6 +70,7 @@ pub fn generate_surface_texture(
                     window_width,
                     window_level,
                     clut.as_array().view(),
+                    opacity_curve.as_array().view(),
                     texture_dim,
                 );
 

--- a/invesalius_rs/src/texture_py.rs
+++ b/invesalius_rs/src/texture_py.rs
@@ -1,0 +1,85 @@
+// Python bindings for surface texture generation
+// Provides Python-accessible functions for texture generation
+
+use numpy::ToPyArray;
+use pyo3::prelude::*;
+
+use crate::texture::generate_surface_texture_internal;
+use crate::types::{VertexArray, FaceArray, ImageTypes3};
+
+/// Generate surface texture from mesh and volume data
+///
+/// This function creates a texture atlas from a 3D mesh by:
+/// 1. Laying out all triangles in a 2D grid
+/// 2. Generating UV coordinates for each triangle
+/// 3. Sampling volume data at each UV position
+/// 4. Applying window/level and color lookup table
+///
+/// Arguments:
+/// * vertices - Mesh vertices (N x 3) - float64
+/// * normals - Vertex normals (N x 3) - float64
+/// * faces - Face indices (M x 3) - int32
+/// * volume - 3D volume data - int16
+/// * spacing - Volume spacing (3 elements) - float64
+/// * window_width - Window width for visualization
+/// * window_level - Window level for visualization
+/// * clut - Color lookup table (256 x 3) - uint8
+/// * texture_dim - Texture atlas dimension (default 5000)
+///
+/// Returns tuple of (tcoords, texture_image, texture_normals)
+/// - tcoords: float64 array (M, 6)
+/// - texture_image: uint8 array (dim, dim, 3)
+/// - texture_normals: uint8 array (dim, dim, 3)
+#[pyfunction]
+pub fn generate_surface_texture(
+    py: Python<'_>,
+    vertices: VertexArray<'_>,
+    normals: VertexArray<'_>,
+    faces: FaceArray<'_>,
+    volume: ImageTypes3<'_>,
+    spacing: numpy::PyReadonlyArray1<'_, f64>,
+    window_width: i32,
+    window_level: i32,
+    clut: numpy::PyReadonlyArray2<'_, u8>,
+    texture_dim: usize,
+) -> PyResult<Py<pyo3::PyAny>> {
+    
+    let spacing_arr = spacing.as_array();
+    let spacing_slice = [spacing_arr[0], spacing_arr[1], spacing_arr[2]];
+    
+    // Handle different input types - only support the main types used by Cython
+    match (vertices, normals, faces, volume, clut) {
+        (
+            VertexArray::F64(vertices),
+            VertexArray::F64(normals),
+            FaceArray::I32(faces),
+            ImageTypes3::I16(volume),
+            clut,
+        ) => {
+            // Call with explicit type parameters: <f64, i32, i16>
+            let (tcoords, texture_image, texture_normals) = generate_surface_texture_internal::<f64, i32, i16>(
+                vertices.as_array().view(),
+                normals.as_array().view(),
+                faces.as_array().view(),
+                volume.as_array().view(),
+                &spacing_slice,
+                window_width,
+                window_level,
+                clut.as_array().view(),
+                texture_dim,
+            );
+            
+            // Convert each array to Python using to_pyarray, then to PyObject
+            let tcoords_py: Py<pyo3::PyAny> = tcoords.to_pyarray(py).into();
+            let texture_image_py: Py<pyo3::PyAny> = texture_image.to_pyarray(py).into();
+            let texture_normals_py: Py<pyo3::PyAny> = texture_normals.to_pyarray(py).into();
+            
+            // Return as tuple
+            let result = pyo3::types::PyTuple::new(py, &[tcoords_py, texture_image_py, texture_normals_py])?;
+            Ok(result.into())
+        }
+        _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Unsupported input types. Use: float64 vertices/normals, int32 faces, int16 volume"
+        ))
+    }
+}

--- a/invesalius_rs/src/texture_py.rs
+++ b/invesalius_rs/src/texture_py.rs
@@ -5,7 +5,9 @@ use numpy::ToPyArray;
 use pyo3::prelude::*;
 
 use crate::texture::generate_surface_texture_internal;
-use crate::types::{VertexArray, FaceArray, ImageTypes3};
+use crate::texture::generate_tcoords_hf_internal;
+use crate::texture::generate_tcoords_internal;
+use crate::types::{FaceArray, ImageTypes3, VertexArray};
 
 /// Generate surface texture from mesh and volume data
 ///
@@ -43,10 +45,9 @@ pub fn generate_surface_texture(
     clut: numpy::PyReadonlyArray2<'_, u8>,
     texture_dim: usize,
 ) -> PyResult<Py<pyo3::PyAny>> {
-    
     let spacing_arr = spacing.as_array();
     let spacing_slice = [spacing_arr[0], spacing_arr[1], spacing_arr[2]];
-    
+
     // Handle different input types - only support the main types used by Cython
     match (vertices, normals, faces, volume, clut) {
         (
@@ -57,29 +58,158 @@ pub fn generate_surface_texture(
             clut,
         ) => {
             // Call with explicit type parameters: <f64, i32, i16>
-            let (tcoords, texture_image, texture_normals) = generate_surface_texture_internal::<f64, i32, i16>(
-                vertices.as_array().view(),
-                normals.as_array().view(),
-                faces.as_array().view(),
-                volume.as_array().view(),
-                &spacing_slice,
-                window_width,
-                window_level,
-                clut.as_array().view(),
-                texture_dim,
-            );
-            
+            let (tcoords, texture_image, texture_normals) =
+                generate_surface_texture_internal::<f64, i32, i16>(
+                    vertices.as_array().view(),
+                    normals.as_array().view(),
+                    faces.as_array().view(),
+                    volume.as_array().view(),
+                    &spacing_slice,
+                    window_width,
+                    window_level,
+                    clut.as_array().view(),
+                    texture_dim,
+                );
+
             // Convert each array to Python using to_pyarray, then to PyObject
             let tcoords_py: Py<pyo3::PyAny> = tcoords.to_pyarray(py).into();
             let texture_image_py: Py<pyo3::PyAny> = texture_image.to_pyarray(py).into();
             let texture_normals_py: Py<pyo3::PyAny> = texture_normals.to_pyarray(py).into();
-            
+
             // Return as tuple
-            let result = pyo3::types::PyTuple::new(py, &[tcoords_py, texture_image_py, texture_normals_py])?;
+            let result =
+                pyo3::types::PyTuple::new(py, &[tcoords_py, texture_image_py, texture_normals_py])?;
             Ok(result.into())
         }
         _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-            "Unsupported input types. Use: float64 vertices/normals, int32 faces, int16 volume"
-        ))
+            "Unsupported input types. Use: float64 vertices/normals, int32 faces, int16 volume",
+        )),
+    }
+}
+
+/// Generate UV coordinates without color mapping
+///
+/// This is a simpler version that generates texture coordinates plus raw volume
+/// data and gradient normals, without applying window/level or color lookup table.
+///
+/// Arguments:
+/// * vertices - Mesh vertices (N x 3) - float64
+/// * faces - Face indices (M x 3) - int32
+/// * volume - 3D volume data - int16
+/// * spacing - Volume spacing (3 elements) - float64
+/// * texture_dim - Texture atlas dimension (default 5000)
+///
+/// Returns tuple of (tcoords, texture_image, texture_normals)
+/// - tcoords: float64 array (M, 6)
+/// - texture_image: int16 array (dim, dim)
+/// - texture_normals: uint8 array (dim, dim, 3)
+#[pyfunction]
+pub fn generate_tcoords(
+    py: Python<'_>,
+    vertices: VertexArray<'_>,
+    faces: FaceArray<'_>,
+    volume: ImageTypes3<'_>,
+    spacing: numpy::PyReadonlyArray1<'_, f64>,
+    texture_dim: usize,
+) -> PyResult<Py<pyo3::PyAny>> {
+    let spacing_arr = spacing.as_array();
+    let spacing_slice = [spacing_arr[0], spacing_arr[1], spacing_arr[2]];
+
+    match (vertices, faces, volume) {
+        (VertexArray::F64(vertices), FaceArray::I32(faces), ImageTypes3::I16(volume)) => {
+            let (tcoords, texture_image, texture_normals) =
+                generate_tcoords_internal::<f64, i32, i16>(
+                    vertices.as_array().view(),
+                    faces.as_array().view(),
+                    volume.as_array().view(),
+                    &spacing_slice,
+                    texture_dim,
+                );
+
+            let tcoords_py: Py<pyo3::PyAny> = tcoords.to_pyarray(py).into();
+            let texture_image_py: Py<pyo3::PyAny> = texture_image.to_pyarray(py).into();
+            let texture_normals_py: Py<pyo3::PyAny> = texture_normals.to_pyarray(py).into();
+
+            let result =
+                pyo3::types::PyTuple::new(py, &[tcoords_py, texture_image_py, texture_normals_py])?;
+            Ok(result.into())
+        }
+        _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Unsupported input types. Use: float64 vertices, int32 faces, int16 volume",
+        )),
+    }
+}
+
+/// Generate high-frequency surface texture with multi-slice raycasting
+///
+/// This generates texture by shooting rays into the volume along surface normals,
+/// collecting samples from multiple slices for enhanced edge/detail detection.
+///
+/// Arguments:
+/// * vertices - Mesh vertices (N x 3) - float64
+/// * normals - Vertex normals (N x 3) - float64
+/// * faces - Face indices (M x 3) - int32
+/// * volume - 3D volume data - int16
+/// * spacing - Volume spacing (3 elements) - float64
+/// * window_width - Window width for visualization
+/// * window_level - Window level for visualization
+/// * clut - Color lookup table (256 x 3) - uint8
+/// * texture_dim - Texture atlas dimension (default 5000)
+/// * n_slices - Number of slices for raycasting (default 5)
+///
+/// Returns tuple of (tcoords, texture_image, texture_normals)
+/// - tcoords: float64 array (M, 6)
+/// - texture_image: int16 array (n_slices, dim, dim)
+/// - texture_normals: uint8 array (dim, dim, 3)
+#[pyfunction]
+pub fn generate_tcoords_hf(
+    py: Python<'_>,
+    vertices: VertexArray<'_>,
+    normals: VertexArray<'_>,
+    faces: FaceArray<'_>,
+    volume: ImageTypes3<'_>,
+    spacing: numpy::PyReadonlyArray1<'_, f64>,
+    window_width: i32,
+    window_level: i32,
+    clut: numpy::PyReadonlyArray2<'_, u8>,
+    texture_dim: usize,
+    n_slices: usize,
+) -> PyResult<Py<pyo3::PyAny>> {
+    let spacing_arr = spacing.as_array();
+    let spacing_slice = [spacing_arr[0], spacing_arr[1], spacing_arr[2]];
+
+    match (vertices, normals, faces, volume, clut) {
+        (
+            VertexArray::F64(vertices),
+            VertexArray::F64(normals),
+            FaceArray::I32(faces),
+            ImageTypes3::I16(volume),
+            clut,
+        ) => {
+            let (tcoords, texture_image, texture_normals) =
+                generate_tcoords_hf_internal::<f64, i32, i16>(
+                    vertices.as_array().view(),
+                    normals.as_array().view(),
+                    faces.as_array().view(),
+                    volume.as_array().view(),
+                    &spacing_slice,
+                    window_width,
+                    window_level,
+                    clut.as_array().view(),
+                    texture_dim,
+                    n_slices,
+                );
+
+            let tcoords_py: Py<pyo3::PyAny> = tcoords.to_pyarray(py).into();
+            let texture_image_py: Py<pyo3::PyAny> = texture_image.to_pyarray(py).into();
+            let texture_normals_py: Py<pyo3::PyAny> = texture_normals.to_pyarray(py).into();
+
+            let result =
+                pyo3::types::PyTuple::new(py, &[tcoords_py, texture_image_py, texture_normals_py])?;
+            Ok(result.into())
+        }
+        _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Unsupported input types. Use: float64 vertices/normals, int32 faces, int16 volume",
+        )),
     }
 }


### PR DESCRIPTION
## Summary
Adds the ability to export a textured 3D surface mesh directly from InVesalius's volume rendering view. Users can now export their CT/MRI surface as a production-quality textured OBJ or VRML file with a single click from the Export tab.
## Implementation
InVesalius already provides beautiful volume rendering with full WW/WL, CLUT, and projection type controls. However, users could not export this as a textured 3D mesh for use in external tools like Blender, MeshLab, Unity, or for 3D printing with colors. 

This feature bridges that gap by physically baking the volume rendering appearance onto the surface mesh and exporting it as a standardized textured 3D file format that natively retains these color maps.

## How It Works
1. User loads a DICOM dataset and creates a 3D surface.
2. User enables Volume Rendering and adjusts settings (WW/WL, CLUT, projection type) as desired.
3. User navigates to the Export tab.
4. User clicks the new hyperlink: "Export 3D surface from volume rendering...".
5. User picks a save location and selects a format (Wavefront OBJ or VRML).
6. A responsive Progress Dialog appears while the high-resolution texture is generated asynchronously.
7. Output files are compiled and saved gracefully:
    *   **OBJ Format:** `mesh.obj` + `mesh.mtl` + `mesh_texture.png`
    *   **VRML Format:** `mesh.vrml` + `mesh_texture.png`

## Technical Implementation

### Algorithm
Based on the `medical_triangle_texture` algorithm by Thiago Franco de Moraes (2016):
*   For each triangle in the surface mesh, the algorithm natively shoots rays along the surface normals INTO the dense CT/MRI volume.
*   It dynamically samples HU values utilizing sub-voxel trilinear interpolation.
*   Applies the active WW/WL + CLUT scalar mapping to accumulate genuine RGB colors using Front-to-Back opacity accumulation.
*   Packs all distinct triangle mappings into a massive single 2D atlas image (`5000x5000` default) and assigns sub-pixel UV coordinates sequentially to the matching mesh faces.

> **Reference:**
> Moraes et al. (2016). *Isosurface rendering of medical images improved by automatic texture mapping.* Computer Methods in Biomechanics and Biomedical Engineering: Imaging & Visualization. [https://doi.org/10.1080/21681163.2016.1254069](https://doi.org/10.1080/21681163.2016.1254069)

### Rust Engine Optimization
The core texture generation fully converted legacy Python/Cython wrappers and ports processing heavily into the native `invesalius_rs` Rust module suite via `_native.generate_surface_texture()`.

### Data Flow
1. `Project().surface_dict` → mesh (vertices, normals, faces)
2. `Slice().matrix` → CT/MRI volume (`int16` Z,Y,X)
3. `Slice().spacing` → voxel spacing (mm)
4. `project.raycasting_preset` → dynamically grabs WW/WL + 16-bit preset CLUT dictionaries
                      ↓
   `_native.generate_surface_texture()`
                      ↓
   Generates RGB high-res texture atlas (`.PNG`) + Barycentric UV maps
                     ↓
   Strict syntax construction to portable `OBJ` / `MTL` or `VRML` standards 

## Files Changed

### New Files
*   `invesalius/data/surface_texture.py`
    *   Core module for surface compilation logic
    *   `export_textured_surface()` bridging function
    *   Strict syntax standard builders for OBJ/MTL and VRML outputs
*   `invesalius/gui/dialog_export_texture.py`
    *   Adds `ExportTextureProgressDialog` keeping wxPython thread-safe `wx.CallAfter` GUI execution while Rust calculates underneath without frame-locking.

### Modified Files
*   `invesalius/gui/task_exporter.py`
    *   Injected `"Export 3D surface from volume rendering..."` button/link.
    *   Added active `OnLinkExportTexturedSurface` router and file-dialog bindings ensuring users simply navigate the native OS Save dialog.
*   Rust Backend (`invesalius_rs/src/*`): Ported core dependencies directly into the rust structure including updating bindings via `texture_py.rs`.

## Key Design Decisions
1.  **Presets:** Utilizes exact settings from the actively viewed volume plane (`Volume()`) and dynamically scrapes `.plist` definitions for embedded 16-bit CLUT tables rather than demanding separate user configuration. "What you see is exactly what exports."
2.  **Volumetric Spatial Alignment:** Added absolute normalization vectors shifting mesh coordinates by `mesh_min - [10, 10, 10]`. This elegantly reverses the Y-axis flips inherent in VTK image data imports, ensuring volumetric arrays are never raycasted onto empty grid spaces.
3.  **Strict 3D Viewer Compliance:** 
    *   **OBJ**: Sanitizes whitespace inside saved `.png` files replacing them with underscores to prevent parsing failures in legacy MTL managers like `MeshLab`.
    *   **VRML**: Extensively formats V2.0 structural arrays ensuring commas are strictly internal and all `MF-Values` are perfectly enclosed inside `[ ]` brackets, bypassing primitive OutOfMemory crashes discovered in native 32-bit viewers like `FreeWRL`.
4.  **No Cython Dependencies:** Pure Rust execution is robust.

## Testing Guidelines

**Build Instructions:**
Since this feature relies on entirely new Rust backend routines for the rendering algorithms, you must first compile the native module before testing the workflow:
```bash
cd invesalius_rs
maturin develop --release
```

**Manual Execution Steps or (see video for execution)**
1.  Launch application via `python app.py`.
2.  Load standard DICOM 
3.  Create an explicit 3D surface from a mask.
4.  Activate Volume Rendering and apply distinctive visual colorations (e.g. `Bone + Skin` preset).
5.  Navigate directly to the active `Export` tab on the left-side workflow.
6.  Click `"Export 3D surface from volume rendering..."` and assign a test save location favoring `OBJ` format.
7.  Verify progress bar fills naturally without blocking the main GUI frame.
8.  Observe output directory contains standard files (`.obj`, `.mtl`, `.png` atlas).
9.  Open `mesh.obj` inside **MeshLab / Blender** verifying dynamic color patterns fully mapped uniformly across mesh triangles.
10. Repeat workflow but explicitly define `VRML` output format. Open rendered VRML inside strict clients like FreeWRL to ensure valid parsing structure parsing completion.

https://github.com/user-attachments/assets/42d05618-6df6-454d-bef5-0cb42c0f68d3



## Resources & Related
*   **Discussion Thread**: #1255
*   **Core Implementation Source**: [medical_triangle_texture GitHub Repo](https://github.com/tfmoraes/medical_triangle_texture)
*   **GSoC 2026 Assignment Focus**: Surface Texture Export


Note: Surface texture raytracing algorithms are  heavily parallel-dependent . Average executions will scale natively with defined `texture_dim` grid sizes ( computationally reasonable `5000x5000`). If no custom volumetric layout is assigned initially, execution strictly falls back implicitly prioritizing conventional generic `HotMetal` mappings.