### PR TITLE
Fix mouse wheel zero division in DICOM preview panel

### DIFF
--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -701,7 +701,7 @@ class DicomPreviewSlice(wx.Panel):
         self._display_previews()
 
     def OnWheel(self, evt):
-        d =  evt.GetWheelRotation()//evt.GetWheelDelta()
+        d = evt.GetWheelRotation() // evt.GetWheelDelta()
         self.scroll.SetThumbPosition(self.scroll.GetThumbPosition() - d)
         self.OnScroll()
 


### PR DESCRIPTION
This PR fixes a mouse wheel handling issue in the DICOM preview panel.

Problem:
- The wheel step calculation should use `WheelRotation / WheelDelta`, not `WheelDelta / WheelRotation`.
- Scrolling could trigger a `ZeroDivisionError` when `evt.GetWheelRotation()` was 0.

Changes:
- Reversed the calculation order in the wheel step logic.

Result:
- Prevents crashes when scrolling in the preview panel.

<img width="1017" height="732" alt="截圖 2026-03-25 下午5 09 06" src="https://github.com/user-attachments/assets/4ec1e948-82fb-457a-8d8a-c7de1c34b5dc" />
