### PR TITLE
Fix maturin strip conflict on Windows source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ python-source = "."
 # Python packages to include
 python-packages = ["invesalius", "invesalius_rs"]
 # Strip the library for minimum file size
-strip = true
+strip = false
 
 [tool.uv]
 cache-keys = [{ file = "pyproject.toml" }, { file = "invesalius_rs/src/**/*.rs" }, { file = "invesalius_rs/Cargo.toml" }, { file = "invesalius_rs/Cargo.lock" }]


### PR DESCRIPTION
## Summary
Fixes a Windows build failure caused by a conflict between `--strip` and debug info in maturin.

## Problem
Running:
maturin develop --skip-install

fails with:
--include-debuginfo cannot be used with --strip

This prevents building `invesalius_rs._native`, which blocks application startup.

## Root Cause
`pyproject.toml` sets:
strip = true

which conflicts with maturin's default debug build settings.

## Fix
Set:
strip = false

## Result
- Rust extension builds successfully
- `import invesalius_rs._native` works
- Application launches with `python app.py`