### PR TITLE
fix: defer surface list repopulation after deletion

### DIFF
--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1745,7 +1745,9 @@ class SurfacesListCtrlPanel(InvListCtrl):
 
         if selected_items:
             Publisher.sendMessage("Remove surfaces", surface_indexes=selected_items)
-            Publisher.sendMessage("Repopulate surfaces")
+            # Defer rebuild to avoid destroying list controls in the same
+            # native event cycle that triggered the deletion (macOS crash).
+            wx.CallAfter(Publisher.sendMessage, "Repopulate surfaces")
         else:
             dlg.SurfaceSelectionRequiredForRemoval()
 


### PR DESCRIPTION
Fixes #1312 
When deleting a surface, the code was immediately rebuilding the surfaces list in the same event cycle. On macOS (wx), that can destroy UI widgets while the right-click event is still being processed, which can cause a segmentation fault.

So I changed it to defer the list rebuild with wx.CallAfter(...), so repopulation happens right after the current event finishes.
No behavior change for users—just safer timing to prevent the crash.