### PR TITLE
Add test coverage for PLY export functionality

### DIFF
--- a/tests/test_ply_export.py
+++ b/tests/test_ply_export.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+import wx
+from vtkmodules.vtkIOPLY import vtkPLYReader
+
+import invesalius.constants as const
+from invesalius.data.surface import SurfaceManager
+from tests.test_stl_export import surface_manager_with_surfaces, clean_project
+
+
+@pytest.fixture(scope="module", autouse=True)
+def wx_app():
+    app = wx.GetApp() or wx.App(False)
+    yield app
+
+
+def test_export_surface_to_ply(surface_manager_with_surfaces, tmp_path: Path) -> None:
+    surface_manager, _ = surface_manager_with_surfaces
+
+    filename = tmp_path / "exported_surface.ply"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_PLY, convert_to_world=False)
+
+    assert os.path.exists(filename), f"PLY file not created: {filename}"
+    assert os.path.getsize(filename) > 0, f"PLY file is empty: {filename}"
+
+    reader = vtkPLYReader()
+    reader.SetFileName(str(filename))
+    reader.Update()
+    mesh = reader.GetOutput()
+
+    assert mesh.GetNumberOfPoints() > 0, "Exported mesh has no points"
+    assert mesh.GetNumberOfCells() > 0, "Exported mesh has no cells"
+
+
+def test_export_surface_empty_project(clean_project, tmp_path: Path) -> None:
+    surface_manager = SurfaceManager()
+
+    filename = tmp_path / "empty_export.ply"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_PLY, convert_to_world=False)
+
+    assert not os.path.exists(filename), "File should not be created when no surfaces are visible"
+
+
+def test_export_surface_multiple_visible(surface_manager_with_surfaces, tmp_path: Path) -> None:
+    surface_manager, project = surface_manager_with_surfaces
+
+    for index in project.surface_dict:
+        project.surface_dict[index].is_shown = True
+
+    filename = tmp_path / "multiple_surfaces.ply"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_PLY, convert_to_world=False)
+
+    assert os.path.exists(filename), f"PLY file not created: {filename}"
+    assert os.path.getsize(filename) > 0, f"PLY file is empty: {filename}"
+
+    reader = vtkPLYReader()
+    reader.SetFileName(str(filename))
+    reader.Update()
+    mesh = reader.GetOutput()
+
+    assert mesh.GetNumberOfPoints() > 0, "Exported mesh has no points"
+    assert mesh.GetNumberOfCells() > 0, "Exported mesh has no cells"


### PR DESCRIPTION
This PR adds test coverage for PLY export functionality, following the existing STL export test structure.

While exploring the export pipeline more deeply for the 3MF project, I noticed that test coverage currently exists only for STL, while other supported formats like PLY were not covered. Based on this, I added tests for the PLY export path.

It includes:
- Exporting visible surfaces to PLY
- Handling empty project cases
- Exporting multiple visible surfaces
- Verifying exported files using vtkPLYReader

A minimal wx.App fixture is included to ensure tests run correctly in a headless environment.

This improves reliability of the export pipeline and ensures consistency across supported formats.