### PR TITLE
fix: Handle None matrix_tracker_to_robot in Robot.SaveConfig and InitializeRobot (#1281)

### DIFF
--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -58,8 +58,7 @@ class Robot(metaclass=Singleton):
         self.objective = RobotObjective.NONE
         self.target = None
 
-        # If tracker already has fiducials set, send them to the robot; this can happen, e.g.,
-        # when a pre-existing state is loaded at start-up.
+        # If tracker already has fiducials set, send them to the robot; this can happen, e.g.,when a pre-existing state is loaded at start-up.
         if self.tracker.AreTrackerFiducialsSet():
             self.TrackerFiducialsSet()
 
@@ -92,7 +91,11 @@ class Robot(metaclass=Singleton):
             state = {
                 "robot_ip": self.robot_ip,
                 "robot_ip_options": self.robot_ip_options,
-                "tracker_to_robot": self.matrix_tracker_to_robot.tolist(),
+                "tracker_to_robot": (
+                    self.matrix_tracker_to_robot.tolist()
+                    if self.matrix_tracker_to_robot is not None
+                    else None
+                ),
             }
             if self.coil_name is not None:
                 state["robot_coil"] = self.coil_name
@@ -182,6 +185,8 @@ class Robot(metaclass=Singleton):
         print("Connected to robot")
 
     def InitializeRobot(self):
+        if self.matrix_tracker_to_robot is None:
+            return
         Publisher.sendMessage(
             "Neuronavigation to Robot: Set robot transformation matrix",
             data=self.matrix_tracker_to_robot.tolist(),


### PR DESCRIPTION
**probem:**
As mentioned in the issue #1281 , currently Invesalius's Robot.py calling `SaveConfig()` or `InitializeRobot()` before robot calibration crashes with `AttributeError: 'NoneType' has no attribute 'tolist'` because `matrix_tracker_to_robot `is initialized as `None` and both methods call` .tolist() `on it unconditionally.

we can reproduce the crash using this script: [Reproduce #1281 script](https://gist.github.com/MadhankumarAI/388ec0f117b4346d7e52ff7ae8672829)

**fix:**
SaveConfig():I have added a `None `check before calling `.tolist()`, this saves `None` to session config if uncalibrated
InitializeRobot():this will now return early if `matrix_tracker_to_robot` is None