### PR TITLE
Fix(#1324): Disable SSAO during 3D measurements to prevent picking interference

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -365,6 +365,7 @@ class Viewer(wx.Panel):
         # SSAO state tracking
         self.ssao_enabled = False
         self.ssao_pass = None
+        self.ssao_before_measurement = False  # Track SSAO state before entering measurement mode
 
         # self.renderers = (self.target_guide_renderer, ren, canvas_renderer)
 
@@ -2677,6 +2678,26 @@ class Viewer(wx.Panel):
         imsave("/tmp/polygon.png", arr)
 
     def SetInteractorStyle(self, state):
+        # Check if we're entering or exiting a measurement state
+        measurement_states = {
+            const.STATE_MEASURE_DISTANCE,
+            const.STATE_MEASURE_ANGLE,
+            const.STATE_MEASURE_CURVED_LINEAR,
+            const.STATE_MEASURE_ANNOTATION,
+        }
+
+        entering_measurement = state in measurement_states
+        exiting_measurement = (
+            hasattr(self, "state")
+            and self.state in measurement_states
+            and state not in measurement_states
+        )
+
+        # Temporarily disable SSAO when entering measurement mode
+        if entering_measurement and self.ssao_enabled:
+            self.ssao_before_measurement = True
+            self._DisableSSAO()
+
         cleanup = getattr(self.style, "CleanUp", None)
         if cleanup:
             self.style.CleanUp()
@@ -2696,6 +2717,11 @@ class Viewer(wx.Panel):
 
         self.state = state
         self._update_fps_visibility()
+
+        # Re-enable SSAO when exiting measurement mode (if it was enabled before)
+        if exiting_measurement and self.ssao_before_measurement:
+            self.ssao_before_measurement = False
+            self._EnableSSAO()
 
     def enable_style(self, style):
         if styles.Styles.has_style(style):
@@ -3168,6 +3194,18 @@ class Viewer(wx.Panel):
 
     def _EnableSSAO(self):
         if self.ssao_enabled:
+            return
+
+        # Don't enable SSAO during measurement mode (it interferes with picking)
+        measurement_states = {
+            const.STATE_MEASURE_DISTANCE,
+            const.STATE_MEASURE_ANGLE,
+            const.STATE_MEASURE_CURVED_LINEAR,
+            const.STATE_MEASURE_ANNOTATION,
+        }
+        if hasattr(self, "state") and self.state in measurement_states:
+            # Remember that user wants SSAO enabled, so it will be restored after measurement
+            self.ssao_before_measurement = True
             return
 
         # SSAO should only be applied to surfaces, not volume rendering

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1327,7 +1327,9 @@ class SurfaceButtonControlPanel(wx.Panel):
         BMP_DUPLICATE = wx.Bitmap(
             os.path.join(inv_paths.ICON_DIR, "data_duplicate.png"), wx.BITMAP_TYPE_PNG
         )
-        BMP_OPEN = wx.Bitmap(os.path.join(inv_paths.ICON_DIR, "surface_import_original_min.png"), wx.BITMAP_TYPE_PNG)
+        BMP_OPEN = wx.Bitmap(
+            os.path.join(inv_paths.ICON_DIR, "surface_import_original_min.png"), wx.BITMAP_TYPE_PNG
+        )
 
         BMP_EXPORT = wx.Bitmap(
             os.path.join(inv_paths.ICON_DIR, "surface_export_original_min.png"), wx.BITMAP_TYPE_PNG


### PR DESCRIPTION
### Fix: SSAO breaks 3D measurements & annotations

#### Problem  
Enabling SSAO prevents 3D measurements (linear, angular, curved) and annotations from working due to failed picking with `vtkPropPicker`.

#### Root Cause  
`vtkSSAOPass` modifies the rendering pipeline, interfering with surface picking used by measurement interactor styles.

#### Solution  
Automatically disable SSAO when entering measurement mode and restore its previous state on exit.

#### Implementation  
- Added `ssao_before_measurement` to track SSAO state  
- Updated `SetInteractorStyle()` to manage measurement mode transitions  
- Guarded `_EnableSSAO()` to prevent enabling SSAO during measurement  
- Deferred user-triggered SSAO enable until exit  

#### Affected Features  
- Linear, Angular, Curved measurements  
- Annotations  

#### Files Modified  
- `viewer_volume.py`  
- `data_notebook.py` (minor formatting)

#### Result  
- Reliable picking with SSAO enabled  
- Automatic SSAO handling (no user intervention)  
- No breaking changes  

#### Testing  
- Verified all measurement tools work correctly with SSAO toggling automatically  

Fixes #1324 