### PR TITLE
Fix MRI 3D camera orientation 

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -111,11 +111,12 @@ from invesalius.pubsub import pub as Publisher
 if sys.platform == "win32":
     try:
         import win32api
-
         _has_win32api = True
     except ImportError:
+        win32api = None
         _has_win32api = False
 else:
+    win32api = None
     _has_win32api = False
 
 PROP_MEASURE = 0.8
@@ -2955,7 +2956,12 @@ class Viewer(wx.Panel):
         self.surface_added = True
 
         if not self.view_angle:
-            self.SetViewAngle(const.VOL_FRONT)
+            proj = prj.Project()
+            modality = str(getattr(proj, "modality", "CT")).upper()
+            if modality in ["MRI", "MR"]:
+                self.SetViewAngle(const.VOL_BACK)
+            else:
+                self.SetViewAngle(const.VOL_FRONT)
             self.view_angle = 1
         else:
             ren.ResetCamera()
@@ -3022,8 +3028,14 @@ class Viewer(wx.Panel):
 
         self.ren.SetBackground(colour)
 
-        if not (self.view_angle):
-            self.SetViewAngle(const.VOL_FRONT)
+        if not self.view_angle:
+            proj = prj.Project()
+            modality = str(getattr(proj, "modality", "CT")).upper()
+            if modality in ["MRI", "MR"]:
+                self.SetViewAngle(const.VOL_BACK)
+            else:
+                self.SetViewAngle(const.VOL_FRONT)
+            self.view_angle = 1
         else:
             self.ren.ResetCamera()
             self.ren.ResetCameraClippingRange()
@@ -3057,7 +3069,12 @@ class Viewer(wx.Panel):
 
         if flag:
             if not self.view_angle:
-                self.SetViewAngle(const.VOL_FRONT)
+                proj = prj.Project()
+                modality = str(getattr(proj, "modality", "CT")).upper()
+                if modality in ["MRI", "MR"]:
+                    self.SetViewAngle(const.VOL_BACK)
+                else:
+                    self.SetViewAngle(const.VOL_FRONT)
                 self.view_angle = 1
 
             # Match the parallel projection used by AddSurface/LoadVolume so that

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -111,6 +111,7 @@ from invesalius.pubsub import pub as Publisher
 if sys.platform == "win32":
     try:
         import win32api
+
         _has_win32api = True
     except ImportError:
         win32api = None


### PR DESCRIPTION
## fixes: #794

The 3D viewer in InVesalius defaulted to showing the back of the head for MRI datasets, which disrupted the user workflow and required manual re-orientation. Furthermore, the application suffered from cross-platform static analysis errors regarding win32api on macOS systems and lacked robust defensive logic for modality detection, creating potential stability issues during project initialisation.

### Changes
Conditional Camera Position: Implemented an automated check in AddSurface, LoadVolume, and load_mask_preview to detect MRI/MR datasets and set the initial view angle to VOL_BACK (Face View).
Static Analysis Fix: Ensured win32api is always defined as None on non-Windows platforms, resolving cross-platform IDE warnings.
Robustness: Used getattr() for safer modality detection and ensured consistent view_angle state updates to prevent redundant resets.

### Before fix:
<img width="1025" height="746" alt="Screenshot 2026-04-13 at 10 05 48 AM" src="https://github.com/user-attachments/assets/7073126c-f179-4797-8ff2-7be301fd7ad6" />

### After fix:

https://github.com/user-attachments/assets/1b5e940d-a3be-4622-9874-cf57217cf16a

