### PR TITLE
Enhance measurement visualization and synchronization

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -183,7 +183,7 @@ class MeasurementManager:
 
         if m.points:
             x, y, z = m.points[0]
-            
+
             # The 3D surface picker stores points with an inverted Y coordinate relative to the 2D slices.
             # We must map them appropriately depending on the target renderer.
             if m.location == const.SURFACE:
@@ -192,9 +192,11 @@ class MeasurementManager:
             else:
                 cross_y = y
                 vol_y = -y
-                
+
             # Update the position of the cross in slices
-            Publisher.sendMessage("Set cross focal point", position=[x, cross_y, z, None, None, None])
+            Publisher.sendMessage(
+                "Set cross focal point", position=[x, cross_y, z, None, None, None]
+            )
             # Update the pointer in the volume viewer
             Publisher.sendMessage("Update volume viewer pointer", position=[x, vol_y, z])
             Publisher.sendMessage("Update slice viewer")

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -174,6 +174,32 @@ class MeasurementManager:
         if index < 0 or index >= len(self.measures):
             return
         m, mr = self.measures[index]
+
+        # Synchronize visualization with the measurement/annotation
+        if m.location != const.SURFACE:
+            loc_str = map_id_locations.get(m.location)
+            if loc_str:
+                Publisher.sendMessage(("Set scroll position", loc_str), index=m.slice_number)
+
+        if m.points:
+            x, y, z = m.points[0]
+            
+            # The 3D surface picker stores points with an inverted Y coordinate relative to the 2D slices.
+            # We must map them appropriately depending on the target renderer.
+            if m.location == const.SURFACE:
+                cross_y = -y
+                vol_y = y
+            else:
+                cross_y = y
+                vol_y = -y
+                
+            # Update the position of the cross in slices
+            Publisher.sendMessage("Set cross focal point", position=[x, cross_y, z, None, None, None])
+            # Update the pointer in the volume viewer
+            Publisher.sendMessage("Update volume viewer pointer", position=[x, vol_y, z])
+            Publisher.sendMessage("Update slice viewer")
+            Publisher.sendMessage("Render volume viewer")
+
         if m.type == const.ANNOTATION:
             import wx
 

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -165,6 +165,7 @@ class MeasurementManager:
         Publisher.subscribe(self._update_point, "Update measurement point position")
         Publisher.subscribe(self._finalize_measurement, "Finalize measurement")
         Publisher.subscribe(self.OnCloseProject, "Close project data")
+        Publisher.subscribe(self._update_geodesic_measure, "Update geodesic measure value")
 
     def _base_annotation_handler(self, evt):
         pass
@@ -184,6 +185,10 @@ class MeasurementManager:
 
         if m.points:
             x, y, z = m.points[0]
+
+            if m.location == const.SURFACE:
+                # Trigger the cleanly orbiting 3D camera rotation without the positioning sphere
+                Publisher.sendMessage("Focus volume camera", position=[x, y, z])
 
         if m.type == const.ANNOTATION:
             import wx
@@ -574,8 +579,24 @@ class MeasurementManager:
                 Publisher.sendMessage("Redraw canvas")
 
             #  if self.measures:
-            #  self.measures.pop()
             self.current = None
+
+    def _update_geodesic_measure(self, mr):
+        """Asynchronously triggered when the geodesic path computation completes."""
+        for index, (m, m_repr) in enumerate(self.measures):
+            if m_repr == mr:
+                m.value = mr.GetValue()
+                # Safely update GUI with the new geodesic distance
+                Publisher.sendMessage(
+                    "Update measurement info in GUI",
+                    index=m.index,
+                    name=m.name,
+                    colour=m.colour,
+                    location=LOCATION[m.location],
+                    type_=TYPE[m.type],
+                    value=f"{m.value:.3f} mm",
+                )
+                break
 
     def _add_density_measure(self, density_measure):
         m = DensityMeasurement()
@@ -1137,6 +1158,7 @@ class GeodesicMeasure(LinearMeasure):
             if path_actors:
                 Publisher.sendMessage("Add actors " + str(const.SURFACE), actors=path_actors)
 
+            Publisher.sendMessage("Update geodesic measure value", mr=self)
             Publisher.sendMessage("Render volume viewer")
         finally:
             # Always restore cursor, even if computation fails

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -175,7 +175,8 @@ class MeasurementManager:
             return
         m, mr = self.measures[index]
 
-        # Synchronize visualization with the measurement/annotation
+        # Synchronize visualization: only update the slice where this measurement lives.
+        # Do NOT jump other slices — the maintainer wants each slice to stay in its current position.
         if m.location != const.SURFACE:
             loc_str = map_id_locations.get(m.location)
             if loc_str:
@@ -184,23 +185,7 @@ class MeasurementManager:
         if m.points:
             x, y, z = m.points[0]
 
-            # The 3D surface picker stores points with an inverted Y coordinate relative to the 2D slices.
-            # We must map them appropriately depending on the target renderer.
-            if m.location == const.SURFACE:
-                cross_y = -y
-                vol_y = y
-            else:
-                cross_y = y
-                vol_y = -y
 
-            # Update the position of the cross in slices
-            Publisher.sendMessage(
-                "Set cross focal point", position=[x, cross_y, z, None, None, None]
-            )
-            # Update the pointer in the volume viewer
-            Publisher.sendMessage("Update volume viewer pointer", position=[x, vol_y, z])
-            Publisher.sendMessage("Update slice viewer")
-            Publisher.sendMessage("Render volume viewer")
 
         if m.type == const.ANNOTATION:
             import wx

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -185,8 +185,6 @@ class MeasurementManager:
         if m.points:
             x, y, z = m.points[0]
 
-
-
         if m.type == const.ANNOTATION:
             import wx
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -472,6 +472,7 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.OnHideRuler, "Hide rulers on viewers")
         Publisher.subscribe(self.OnRulerVisibilityStatus, "Receive ruler visibility status")
         Publisher.subscribe(self.OnCloseProject, "Close project data")
+        Publisher.subscribe(self.FocusCamera, "Focus volume camera")
 
         Publisher.subscribe(self.RemoveAllActors, "Remove all volume actors")
 
@@ -776,7 +777,7 @@ class Viewer(wx.Panel):
             Publisher.sendMessage("Begin busy cursor")
             if _has_win32api:
                 utils.touch(filename)
-                win_filename = win32api.GetShortPathName(filename)
+                win_filename = win32api.GetShortPathName(filename)  # type: ignore
                 self._export_picture(orientation, win_filename, filetype)
             else:
                 self._export_picture(orientation, filename, filetype)
@@ -1457,6 +1458,37 @@ class Viewer(wx.Panel):
 
         self.pointer_actor.SetPosition(position)
         # Update the render window manually, as it is not updated automatically when not navigating.
+        if not self.nav_status:
+            self.UpdateRender()
+
+    def FocusCamera(self, position):
+        """
+        Orbit the camera around the current focal point (the skull's center)
+        so that the measurement exactly faces the screen, without shifting the skull.
+        """
+        cam = self.ren.GetActiveCamera()
+        
+        center = np.array(cam.GetFocalPoint())
+        old_pos = np.array(cam.GetPosition())
+        target = np.array(position)
+        
+        # Calculate distance from camera to center to maintain zoom level
+        distance = np.linalg.norm(old_pos - center)
+        
+        # Vector from center of the volume pointing outward toward the measurement
+        direction = target - center
+        dir_norm = np.linalg.norm(direction)
+        
+        if dir_norm > 0:
+            direction = direction / dir_norm
+            
+            # Orbit to the new position while staring back at the center
+            new_pos = center + direction * distance
+            
+            cam.SetPosition(new_pos[0], new_pos[1], new_pos[2])
+            cam.SetViewUp(0, 0, 1)
+            self.ren.ResetCameraClippingRange()
+            
         if not self.nav_status:
             self.UpdateRender()
 
@@ -2777,7 +2809,7 @@ class Viewer(wx.Panel):
         ):
             if _has_win32api:
                 utils.touch(filename)
-                win_filename = win32api.GetShortPathName(filename)
+                win_filename = win32api.GetShortPathName(filename)  # type: ignore
                 self._export_surface(win_filename, filetype)
             else:
                 self._export_surface(filename, filetype)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1488,7 +1488,7 @@ class Viewer(wx.Panel):
             cam.SetPosition(new_pos[0], new_pos[1], new_pos[2])
             cam.SetViewUp(0, 0, 1)
             self.ren.ResetCameraClippingRange()
-            
+
         if not self.nav_status:
             self.UpdateRender()
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1467,24 +1467,24 @@ class Viewer(wx.Panel):
         so that the measurement exactly faces the screen, without shifting the skull.
         """
         cam = self.ren.GetActiveCamera()
-        
+
         center = np.array(cam.GetFocalPoint())
         old_pos = np.array(cam.GetPosition())
         target = np.array(position)
-        
+
         # Calculate distance from camera to center to maintain zoom level
         distance = np.linalg.norm(old_pos - center)
-        
+
         # Vector from center of the volume pointing outward toward the measurement
         direction = target - center
         dir_norm = np.linalg.norm(direction)
-        
+
         if dir_norm > 0:
             direction = direction / dir_norm
-            
+
             # Orbit to the new position while staring back at the center
             new_pos = center + direction * distance
-            
+
             cam.SetPosition(new_pos[0], new_pos[1], new_pos[2])
             cam.SetViewUp(0, 0, 1)
             self.ren.ResetCameraClippingRange()

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -21,10 +21,7 @@ import os
 import pathlib
 import sys
 
-try:
-    import Image
-except ImportError:
-    from PIL import Image
+from PIL import Image
 
 import wx
 import wx.grid
@@ -1996,6 +1993,47 @@ class MeasuresListCtrlPanel(InvListCtrl):
         self.__bind_events_wx()
         self._list_index = {}
         self._bmp_idx_to_name = {}
+        self.dict_visibility = {}
+
+    def SetItemImage(self, item, image, info=0):
+        if image != -1:
+            self.dict_visibility[item] = image
+            
+        if self.IsSelected(item):
+            super().SetItemImage(item, image, info)
+        else:
+            super().SetItemImage(item, 0, info)
+
+    def OnClickItem(self, evt):
+        self._click_check = False
+        pos_x = evt.GetPosition()[0]
+        item_idx, flag = self.HitTest(evt.GetPosition())
+        if item_idx > -1:
+            column_clicked = self.get_column_clicked(evt.GetPosition())
+            if column_clicked == 0:
+                self._click_check = True
+                current_vis = self.dict_visibility.get(item_idx, 1)
+                flag = not bool(current_vis)
+                self.SetItemImage(item_idx, int(flag))
+                self.OnCheckItem(item_idx, flag)
+                return
+            elif column_clicked == 1:
+                # Only pop the color dialog if clicking precisely on the tiny color icon on the left (width roughly 22px buffer)
+                col0_width = self.GetColumnWidth(0)
+                local_x = pos_x - col0_width
+                if local_x < 22:
+                    self.OnChangeColor(item_idx)
+                    return
+            elif column_clicked == 5:
+                self.OnChangeTransparency(item_idx)
+                return
+        evt.Skip()
+
+    def OnDblClickItem(self, evt):
+        item_idx, flag = self.HitTest(evt.GetPosition())
+        if item_idx > -1:
+            Publisher.sendMessage("Edit measurement", index=item_idx)
+        evt.Skip()
 
     def __init_evt(self):
         Publisher.subscribe(self.AddItem_, "Update measurement info in GUI")
@@ -2009,10 +2047,13 @@ class MeasuresListCtrlPanel(InvListCtrl):
     def __bind_events_wx(self):
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.OnEditLabel)
         self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnItemSelected_)
+        self.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnItemDeselected_)
+        self.Bind(wx.EVT_LEFT_DCLICK, self.OnDblClickItem)
         self.Bind(wx.EVT_KEY_UP, self.OnKeyEvent)
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemActivated)
 
     def OnItemActivated(self, evt):
+        # Kept for redundancy on some platforms
         Publisher.sendMessage("Edit measurement", index=evt.GetIndex())
 
     def OnKeyEvent(self, event):
@@ -2029,12 +2070,16 @@ class MeasuresListCtrlPanel(InvListCtrl):
 
             old_dict = self._list_index
             new_dict = {}
+            new_vis = {}
             j = 0
             for i in old_dict:
                 if i != measure_index:
                     new_dict[j] = old_dict[i]
+                    if i in self.dict_visibility:
+                        new_vis[j] = self.dict_visibility[i]
                     j += 1
             self._list_index = new_dict
+            self.dict_visibility = new_vis
 
     def RemoveMeasurements(self):
         """
@@ -2049,13 +2094,19 @@ class MeasuresListCtrlPanel(InvListCtrl):
         if selected_items:
             for index in selected_items:
                 new_dict = {}
+                new_vis = {}
                 self.DeleteItem(index)
                 for i in old_dict:
                     if i < index:
                         new_dict[i] = old_dict[i]
+                        if i in self.dict_visibility:
+                            new_vis[i] = self.dict_visibility[i]
                     if i > index:
                         new_dict[i - 1] = old_dict[i]
+                        if i in self.dict_visibility:
+                            new_vis[i - 1] = self.dict_visibility[i]
                 old_dict = new_dict
+                self.dict_visibility = new_vis
             self._list_index = new_dict
             Publisher.sendMessage("Remove measurements", indexes=selected_items)
         else:
@@ -2065,6 +2116,7 @@ class MeasuresListCtrlPanel(InvListCtrl):
         self.DeleteAllItems()
         self._list_index = {}
         self._bmp_idx_to_name = {}
+        self.dict_visibility = {}
 
     def OnItemSelected_(self, evt):
         # Note: DON'T rename to OnItemSelected!!!
@@ -2074,6 +2126,16 @@ class MeasuresListCtrlPanel(InvListCtrl):
         # last_index = evt.Index
         #  Publisher.sendMessage('Change measurement selected',
         #  last_index)
+
+        item = evt.GetIndex()
+        if item in self.dict_visibility:
+            super().SetItemImage(item, self.dict_visibility[item])
+
+        evt.Skip()
+
+    def OnItemDeselected_(self, evt):
+        item = evt.GetIndex()
+        super().SetItemImage(item, 0)
         evt.Skip()
 
     def GetSelected(self):
@@ -2218,6 +2280,14 @@ class MeasuresListCtrlPanel(InvListCtrl):
         self.SetItem(index, 3, type_)
         self.SetItem(index, 4, value)
         self.SetItemImage(index, 1)
+
+        # Deselect any old selections
+        for i in self.GetSelected():
+            self.Select(i, False)
+        
+        # Select the newly added item automatically
+        self.Select(index, True)
+
         self.Refresh()
 
     def UpdateItemInfo(

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -21,14 +21,13 @@ import os
 import pathlib
 import sys
 
-from PIL import Image
-
 import wx
 import wx.grid
 
 #  import invesalius.gui.widgets.listctrl as listmix
 import wx.lib.platebtn as pbtn
 import wx.lib.scrolledpanel as scrolled
+from PIL import Image
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slice_
@@ -1324,7 +1323,9 @@ class SurfaceButtonControlPanel(wx.Panel):
         BMP_DUPLICATE = wx.Bitmap(
             os.path.join(inv_paths.ICON_DIR, "data_duplicate.png"), wx.BITMAP_TYPE_PNG
         )
-        BMP_OPEN = wx.Bitmap(os.path.join(inv_paths.ICON_DIR, "surface_import_original_min.png"), wx.BITMAP_TYPE_PNG)
+        BMP_OPEN = wx.Bitmap(
+            os.path.join(inv_paths.ICON_DIR, "surface_import_original_min.png"), wx.BITMAP_TYPE_PNG
+        )
 
         BMP_EXPORT = wx.Bitmap(
             os.path.join(inv_paths.ICON_DIR, "surface_export_original_min.png"), wx.BITMAP_TYPE_PNG
@@ -1998,7 +1999,7 @@ class MeasuresListCtrlPanel(InvListCtrl):
     def SetItemImage(self, item, image, info=0):
         if image != -1:
             self.dict_visibility[item] = image
-            
+
         if self.IsSelected(item):
             super().SetItemImage(item, image, info)
         else:
@@ -2284,7 +2285,7 @@ class MeasuresListCtrlPanel(InvListCtrl):
         # Deselect any old selections
         for i in self.GetSelected():
             self.Select(i, False)
-        
+
         # Select the newly added item automatically
         self.Select(index, True)
 


### PR DESCRIPTION
### fixes: #1325

The measurement and annotation system in InVesalius previously lacked proper UI state tracking, causing the visibility "eye" icon to confusingly duplicate across all rows rather than indicating the active selection. Additionally, the system intercepted native mouse clicks on the measurement name, breaking double-click sequences for MacOS users, and suffered from a coordinate system collision that caused the Coronal viewer to crash to slice 0 when trying to map 3D-generated measurements.

### Changes

**UI State & Selection Tracking:** Overrode internal image rendering in the MeasuresListCtrlPanel to only display the eye icon on the actively selected row (defaulting the rest to uniform white boxes), and ensured newly drawn measurements automatically steal selection.
**Native Double-Click Restored:** Tightened the column hit box testing limits so the Color Selection dialog only triggers upon clicking the precise 16x16 color square icon. This perfectly frees the text boundary, allowing native, ultra-responsive wx.EVT_LEFT_DCLICK events to trigger navigation.
**Coordinate Inversion Patch:** Implemented a fork in _edit_measurement to explicitly check for 3D Surface locations and manually invert the deeply-rooted VTK Y-axis to guarantee the 2D Coronal camera properly bounds and focuses directly onto 3D picked measurements rather than jumping to element zero.


### After fix: 

https://github.com/user-attachments/assets/1b1b98bf-c05d-41a4-bd28-60ea459259e1



