### PR TITLE
fix (#1330): Make "Clear Mask" shortcut (Ctrl+Shift+A) work globally

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -235,7 +235,7 @@ class Frame(wx.Frame):
             and not is_shell_focused
         ):
             # Only clear mask if a mask is available (menu is enabled)
-            if self.clean_mask_menu.IsEnabled():
+            if hasattr(self, "clean_mask_menu") and self.clean_mask_menu.IsEnabled():
                 self.OnCleanMask()
             return
 

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -227,6 +227,18 @@ class Frame(wx.Frame):
                 event.Skip()
                 return
 
+        # Handle Ctrl+Shift+A for clearing mask (should work at any time, even outside edit mode)
+        if (
+            modifiers == (wx.MOD_CONTROL | wx.MOD_SHIFT)
+            and keycode == ord("A")
+            and not is_search_field
+            and not is_shell_focused
+        ):
+            # Only clear mask if a mask is available (menu is enabled)
+            if self.clean_mask_menu.IsEnabled():
+                self.OnCleanMask()
+            return
+
         # If the key is a move marker key, publish a message to move the marker,
         # but only if we're not in a search field or shell
         if (

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -237,6 +237,7 @@ class Frame(wx.Frame):
             # Only clear mask if a mask is available (menu is enabled)
             if hasattr(self, "clean_mask_menu") and self.clean_mask_menu.IsEnabled():
                 self.OnCleanMask()
+            event.Skip()
             return
 
         # If the key is a move marker key, publish a message to move the marker,


### PR DESCRIPTION
### Fixes #1330

## Summary
The SHIFT + CTRL + A shortcut for clearing the mask was not working reliably because it was only defined as a menu accelerator (`\tCtrl+Shift+A`). This approach fails when focus is on certain UI elements or outside edit mode.

## Fix
Added explicit handling for the shortcut in the global key handler (`OnGlobalKey` in `frame.py`).

- Detects `CTRL + SHIFT + A` keypress
- Ignores input when focus is on text fields or interactive shells
- Ensures a mask is available (via menu item state)
- Triggers `OnCleanMask()` to clear the mask

## Result
The shortcut now works consistently across all contexts, including outside edit mode, without interfering with text input.

## Notes
Implementation follows the same global shortcut handling pattern used for:
- Marker movement (arrow keys)
- Marker deletion (Delete key)