### PR TITLE
Fix (#1331): Restore correct left panel width when loading .inv3 projects

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -273,7 +273,17 @@ class Frame(wx.Frame):
 
         # First, the task panel, to be on the left fo the frame
         # This will be specific according to InVesalius application
-        aui_manager.AddPane(task_panel, wx.aui.AuiPaneInfo().Name("Tasks").CaptionVisible(False))
+        aui_manager.AddPane(
+            task_panel,
+            wx.aui.AuiPaneInfo()
+            .Name("Tasks")
+            .CaptionVisible(False)
+            .Left()
+            .BestSize((385, -1))
+            .MinSize((385, -1))
+            .CloseButton(False)
+            .Layer(0),
+        )
 
         # Then, add the viewers panel, which will contain slices and
         # volume panels. In future this might also be specific


### PR DESCRIPTION
### Fixes #1331

## Summary
Fixes an issue where the left-side Tasks panel was loaded with a reduced width when opening an existing `.inv3` project, while it appeared correctly sized when loading DICOM data.

## Problem
- When starting from DICOM, the panel initializes with the correct width (~385px)
- When opening an existing project, the panel appears narrower
- This creates an inconsistent UI experience

## Fix
Updated the AUI configuration for the Tasks panel in `frame.py`:

- `.Left()` → Ensures correct docking position
- `.BestSize((385, -1))` → Sets preferred width
- `.MinSize((385, -1))` → Prevents shrinking below expected size

## Result
The panel now maintains a consistent width when:
- Loading DICOM data
- Opening existing `.inv3` projects
- Restarting and reopening projects

## Testing
Tested on macOS:

- Loaded DICOM → panel width correct
- Saved project → reopened `.inv3` → width preserved
- No unexpected shrinking observed

