### PR TITLE
ENH (#1333): Display a progress window when loading a project( .inv3)

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -507,7 +507,10 @@ class Controller:
         
         path = os.path.abspath(filepath)
 
-        # Create progress dialog (no busy cursor - user needs to click cancel)
+        # Show busy cursor during loading (main window)
+        Publisher.sendMessage("Begin busy cursor")
+        
+        # Create progress dialog (modal - cancel button remains clickable)
         progress_dlg = dialogs.ProjectLoadProgressDialog()
         
         try:
@@ -528,6 +531,9 @@ class Controller:
                 # Clean up the partially loaded project
                 proj.Close()
                 
+                # End busy cursor
+                Publisher.sendMessage("End busy cursor")
+                
                 # Show cancellation message
                 wx.MessageBox(
                     _("Project loading was cancelled."),
@@ -540,6 +546,7 @@ class Controller:
             if not progress_dlg.Update(96, _("Initializing project...")):
                 progress_dlg.Close()
                 proj.Close()
+                Publisher.sendMessage("End busy cursor")
                 return
             
             proj.SetAcquisitionModality(proj.modality)
@@ -561,27 +568,34 @@ class Controller:
             if not progress_dlg.Update(98, _("Loading project into interface...")):
                 progress_dlg.Close()
                 proj.Close()
+                Publisher.sendMessage("End busy cursor")
                 return
 
-            self.LoadProject(end_busy_cursor=False)  # Don't end busy cursor - we're using progress dialog
+            self.LoadProject(end_busy_cursor=False)
 
             session = ses.Session()
             session.OpenProject(filepath)
             Publisher.sendMessage("Enable state project", state=True)
             
-            # Complete
+            # Complete - dialog will auto-hide at 100%
             progress_dlg.Update(100, _("Project loaded successfully!"))
+            
+            # End busy cursor after successful load
+            Publisher.sendMessage("End busy cursor")
             
         except Exception as e:
             # Handle any errors during loading
+            progress_dlg.Close()
+            Publisher.sendMessage("End busy cursor")
             wx.MessageBox(
                 _("Error loading project: {}").format(str(e)),
                 _("Load Error"),
                 wx.OK | wx.ICON_ERROR
             )
         finally:
-            # Always close the progress dialog
-            progress_dlg.Close()
+            # Ensure progress dialog is closed
+            if progress_dlg.dlg:
+                progress_dlg.Close()
 
     def OnSaveProject(self, filepath: Optional["str | Path"]) -> None:
         self.SaveProject(filepath)

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -497,31 +497,91 @@ class Controller:
             dialog.InexistentPath(filepath)
 
     def OpenProject(self, filepath: "str | Path") -> None:
-        Publisher.sendMessage("Begin busy cursor")
+        """
+        Open a .inv3 project file with progress dialog and cancellation support.
+        
+        Args:
+            filepath: Path to the .inv3 project file
+        """
+        from invesalius.gui import dialogs
+        
         path = os.path.abspath(filepath)
 
-        proj = prj.Project()
-        proj.OpenPlistProject(path)
-        proj.SetAcquisitionModality(proj.modality)
-        self.Slice = sl.Slice()
-        self.Slice._open_image_matrix(
-            proj.matrix_filename, tuple(proj.matrix_shape), proj.matrix_dtype
-        )
+        # Create progress dialog (no busy cursor - user needs to click cancel)
+        progress_dlg = dialogs.ProjectLoadProgressDialog()
+        
+        try:
+            proj = prj.Project()
+            
+            # Define progress callback
+            def progress_callback(value, message):
+                """Update progress dialog and check for cancellation."""
+                return progress_dlg.Update(value, message)
+            
+            # Load project with progress updates
+            result = proj.OpenPlistProject(path, progress_callback)
+            
+            # Check if loading was cancelled
+            if result is False or progress_dlg.WasCancelled():
+                progress_dlg.Close()
+                
+                # Clean up the partially loaded project
+                proj.Close()
+                
+                # Show cancellation message
+                wx.MessageBox(
+                    _("Project loading was cancelled."),
+                    _("Load Cancelled"),
+                    wx.OK | wx.ICON_INFORMATION
+                )
+                return
+            
+            # Update progress
+            if not progress_dlg.Update(96, _("Initializing project...")):
+                progress_dlg.Close()
+                proj.Close()
+                return
+            
+            proj.SetAcquisitionModality(proj.modality)
+            self.Slice = sl.Slice()
+            self.Slice._open_image_matrix(
+                proj.matrix_filename, tuple(proj.matrix_shape), proj.matrix_dtype
+            )
 
-        self.Slice.window_level = proj.level
-        self.Slice.window_width = proj.window
-        if proj.affine:
-            self.Slice.affine = np.asarray(proj.affine).reshape(4, 4)
-        else:
-            self.Slice.affine = np.identity(4)
+            self.Slice.window_level = proj.level
+            self.Slice.window_width = proj.window
+            if proj.affine:
+                self.Slice.affine = np.asarray(proj.affine).reshape(4, 4)
+            else:
+                self.Slice.affine = np.identity(4)
 
-        Publisher.sendMessage("Update threshold limits list", threshold_range=proj.threshold_range)
+            Publisher.sendMessage("Update threshold limits list", threshold_range=proj.threshold_range)
 
-        self.LoadProject()
+            # Update progress
+            if not progress_dlg.Update(98, _("Loading project into interface...")):
+                progress_dlg.Close()
+                proj.Close()
+                return
 
-        session = ses.Session()
-        session.OpenProject(filepath)
-        Publisher.sendMessage("Enable state project", state=True)
+            self.LoadProject(end_busy_cursor=False)  # Don't end busy cursor - we're using progress dialog
+
+            session = ses.Session()
+            session.OpenProject(filepath)
+            Publisher.sendMessage("Enable state project", state=True)
+            
+            # Complete
+            progress_dlg.Update(100, _("Project loaded successfully!"))
+            
+        except Exception as e:
+            # Handle any errors during loading
+            wx.MessageBox(
+                _("Error loading project: {}").format(str(e)),
+                _("Load Error"),
+                wx.OK | wx.ICON_ERROR
+            )
+        finally:
+            # Always close the progress dialog
+            progress_dlg.Close()
 
     def OnSaveProject(self, filepath: Optional["str | Path"]) -> None:
         self.SaveProject(filepath)
@@ -756,7 +816,7 @@ class Controller:
 
     # -------------------------------------------------------------------------------------
 
-    def LoadProject(self, create_default_mask=True):
+    def LoadProject(self, create_default_mask=True, end_busy_cursor=True):
         proj = prj.Project()
 
         const.THRESHOLD_OUTVALUE = proj.threshold_range[0]
@@ -833,7 +893,9 @@ class Controller:
         img_file = Path(outdir) / "proj_image.nii.gz"
         proj.export_project_to_nifti(img_file, save_masks=False)
 
-        Publisher.sendMessage("End busy cursor")
+        # End busy cursor only if it was started (not when using progress dialog)
+        if end_busy_cursor:
+            Publisher.sendMessage("End busy cursor")
         Publisher.sendMessage("Project loaded successfully")
 
     def CreateDicomProject(self, dicom, matrix, matrix_filename):

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -7839,7 +7839,7 @@ class ProjectLoadProgressDialog:
 
         self.title = _("Loading Project")
         self.msg = _("Preparing to load project...")
-        self.style = wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME
+        self.style = wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE
         self.cancelled = False
 
         self.dlg = wx.ProgressDialog(

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -7830,6 +7830,67 @@ class ProgressBarHandler(wx.ProgressDialog):
             super().Pulse(msg)
 
 
+class ProjectLoadProgressDialog:
+    """Progress dialog for loading .inv3 project files with cancellation support."""
+
+    def __init__(self, parent: Optional[wx.Window] = None):
+        if parent is None:
+            parent = wx.GetApp().GetTopWindow()
+
+        self.title = _("Loading Project")
+        self.msg = _("Preparing to load project...")
+        self.style = wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME
+        self.cancelled = False
+
+        self.dlg = wx.ProgressDialog(
+            self.title, self.msg, maximum=100, parent=parent, style=self.style
+        )
+
+        # Force the dialog to paint before loading starts
+        wx.SafeYield()
+
+    def Update(self, value: int, message: str = "") -> bool:
+        """
+        Update progress dialog.
+
+        Args:
+            value: Progress value (0-100)
+            message: Status message to display
+
+        Returns:
+            True if should continue, False if cancelled
+        """
+        if self.cancelled:
+            return False
+
+        try:
+            if message:
+                continue_loading, skip = self.dlg.Update(value, message)
+            else:
+                continue_loading, skip = self.dlg.Update(value)
+
+            if not continue_loading:
+                self.cancelled = True
+                return False
+
+            return True
+        except Exception:
+            return False
+
+    def WasCancelled(self) -> bool:
+        """Check if user cancelled the operation."""
+        return self.cancelled
+
+    def Close(self) -> None:
+        """Close and destroy the progress dialog."""
+        try:
+            if self.dlg:
+                self.dlg.Destroy()
+                self.dlg = None
+        except Exception:
+            pass
+
+
 class AnnotationDialog(wx.Dialog):
     """Dialog for entering a annotation text."""
 

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -287,7 +287,19 @@ class Project(metaclass=Singleton):
             if filelist[f].endswith(".plist"):
                 os.remove(f)
 
-    def OpenPlistProject(self, filename):
+    def OpenPlistProject(self, filename, progress_callback=None):
+        """
+        Open a .inv3 project file.
+        
+        Args:
+            filename: Path to the .inv3 file
+            progress_callback: Optional callback function(value, message) for progress updates
+                              Should return False to cancel loading
+        """
+        if progress_callback:
+            if not progress_callback(5, _("Extracting project archive...")):
+                return False
+
         if not const.VTK_WARNING:
             log_path = os.path.join(inv_paths.USER_LOG_DIR, "vtkoutput.txt")
             fow = vtkFileOutputWindow()
@@ -295,17 +307,35 @@ class Project(metaclass=Singleton):
             ow = vtkOutputWindow()
             ow.SetInstance(fow)
 
+        if progress_callback:
+            if not progress_callback(15, _("Extracting files...")):
+                return False
+
         filelist = Extract(filename, tempfile.mkdtemp())
         dirpath = os.path.abspath(os.path.split(filelist[0])[0])
-        self.load_from_folder(dirpath)
 
-    def load_from_folder(self, dirpath):
+        if progress_callback:
+            if not progress_callback(25, _("Loading project data...")):
+                return False
+
+        return self.load_from_folder(dirpath, progress_callback)
+
+    def load_from_folder(self, dirpath, progress_callback=None):
         """
         Loads invesalius3 project files from dipath.
+        
+        Args:
+            dirpath: Directory containing extracted project files
+            progress_callback: Optional callback function(value, message) for progress updates
+                              Should return False to cancel loading
         """
         import invesalius.data.mask as msk
         import invesalius.data.measures as ms
         import invesalius.data.surface as srf
+
+        if progress_callback:
+            if not progress_callback(30, _("Reading project metadata...")):
+                return False
 
         # Opening the main file from invesalius 3 project
         main_plist = os.path.join(dirpath, "main.plist")
@@ -317,6 +347,10 @@ class Project(metaclass=Singleton):
             from invesalius.gui.dialogs import ImportOldFormatInvFile
 
             ImportOldFormatInvFile()
+
+        if progress_callback:
+            if not progress_callback(40, _("Loading project information...")):
+                return False
 
         # case info
         self.name = project["name"]
@@ -343,9 +377,21 @@ class Project(metaclass=Singleton):
         except KeyError:
             pass
 
+        if progress_callback:
+            if not progress_callback(55, _("Loading image data...")):
+                return False
+
         # Opening the masks
         self.mask_dict = TwoWaysDictionary()
-        for index in sorted(project.get("masks", []), key=lambda x: int(x)):
+        masks = project.get("masks", [])
+        total_masks = len(masks)
+        
+        for idx, index in enumerate(sorted(masks, key=lambda x: int(x))):
+            if progress_callback:
+                progress = 60 + int((idx / max(total_masks, 1)) * 15)
+                if not progress_callback(progress, _("Loading mask {} of {}...").format(idx + 1, total_masks)):
+                    return False
+
             filename = project["masks"][index]
             filepath = os.path.join(dirpath, filename)
             m = msk.Mask()
@@ -354,14 +400,30 @@ class Project(metaclass=Singleton):
             m.index = len(self.mask_dict)
             self.mask_dict[m.index] = m
 
+        if progress_callback:
+            if not progress_callback(75, _("Loading surfaces...")):
+                return False
+
         # Opening the surfaces
         self.surface_dict: dict[int, srf.Surface] = {}
-        for index in sorted(project.get("surfaces", []), key=lambda x: int(x)):
+        surfaces = project.get("surfaces", [])
+        total_surfaces = len(surfaces)
+        
+        for idx, index in enumerate(sorted(surfaces, key=lambda x: int(x))):
+            if progress_callback:
+                progress = 75 + int((idx / max(total_surfaces, 1)) * 15)
+                if not progress_callback(progress, _("Loading surface {} of {}...").format(idx + 1, total_surfaces)):
+                    return False
+
             filename = project["surfaces"][index]
             filepath = os.path.join(dirpath, filename)
             s = srf.Surface(int(index))
             s.OpenPList(filepath)
             self.surface_dict[s.index] = s
+
+        if progress_callback:
+            if not progress_callback(90, _("Loading measurements...")):
+                return False
 
         # Opening the measurements
         self.measurement_dict = {}
@@ -376,6 +438,12 @@ class Project(metaclass=Singleton):
                     measure = ms.Measurement()
                 measure.Load(measurements[index])
                 self.measurement_dict[int(index)] = measure
+
+        if progress_callback:
+            if not progress_callback(95, _("Finalizing project load...")):
+                return False
+
+        return True
 
     def create_project_file(
         self,


### PR DESCRIPTION
### Implements #1333 

## Summary
Adds a progress dialog for `.inv3` project loading with real-time updates and cancellation support. This improves user feedback and allows safe interruption of long loading operations.

## Problem
Opening `.inv3` projects previously:
- Provided no loading feedback
- Blocked the UI during long operations
- Did not allow cancellation

## Solution
Introduced a progress dialog with cancel support integrated into the project loading pipeline.

### Key Features
- Displays progress with detailed status messages
- Allows users to cancel loading at any stage
- Ensures proper cleanup of partially loaded data
- Maintains application stability on cancel or error

## Implementation
- Added `ProjectLoadProgressDialog` for handling progress UI
- Introduced `progress_callback` mechanism for decoupled updates
- Integrated progress updates across all major loading stages
- Implemented safe cancellation with cleanup (`proj.Close()`)

## Result
- Loading is now transparent and user-friendly
- Users can safely cancel long operations
- No inconsistent or partially loaded states remain after cancellation

## Testing
Tested on macOS:

- Progress dialog appears and updates correctly
- Cancel works at multiple stages of loading
- No partial data remains after cancellation
- Application remains stable after cancel or error
- Re-loading after cancellation works correctly

#### Cancellation Testing (with Controlled Delay)
To properly validate cancellation behavior, the loading process was intentionally slowed down by introducing temporary `time.sleep()` delays during key stages.

This allowed sufficient time to trigger cancellation at different points in the loading pipeline.

- Cancel during early stages (e.g., archive extraction)
- Cancel during intermediate stages (e.g., mask loading)
- Cancel during later stages (e.g., surface loading / finalization)
- Cancellation is handled immediately without UI freeze
- Progress dialog closes cleanly after cancel
- No partially loaded data remains (clean rollback confirmed)
- Application remains stable after cancellation
- Subsequent project loads work correctly


## Notes
- Fast-loading small files may complete before cancellation is possible (expected behavior)
- Existing loading workflows (DICOM, bitmap, etc.) remain unaffected
