### PR TITLE
Feature: Implement 3D Orientation Reference Cube in Volume Viewer

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -632,6 +632,7 @@ ID_MASK_3D_EDIT = wx.NewIdRef()
 
 ID_GOTO_SLICE = wx.NewIdRef()
 ID_GOTO_COORD = wx.NewIdRef()
+ID_ORIENTATION_CUBE = wx.NewIdRef()
 
 ID_MANUAL_WWWL = wx.NewIdRef()
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -471,17 +471,17 @@ class Viewer(wx.Panel):
 
             # Build the annotated cube actor with anatomical labels.
             cube = vtkAnnotatedCubeActor()
-            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)  # A – Anterior
-            cube.GetXMinusFaceProperty().SetColor(1, 0, 0)  # P – Posterior
-            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)  # L – Left
-            cube.GetYMinusFaceProperty().SetColor(0, 1, 0)  # R – Right
+            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)  # L – Left
+            cube.GetXMinusFaceProperty().SetColor(1, 0, 0)  # R – Right
+            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)  # P – Posterior
+            cube.GetYMinusFaceProperty().SetColor(0, 1, 0)  # A – Anterior
             cube.GetZPlusFaceProperty().SetColor(0, 0, 1)  # T – Top
             cube.GetZMinusFaceProperty().SetColor(0, 0, 1)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0, 0, 0)
-            cube.SetXPlusFaceText(_("A"))
-            cube.SetXMinusFaceText(_("P"))
-            cube.SetYPlusFaceText(_("L"))
-            cube.SetYMinusFaceText(_("R"))
+            cube.SetXPlusFaceText(_("L"))
+            cube.SetXMinusFaceText(_("R"))
+            cube.SetYPlusFaceText(_("P"))
+            cube.SetYMinusFaceText(_("A"))
             cube.SetZPlusFaceText(_("T"))
             cube.SetZMinusFaceText(_("B"))
 
@@ -3254,13 +3254,16 @@ class Viewer(wx.Panel):
         cube.GetZPlusFaceProperty().SetColor(0, 0, 1)
         cube.GetTextEdgesProperty().SetColor(0, 0, 0)
 
-        # anatomic labelling
-        cube.SetXPlusFaceText("A")
-        cube.SetXMinusFaceText("P")
-        cube.SetYPlusFaceText("L")
-        cube.SetYMinusFaceText("R")
-        cube.SetZPlusFaceText("S")
-        cube.SetZMinusFaceText("I")
+        # Face labels as specified in the issue: A (Anterior/front), P (Posterior/back),
+        # R (Right), L (Left), T (Top), B (Bottom).
+        # InVesalius AXIAL orientation: VOL_FRONT camera is at (0, -1, 0), so the
+        # Y-minus face faces the viewer → A. X-axis → L/R. Z-axis → T/B.
+        cube.SetXPlusFaceText("L")
+        cube.SetXMinusFaceText("R")
+        cube.SetYPlusFaceText("P")
+        cube.SetYMinusFaceText("A")
+        cube.SetZPlusFaceText("T")
+        cube.SetZMinusFaceText("B")
 
         axes = vtkAxesActor()
         axes.SetShaftTypeToCylinder()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -83,7 +83,6 @@ from vtkmodules.vtkRenderingCore import (
     vtkRenderer,
     vtkWindowToImageFilter,
 )
-from vtkmodules.vtkRenderingFreeType import vtkVectorText
 from vtkmodules.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 
 import invesalius.constants as const
@@ -458,6 +457,14 @@ class Viewer(wx.Panel):
         else:
             if self.orientation_widget:
                 self.orientation_widget.SetEnabled(0)
+                # Remove renderer observer so we stop updating a hidden cube.
+                tag = getattr(self, "_cube_render_observer_tag", None)
+                if tag is not None:
+                    try:
+                        self.ren.RemoveObserver(tag)
+                    except Exception:
+                        pass
+                    self._cube_render_observer_tag = None
                 self.UpdateRender()
 
     def _ShowOrientationCube(self):
@@ -500,44 +507,25 @@ class Viewer(wx.Panel):
             cube.GetZPlusFaceProperty().SetColor(0.1, 0.1, 0.7)   # T – Top
             cube.GetZMinusFaceProperty().SetColor(0.1, 0.1, 0.7)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0.5, 0.5, 0.5)
-
             cube.SetXPlusFaceText(_("L"))
             cube.SetXMinusFaceText(_("R"))
             cube.SetYPlusFaceText(_("P"))
             cube.SetYMinusFaceText(_("A"))
-            # Decouple T/B from vtkAnnotatedCubeActor shared Z-face rotation.
-            # Keep cube Z faces colorized, but draw T/B as independent 3D text actors.
-            cube.SetZPlusFaceText("")
-            cube.SetZMinusFaceText("")
+            # Use built-in face text for T/B.
+            # SetZFaceTextRotation applies the SAME angle to both Z faces; since T (+Z)
+            # and B (-Z) have opposite normals, +90 makes T upright but B upside-down.
+            # _UpdateOrientationCubeZTextRotation() switches between +90 and -90 on
+            # every render based on the camera's Z position relative to the focal point,
+            # so whichever Z face is currently visible always appears upright.
+            cube.SetZPlusFaceText(_("T"))
+            cube.SetZMinusFaceText(_("B"))
+            cube.SetZFaceTextRotation(90)  # initial default; updated dynamically
+            # Store reference so _UpdateOrientationCubeZTextRotation can reach the actor.
+            self._orientation_cube_actor = cube
 
             # Wrap in vtkAssembly to ensure the orientation is preserved.
             assembly = vtkAssembly()
             assembly.AddPart(cube)
-
-            def _make_face_text_actor(text: str, z_pos: float, rotate_x: float) -> vtkActor:
-                text_source = vtkVectorText()
-                text_source.SetText(text)
-
-                text_mapper = vtkPolyDataMapper()
-                text_mapper.SetInputConnection(text_source.GetOutputPort())
-
-                text_actor = vtkActor()
-                text_actor.SetMapper(text_mapper)
-                text_actor.SetScale(0.22, 0.22, 0.22)
-                text_actor.SetPosition(-0.07, -0.08, z_pos)
-                text_actor.RotateX(rotate_x)
-                text_actor.GetProperty().SetColor(0.1, 0.1, 0.7)
-                text_actor.GetProperty().SetAmbient(1.0)
-                text_actor.GetProperty().SetDiffuse(0.0)
-                text_actor.GetProperty().BackfaceCullingOff()
-                text_actor.PickableOff()
-                return text_actor
-
-            top_text_actor = _make_face_text_actor("T", 0.53, 0.0)
-            # Independent orientation for B, no dependency on T.
-            bottom_text_actor = _make_face_text_actor("B", -0.53, 180.0)
-            assembly.AddPart(top_text_actor)
-            assembly.AddPart(bottom_text_actor)
 
             widget = vtkOrientationMarkerWidget()
             widget.SetOrientationMarker(assembly)
@@ -549,6 +537,24 @@ class Viewer(wx.Panel):
             
             # Reset retries once successfully shown
             self._cube_retries = 0
+
+            # Add a renderer StartEvent observer so _UpdateOrientationCubeZTextRotation
+            # is called before EVERY render — including those from VTK mouse-rotation
+            # events that bypass InVesalius's UpdateRender().  Without this, the
+            # Z-face text rotation can get stuck at the wrong value whenever the cube
+            # is first created (skull may have just changed the focal point) and not
+            # get corrected until the next Publisher-triggered render.
+            existing_tag = getattr(self, "_cube_render_observer_tag", None)
+            if existing_tag is not None:
+                try:
+                    self.ren.RemoveObserver(existing_tag)
+                except Exception:
+                    pass
+            self._cube_render_observer_tag = self.ren.AddObserver(
+                "StartEvent",
+                lambda *_: self._UpdateOrientationCubeZTextRotation()
+            )
+
             self._UpdateOrientationCubeZTextRotation()
             self.UpdateRender()
         except Exception as e:
@@ -557,13 +563,26 @@ class Viewer(wx.Panel):
 
     def _UpdateOrientationCubeZTextRotation(self):
         """
-        Keep Z-face letters (T/B) upright.
-        VTK exposes one Z-face text rotation for both faces, so we adapt it based
-        on whether camera is below or above the focal point.
+        Dynamically keep Z-face letters (T/B) upright by switching
+        SetZFaceTextRotation between +90 and -90 based on the camera position.
+
+        Reason: vtkAnnotatedCubeActor exposes only ONE Z-face rotation value
+        that applies identically to both the T (+Z) and B (-Z) faces.  Because
+        those faces have opposite normals, +90 makes T upright but leaves B
+        rotated 180°, while -90 does the reverse.  We resolve this by switching
+        the value on every render so that whichever face the camera is looking
+        at always appears upright.
         """
-        # No-op: T/B are now separate billboard labels with independent upright
-        # orientation, so no shared Z-face text rotation is needed.
-        return
+        cube = getattr(self, "_orientation_cube_actor", None)
+        if cube is None:
+            return
+        camera = self.ren.GetActiveCamera()
+        cam_z = camera.GetPosition()[2]
+        focal_z = camera.GetFocalPoint()[2]
+        # Camera above focal point → T face is towards camera → use +90
+        # Camera below focal point → B face is towards camera → use -90
+        rotation = 90 if cam_z >= focal_z else -90
+        cube.SetZFaceTextRotation(rotation)
 
     def OnInteractorEvent(self, sender, event):
         if self.canvas and self.ruler and self.ruler in self.canvas.draw_list:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -451,7 +451,7 @@ class Viewer(wx.Panel):
                 except:
                     pass
                 self.orientation_widget = None
-                
+
             self._cube_retries = 0
             self._ShowOrientationCube()
         else:
@@ -488,6 +488,7 @@ class Viewer(wx.Panel):
                 wx.CallLater(100, self._ShowOrientationCube)
             else:
                 import logging
+
                 logging.warning("Orientation cube failed to initialize: Interactor timeout")
                 Publisher.sendMessage("Set orientation cube state", status=False)
                 self._cube_retries = 0
@@ -500,11 +501,11 @@ class Viewer(wx.Panel):
             # Canonical anatomical mapping:
             # X axis -> Left/Right, Y axis -> Posterior/Anterior, Z axis -> Top/Bottom.
             # With VOL_FRONT camera (0, -1, 0), the Y- face is visible => "A".
-            cube.GetXPlusFaceProperty().SetColor(0.7, 0.1, 0.1)   # L – Left
+            cube.GetXPlusFaceProperty().SetColor(0.7, 0.1, 0.1)  # L – Left
             cube.GetXMinusFaceProperty().SetColor(0.7, 0.1, 0.1)  # R – Right
-            cube.GetYPlusFaceProperty().SetColor(0.1, 0.7, 0.1)   # P – Posterior
+            cube.GetYPlusFaceProperty().SetColor(0.1, 0.7, 0.1)  # P – Posterior
             cube.GetYMinusFaceProperty().SetColor(0.1, 0.7, 0.1)  # A – Anterior
-            cube.GetZPlusFaceProperty().SetColor(0.1, 0.1, 0.7)   # T – Top
+            cube.GetZPlusFaceProperty().SetColor(0.1, 0.1, 0.7)  # T – Top
             cube.GetZMinusFaceProperty().SetColor(0.1, 0.1, 0.7)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0.5, 0.5, 0.5)
             cube.SetXPlusFaceText(_("L"))
@@ -534,7 +535,7 @@ class Viewer(wx.Panel):
             widget.SetEnabled(1)
             widget.InteractiveOff()  # Fixed position – does not move with mouse
             self.orientation_widget = widget
-            
+
             # Reset retries once successfully shown
             self._cube_retries = 0
 
@@ -551,14 +552,14 @@ class Viewer(wx.Panel):
                 except Exception:
                     pass
             self._cube_render_observer_tag = self.ren.AddObserver(
-                "StartEvent",
-                lambda *_: self._UpdateOrientationCubeZTextRotation()
+                "StartEvent", lambda *_: self._UpdateOrientationCubeZTextRotation()
             )
 
             self._UpdateOrientationCubeZTextRotation()
             self.UpdateRender()
         except Exception as e:
             import logging
+
             logging.error("Failed to show orientation cube: %s", e)
 
     def _UpdateOrientationCubeZTextRotation(self):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -437,7 +437,7 @@ class Viewer(wx.Panel):
         if status:
             # When no 3D surface exists yet, force the canonical front camera so
             # the cube starts with "A" (anterior) facing the viewer.
-            if not self.surface_added:
+            if not self.view_angle:
                 self.SetViewAngle(const.VOL_FRONT)
 
             # FORCE RE-CREATION to fix "1st click" and "2nd click" synchronization issues
@@ -3341,7 +3341,7 @@ class Viewer(wx.Panel):
             self.ren.RemoveVolume(mask_3d_actor)
 
         if flag:
-            if not self.surface_added:
+            if not self.view_angle:
                 proj = prj.Project()
                 modality = str(getattr(proj, "modality", "CT")).upper()
                 if modality in ["MRI", "MR"]:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -74,6 +74,7 @@ from vtkmodules.vtkIOImage import (
 from vtkmodules.vtkRenderingAnnotation import vtkAnnotatedCubeActor, vtkAxesActor
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
+    vtkAssembly,
     vtkCompositePolyDataMapper,
     vtkPointPicker,
     vtkPolyDataMapper,
@@ -82,6 +83,7 @@ from vtkmodules.vtkRenderingCore import (
     vtkRenderer,
     vtkWindowToImageFilter,
 )
+from vtkmodules.vtkRenderingFreeType import vtkVectorText
 from vtkmodules.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 
 import invesalius.constants as const
@@ -379,11 +381,15 @@ class Viewer(wx.Panel):
 
         print(len(self.renderers))
 
+        # Set default view angle to Anterior (Front) so orientation cube shows "A"
+        # even before data is loaded.
+        self.SetViewAngle(const.VOL_FRONT)
+
         Publisher.sendMessage("Press target mode button", pressed=False)
         self._update_fps_visibility()
-        # NOTE: We do NOT request the cube here. The cube must only appear
-        # after a 3D surface is loaded so that the camera is already in the
-        # correct position. See AddSurface for the actual trigger.
+        # Request the orientation cube visibility status with a small delay
+        # to ensure the interactor has time to initialize during app startup.
+        wx.CallLater(1000, Publisher.sendMessage, "Send orientation cube visibility status")
 
     def _update_fps_visibility(self):
         show_fps = (
@@ -430,74 +436,134 @@ class Viewer(wx.Panel):
         """
         Receive the requested visibility state for the orientation cube.
         """
-        if not self.surface_added:
-            # Surface not yet present – notify user and revert toolbar state
-            from invesalius.gui.utils import show_warning
-
-            show_warning(
-                _("Orientation Cube"),
-                _("The orientation cube can only be displayed on the 3D surface."),
-            )
-            # Revert the toolbar to "True" to ensure the feature stays enabled
-            # by default and will auto-show once the surface is finally created.
-            Publisher.sendMessage("Set orientation cube state", status=True)
-            return
+        # Track the intended state to handle retry loop cancellation
+        self._cube_request_on = status
 
         if status:
+            # When no 3D surface exists yet, force the canonical front camera so
+            # the cube starts with "A" (anterior) facing the viewer.
+            if not self.surface_added:
+                self.SetViewAngle(const.VOL_FRONT)
+
+            # FORCE RE-CREATION to fix "1st click" and "2nd click" synchronization issues
+            if self.orientation_widget:
+                try:
+                    self.orientation_widget.SetEnabled(0)
+                except:
+                    pass
+                self.orientation_widget = None
+                
+            self._cube_retries = 0
             self._ShowOrientationCube()
         else:
-            if self.orientation_widget is not None:
+            if self.orientation_widget:
                 self.orientation_widget.SetEnabled(0)
                 self.UpdateRender()
 
     def _ShowOrientationCube(self):
         """
-        Build (if necessary) and show the vtkOrientationMarkerWidget.
+        Build and enable the 3D orientation cube (anatomical directions).
         """
+        if not getattr(self, "_cube_request_on", False):
+            return
+
+        if not self.interactor:
+            wx.CallLater(100, self._ShowOrientationCube)
+            return
+
+        if not self.interactor.GetInitialized():
+            # Interactor not ready yet – retry up to 200 times (approx 20s total).
+            # Force a render attempt to trigger initialization.
+            self.interactor.Render()
+            retries = getattr(self, "_cube_retries", 0)
+            if retries < 200:
+                self._cube_retries = retries + 1
+                wx.CallLater(100, self._ShowOrientationCube)
+            else:
+                import logging
+                logging.warning("Orientation cube failed to initialize: Interactor timeout")
+                Publisher.sendMessage("Set orientation cube state", status=False)
+                self._cube_retries = 0
+            return
+
         try:
-            if self.orientation_widget is not None:
-                self.orientation_widget.SetEnabled(1)
-                self.orientation_widget.InteractiveOff()
-                self.UpdateRender()
-                return
-
-            if not self.interactor or not self.interactor.GetInitialized():
-                # Interactor not ready yet – retry up to 10 times.
-                retries = getattr(self, "_cube_retries", 0)
-                if retries < 10:
-                    self._cube_retries = retries + 1
-                    wx.CallLater(200, self._ShowOrientationCube)
-                return
-
             # Build the annotated cube actor with anatomical labels.
             cube = vtkAnnotatedCubeActor()
-            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)  # L – Left
-            cube.GetXMinusFaceProperty().SetColor(1, 0, 0)  # R – Right
-            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)  # P – Posterior
-            cube.GetYMinusFaceProperty().SetColor(0, 1, 0)  # A – Anterior
-            cube.GetZPlusFaceProperty().SetColor(0, 0, 1)  # T – Top
-            cube.GetZMinusFaceProperty().SetColor(0, 0, 1)  # B – Bottom
-            cube.GetTextEdgesProperty().SetColor(0, 0, 0)
+
+            # Canonical anatomical mapping:
+            # X axis -> Left/Right, Y axis -> Posterior/Anterior, Z axis -> Top/Bottom.
+            # With VOL_FRONT camera (0, -1, 0), the Y- face is visible => "A".
+            cube.GetXPlusFaceProperty().SetColor(0.7, 0.1, 0.1)   # L – Left
+            cube.GetXMinusFaceProperty().SetColor(0.7, 0.1, 0.1)  # R – Right
+            cube.GetYPlusFaceProperty().SetColor(0.1, 0.7, 0.1)   # P – Posterior
+            cube.GetYMinusFaceProperty().SetColor(0.1, 0.7, 0.1)  # A – Anterior
+            cube.GetZPlusFaceProperty().SetColor(0.1, 0.1, 0.7)   # T – Top
+            cube.GetZMinusFaceProperty().SetColor(0.1, 0.1, 0.7)  # B – Bottom
+            cube.GetTextEdgesProperty().SetColor(0.5, 0.5, 0.5)
+
             cube.SetXPlusFaceText(_("L"))
             cube.SetXMinusFaceText(_("R"))
             cube.SetYPlusFaceText(_("P"))
             cube.SetYMinusFaceText(_("A"))
-            cube.SetZPlusFaceText(_("T"))
-            cube.SetZMinusFaceText(_("B"))
+            # Decouple T/B from vtkAnnotatedCubeActor shared Z-face rotation.
+            # Keep cube Z faces colorized, but draw T/B as independent 3D text actors.
+            cube.SetZPlusFaceText("")
+            cube.SetZMinusFaceText("")
+
+            # Wrap in vtkAssembly to ensure the orientation is preserved.
+            assembly = vtkAssembly()
+            assembly.AddPart(cube)
+
+            def _make_face_text_actor(text: str, z_pos: float, rotate_x: float) -> vtkActor:
+                text_source = vtkVectorText()
+                text_source.SetText(text)
+
+                text_mapper = vtkPolyDataMapper()
+                text_mapper.SetInputConnection(text_source.GetOutputPort())
+
+                text_actor = vtkActor()
+                text_actor.SetMapper(text_mapper)
+                text_actor.SetScale(0.22, 0.22, 0.22)
+                text_actor.SetPosition(-0.07, -0.08, z_pos)
+                text_actor.RotateX(rotate_x)
+                text_actor.GetProperty().SetColor(0.1, 0.1, 0.7)
+                text_actor.GetProperty().SetAmbient(1.0)
+                text_actor.GetProperty().SetDiffuse(0.0)
+                text_actor.GetProperty().BackfaceCullingOff()
+                text_actor.PickableOff()
+                return text_actor
+
+            top_text_actor = _make_face_text_actor("T", 0.53, 0.0)
+            # Independent orientation for B, no dependency on T.
+            bottom_text_actor = _make_face_text_actor("B", -0.53, 180.0)
+            assembly.AddPart(top_text_actor)
+            assembly.AddPart(bottom_text_actor)
 
             widget = vtkOrientationMarkerWidget()
-            widget.SetOrientationMarker(cube)
+            widget.SetOrientationMarker(assembly)
             widget.SetViewport(0.85, 0.0, 1.0, 0.15)  # Bottom-right corner
             widget.SetInteractor(self.interactor)
             widget.SetEnabled(1)
             widget.InteractiveOff()  # Fixed position – does not move with mouse
             self.orientation_widget = widget
-            self.UpdateRender()
+            
+            # Reset retries once successfully shown
             self._cube_retries = 0
+            self._UpdateOrientationCubeZTextRotation()
+            self.UpdateRender()
         except Exception as e:
             import logging
+            logging.error("Failed to show orientation cube: %s", e)
 
-            logging.warning("Could not create orientation cube: %s", e)
+    def _UpdateOrientationCubeZTextRotation(self):
+        """
+        Keep Z-face letters (T/B) upright.
+        VTK exposes one Z-face text rotation for both faces, so we adapt it based
+        on whether camera is below or above the focal point.
+        """
+        # No-op: T/B are now separate billboard labels with independent upright
+        # orientation, so no shared Z-face text rotation is needed.
+        return
 
     def OnInteractorEvent(self, sender, event):
         if self.canvas and self.ruler and self.ruler in self.canvas.draw_list:
@@ -3126,13 +3192,6 @@ class Viewer(wx.Panel):
         # use the 3D surface actor for measurement calculations
         self.surface = actor
 
-        # Now that the surface is added and the camera is positioned correctly,
-        # show the orientation cube by default and ensure the toolbar icon is active.
-        # We use wx.CallLater (150ms delay) to let the heavy VTK pipeline finish its
-        # current render pass and un-freeze the UI before attaching the overlay widget,
-        # ensuring it displays immediately without requiring a physical click.
-        Publisher.sendMessage("Set orientation cube state", status=True)
-        wx.CallLater(150, self._ShowOrientationCube)
         self.EnableRuler()
 
         # Apply SSAO if enabled in preferences (for newly created surfaces)
@@ -3492,6 +3551,9 @@ class Viewer(wx.Panel):
         cube.SetYMinusFaceText("A")
         cube.SetZPlusFaceText("T")
         cube.SetZMinusFaceText("B")
+        # Keep A/P/L/R exactly as-is; only rotate Z-face text so T/B render upright.
+        if hasattr(cube, "SetZFaceTextRotation"):
+            cube.SetZFaceTextRotation(90)
 
         axes = vtkAxesActor()
         axes.SetShaftTypeToCylinder()
@@ -3511,6 +3573,7 @@ class Viewer(wx.Panel):
         orientation_widget.InteractiveOff()
 
     def UpdateRender(self):
+        self._UpdateOrientationCubeZTextRotation()
         self.interactor.Render()
         if self.fps_text.actor.GetVisibility():
             end = time.monotonic()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -433,8 +433,10 @@ class Viewer(wx.Panel):
         if not self.surface_added:
             # Surface not yet present – notify user and revert toolbar state
             from invesalius.gui.utils import show_warning
+
             show_warning(
-                _("Orientation Cube"), _("The orientation cube can only be displayed on the 3D surface.")
+                _("Orientation Cube"),
+                _("The orientation cube can only be displayed on the 3D surface."),
             )
             # Revert the toolbar to "True" to ensure the feature stays enabled
             # by default and will auto-show once the surface is finally created.
@@ -469,11 +471,11 @@ class Viewer(wx.Panel):
 
             # Build the annotated cube actor with anatomical labels.
             cube = vtkAnnotatedCubeActor()
-            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)   # A – Anterior
+            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)  # A – Anterior
             cube.GetXMinusFaceProperty().SetColor(1, 0, 0)  # P – Posterior
-            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)   # L – Left
+            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)  # L – Left
             cube.GetYMinusFaceProperty().SetColor(0, 1, 0)  # R – Right
-            cube.GetZPlusFaceProperty().SetColor(0, 0, 1)   # T – Top
+            cube.GetZPlusFaceProperty().SetColor(0, 0, 1)  # T – Top
             cube.GetZMinusFaceProperty().SetColor(0, 0, 1)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0, 0, 0)
             cube.SetXPlusFaceText(_("A"))
@@ -494,6 +496,7 @@ class Viewer(wx.Panel):
             self._cube_retries = 0
         except Exception as e:
             import logging
+
             logging.warning("Could not create orientation cube: %s", e)
 
     def OnInteractorEvent(self, sender, event):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -114,8 +114,10 @@ if sys.platform == "win32":
 
         _has_win32api = True
     except ImportError:
+        win32api = None  # type: ignore[assignment]
         _has_win32api = False
 else:
+    win32api = None  # type: ignore[assignment]
     _has_win32api = False
 
 PROP_MEASURE = 0.8
@@ -213,16 +215,8 @@ class Viewer(wx.Panel):
         # Enable canvas for ruler to be drawn
         self.canvas = CanvasRendererCTX(self, self.ren, self.canvas_renderer)
         self.prev_view_port_height = None
-        # self.canvas.draw_list.append(self.text)
-        # self.canvas.draw_list.append(self.polygon)
-        # axes = vtkAxesActor()
-        # axes.SetXAxisLabelText('x')
-        # axes.SetYAxisLabelText('y')
-        # axes.SetZAxisLabelText('z')
-        # axes.SetTotalLength(50, 50, 50)
-        #
-        # self.ren.AddActor(axes)
         self.ruler = None
+        self.orientation_widget = None  # VTK orientation cube widget
 
         self.slice_plane = None
 
@@ -387,6 +381,9 @@ class Viewer(wx.Panel):
 
         Publisher.sendMessage("Press target mode button", pressed=False)
         self._update_fps_visibility()
+        # NOTE: We do NOT request the cube here. The cube must only appear
+        # after a 3D surface is loaded so that the camera is already in the
+        # correct position. See AddSurface for the actual trigger.
 
     def _update_fps_visibility(self):
         show_fps = (
@@ -428,6 +425,76 @@ class Viewer(wx.Panel):
 
     def OnShowRuler(self):
         self.ShowRuler()
+
+    def OnShowOrientationCube(self, status):
+        """
+        Receive the requested visibility state for the orientation cube.
+        """
+        if not self.surface_added:
+            # Surface not yet present – notify user and revert toolbar state
+            from invesalius.gui.utils import show_warning
+            show_warning(
+                _("Orientation Cube"), _("The orientation cube can only be displayed on the 3D surface.")
+            )
+            # Revert the toolbar to "True" to ensure the feature stays enabled
+            # by default and will auto-show once the surface is finally created.
+            Publisher.sendMessage("Set orientation cube state", status=True)
+            return
+
+        if status:
+            self._ShowOrientationCube()
+        else:
+            if self.orientation_widget is not None:
+                self.orientation_widget.SetEnabled(0)
+                self.UpdateRender()
+
+    def _ShowOrientationCube(self):
+        """
+        Build (if necessary) and show the vtkOrientationMarkerWidget.
+        """
+        try:
+            if self.orientation_widget is not None:
+                self.orientation_widget.SetEnabled(1)
+                self.orientation_widget.InteractiveOff()
+                self.UpdateRender()
+                return
+
+            if not self.interactor or not self.interactor.GetInitialized():
+                # Interactor not ready yet – retry up to 10 times.
+                retries = getattr(self, "_cube_retries", 0)
+                if retries < 10:
+                    self._cube_retries = retries + 1
+                    wx.CallLater(200, self._ShowOrientationCube)
+                return
+
+            # Build the annotated cube actor with anatomical labels.
+            cube = vtkAnnotatedCubeActor()
+            cube.GetXPlusFaceProperty().SetColor(1, 0, 0)   # A – Anterior
+            cube.GetXMinusFaceProperty().SetColor(1, 0, 0)  # P – Posterior
+            cube.GetYPlusFaceProperty().SetColor(0, 1, 0)   # L – Left
+            cube.GetYMinusFaceProperty().SetColor(0, 1, 0)  # R – Right
+            cube.GetZPlusFaceProperty().SetColor(0, 0, 1)   # T – Top
+            cube.GetZMinusFaceProperty().SetColor(0, 0, 1)  # B – Bottom
+            cube.GetTextEdgesProperty().SetColor(0, 0, 0)
+            cube.SetXPlusFaceText(_("A"))
+            cube.SetXMinusFaceText(_("P"))
+            cube.SetYPlusFaceText(_("L"))
+            cube.SetYMinusFaceText(_("R"))
+            cube.SetZPlusFaceText(_("T"))
+            cube.SetZMinusFaceText(_("B"))
+
+            widget = vtkOrientationMarkerWidget()
+            widget.SetOrientationMarker(cube)
+            widget.SetViewport(0.85, 0.0, 1.0, 0.15)  # Bottom-right corner
+            widget.SetInteractor(self.interactor)
+            widget.SetEnabled(1)
+            widget.InteractiveOff()  # Fixed position – does not move with mouse
+            self.orientation_widget = widget
+            self.UpdateRender()
+            self._cube_retries = 0
+        except Exception as e:
+            import logging
+            logging.warning("Could not create orientation cube: %s", e)
 
     def OnInteractorEvent(self, sender, event):
         if self.canvas and self.ruler and self.ruler in self.canvas.draw_list:
@@ -478,6 +545,7 @@ class Viewer(wx.Panel):
         Publisher.subscribe(self.OnShowRuler, "Show rulers on viewers")
         Publisher.subscribe(self.OnHideRuler, "Hide rulers on viewers")
         Publisher.subscribe(self.OnRulerVisibilityStatus, "Receive ruler visibility status")
+        Publisher.subscribe(self.OnShowOrientationCube, "Show orientation cube")
         Publisher.subscribe(self.OnCloseProject, "Close project data")
 
         Publisher.subscribe(self.RemoveAllActors, "Remove all volume actors")
@@ -830,6 +898,15 @@ class Viewer(wx.Panel):
             )
 
     def OnCloseProject(self):
+        # Disable the orientation cube widget cleanly to prevent visualization
+        # artifacts across projects, but leave the object intact so the Python
+        # GC can clean it up safely during application exit without segfaulting.
+        if self.orientation_widget is not None:
+            try:
+                self.orientation_widget.SetEnabled(0)
+            except Exception:
+                pass
+
         if self.raycasting_volume:
             self.raycasting_volume = False
 
@@ -3009,11 +3086,6 @@ class Viewer(wx.Panel):
         else:
             ren.ResetCamera()
             ren.ResetCameraClippingRange()
-
-            # XXX: This is a hack to get some decent initial settings for the camera, needed when
-            #   a session is restored when a target is already set. (When unsetting the target, the
-            #   camera settings will be restored from self.stored_camera_settings, hence we need
-            #   to ensure that these settings can be used.)
             self.stored_camera_settings = self.GetCameraSettings()
         if not self.nav_status:
             self.UpdateRender()
@@ -3023,6 +3095,14 @@ class Viewer(wx.Panel):
 
         # use the 3D surface actor for measurement calculations
         self.surface = actor
+
+        # Now that the surface is added and the camera is positioned correctly,
+        # show the orientation cube by default and ensure the toolbar icon is active.
+        # We use wx.CallLater (150ms delay) to let the heavy VTK pipeline finish its
+        # current render pass and un-freeze the UI before attaching the overlay widget,
+        # ensuring it displays immediately without requiring a physical click.
+        Publisher.sendMessage("Set orientation cube state", status=True)
+        wx.CallLater(150, self._ShowOrientationCube)
         self.EnableRuler()
 
         # Apply SSAO if enabled in preferences (for newly created surfaces)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -380,10 +380,6 @@ class Viewer(wx.Panel):
 
         print(len(self.renderers))
 
-        # Set default view angle to Anterior (Front) so orientation cube shows "A"
-        # even before data is loaded.
-        self.SetViewAngle(const.VOL_FRONT)
-
         Publisher.sendMessage("Press target mode button", pressed=False)
         self._update_fps_visibility()
         # Request the orientation cube visibility status with a small delay
@@ -465,7 +461,7 @@ class Viewer(wx.Panel):
                     except Exception:
                         pass
                     self._cube_render_observer_tag = None
-                self.UpdateRender()
+            self.UpdateRender()
 
     def _ShowOrientationCube(self):
         """
@@ -3345,7 +3341,7 @@ class Viewer(wx.Panel):
             self.ren.RemoveVolume(mask_3d_actor)
 
         if flag:
-            if not self.view_angle:
+            if not self.surface_added:
                 proj = prj.Project()
                 modality = str(getattr(proj, "modality", "CT")).upper()
                 if modality in ["MRI", "MR"]:
@@ -3359,6 +3355,8 @@ class Viewer(wx.Panel):
             # matrix for the 3D mask editor (fixes #1086 – "Edit in 3D" without a
             # surface generated first).
             self.ren.GetActiveCamera().ParallelProjectionOn()
+
+        self.UpdateRender()
 
     def remove_mask_preview(self, mask_3d_actor):
         self.ren.RemoveVolume(mask_3d_actor)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -2572,7 +2572,7 @@ class LayoutToolBar(AuiToolBar):
         self.ontool_layout = False
         self.ontool_text = True
         self.ontool_ruler = True
-        self.ontool_orientation_cube = True  # visible by default
+        self.ontool_orientation_cube = False  # hidden by default; click icon to show
 
         self.Realize()
         self.SetStateProjectClose()
@@ -2656,7 +2656,7 @@ class LayoutToolBar(AuiToolBar):
             self.BMP_ORIENTATION_CUBE,
             wx.NullBitmap,
             wx.ITEM_NORMAL,
-            short_help_string=_("Hide orientation cube"),
+            short_help_string=_("Show orientation cube"),
         )
 
     def _EnableState(self, state):

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -57,6 +57,8 @@ except ImportError:
 # Layout tools' IDs - this is used only locally, therefore doesn't
 # need to be defined in constants.py
 VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range(3)]
+# ID_ORIENTATION_CUBE is defined globally in constants.py because it is used
+# both in the LayoutToolBar and in the MenuBar.
 
 # Custom IDs for our new menu items
 [ID_SHOW_LOG_VIEWER, ID_INTERACTIVE_SHELL] = [wx.NewIdRef() for number in range(2)]
@@ -250,6 +252,7 @@ class Frame(wx.Frame):
 
         # For all other keys, continue with the normal event handling (propagate the event).
         event.Skip()
+
 
     def __init_aui(self):
         """
@@ -1719,6 +1722,7 @@ class MenuBar(wx.MenuBar):
         v = self.NavigationModeStatus()
         self.mode_menu.Check(const.ID_MODE_NAVIGATION, v)
 
+
     def AddPluginsItems(self, items):
         for menu_item in self.plugins_menu.GetMenuItems():
             if menu_item.GetId() != const.ID_PLUGINS_SHOW_PATH:
@@ -2539,7 +2543,7 @@ class LayoutToolBar(AuiToolBar):
         self.SetToolBitmapSize(wx.Size(32, 32))
 
         self.parent = parent
-        self.enable_items = [ID_LAYOUT, ID_TEXT, ID_RULER]
+        self.enable_items = [ID_LAYOUT, ID_TEXT, ID_RULER, const.ID_ORIENTATION_CUBE]
         self.__init_items()
         self.__bind_events()
         self.__bind_events_wx()
@@ -2547,6 +2551,7 @@ class LayoutToolBar(AuiToolBar):
         self.ontool_layout = False
         self.ontool_text = True
         self.ontool_ruler = True
+        self.ontool_orientation_cube = True  # visible by default
 
         self.Realize()
         self.SetStateProjectClose()
@@ -2560,6 +2565,8 @@ class LayoutToolBar(AuiToolBar):
         sub(self._SetLayoutWithTask, "Set layout button data only")
         sub(self._SetLayoutWithoutTask, "Set layout button full")
         sub(self._SendRulerVisibilityStatus, "Send ruler visibility status")
+        sub(self._SendOrientationCubeVisibilityStatus, "Send orientation cube visibility status")
+        sub(self._SetOrientationCubeState, "Set orientation cube state")
 
     def __bind_events_wx(self):
         """
@@ -2594,6 +2601,10 @@ class LayoutToolBar(AuiToolBar):
         p = os.path.join(d, "ruler_original_enabled.png")
         self.BMP_WITH_RULER = wx.Bitmap(str(p), wx.BITMAP_TYPE_PNG)
 
+        # Bitmaps for showing/hiding the orientation cube.
+        p = os.path.join(d, "view_isometric.png")
+        self.BMP_ORIENTATION_CUBE = wx.Bitmap(str(p), wx.BITMAP_TYPE_PNG)
+
         self.AddTool(
             ID_LAYOUT,
             "",
@@ -2617,6 +2628,14 @@ class LayoutToolBar(AuiToolBar):
             wx.NullBitmap,
             wx.ITEM_NORMAL,
             short_help_string=_("Hide ruler"),
+        )
+        self.AddTool(
+            const.ID_ORIENTATION_CUBE,
+            "",
+            self.BMP_ORIENTATION_CUBE,
+            wx.NullBitmap,
+            wx.ITEM_NORMAL,
+            short_help_string=_("Hide orientation cube"),
         )
 
     def _EnableState(self, state):
@@ -2656,6 +2675,13 @@ class LayoutToolBar(AuiToolBar):
             self.ToggleText()
         elif id == ID_RULER:
             self.ToggleRulers()
+        elif id == const.ID_ORIENTATION_CUBE:
+            # The cube button is wx.ITEM_NORMAL (not a toggle button), so it
+            # is NOT in VIEW_TOOLS.  Consume the event without Skip() so that
+            # the EVT_TOOL does not propagate up the wx window hierarchy and
+            # get re-dispatched a second time by the AUI manager on macOS.
+            self.ToggleOrientationCube()
+            return  # consume – do NOT call event.Skip()
 
         for item in VIEW_TOOLS:
             state = self.GetToolToggled(item)
@@ -2730,20 +2756,92 @@ class LayoutToolBar(AuiToolBar):
         else:
             self.ShowRulers()
 
+    def ShowOrientationCube(self):
+        """
+        Show the orientation cube in the volume viewer.
+        """
+        # Set state FIRST before any messages fire so that if 'Enable state
+        # project' is re-entrant (via PubSub or wx event), the flag is correct.
+        self.ontool_orientation_cube = True
+        Publisher.sendMessage("Show orientation cube", status=True)
+        self.SetToolShortHelp(
+            const.ID_ORIENTATION_CUBE,
+            _("Hide orientation cube"),
+        )
+        Publisher.sendMessage("Update AUI")
+
+    def HideOrientationCube(self):
+        """
+        Hide the orientation cube in the volume viewer.
+        """
+        # Set state FIRST so any re-entrant calls see the correct flag.
+        self.ontool_orientation_cube = False
+        Publisher.sendMessage("Show orientation cube", status=False)
+        self.SetToolShortHelp(
+            const.ID_ORIENTATION_CUBE,
+            _("Show orientation cube"),
+        )
+        Publisher.sendMessage("Update AUI")
+
+    def ToggleOrientationCube(self):
+        """
+        Toggle orientation cube visibility.
+        """
+        if self.ontool_orientation_cube:
+            self.HideOrientationCube()
+        else:
+            self.ShowOrientationCube()
+
+    def _SendOrientationCubeVisibilityStatus(self):
+        """
+        Called by viewer_volume when it is ready. Sends the current toolbar
+        state so the viewer initialises in the correct visibility state.
+        """
+        Publisher.sendMessage("Show orientation cube", status=self.ontool_orientation_cube)
+
+    def _SetOrientationCubeState(self, status):
+        """
+        Update the internal state and toolbar tooltip to match the given status
+        WITHOUT firing another update message (used by viewer_volume when
+        rejecting a request).
+        """
+        self.ontool_orientation_cube = status
+        self.SetToolShortHelp(
+            const.ID_ORIENTATION_CUBE,
+            _("Hide orientation cube") if status else _("Show orientation cube"),
+        )
+        Publisher.sendMessage("Update AUI")
+
     def SetStateProjectClose(self):
         """
-        Disable menu items (e.g. text) when project is closed.
+        Disable toolbar items when project is closed.
+        The orientation cube state (ontool_orientation_cube) is intentionally
+        NOT reset here so the user preference survives across project open/close.
         """
         self.ontool_text = True
         self.ontool_ruler = True
         self.ToggleText()
         self.HideRulers()
+        # Just disable the tool button visually; do NOT call HideOrientationCube()
+        # because that would flip ontool_orientation_cube to False, causing the
+        # cube to stay hidden when the next project is opened.
         for tool in self.enable_items:
             self.EnableTool(tool, False)
 
     def SetStateProjectOpen(self):
         """
-        Disable menu items (e.g. text) when project is closed.
+        Enable toolbar items when a project is opened.
+
+        NOTE: We deliberately do NOT call ShowOrientationCube/HideOrientationCube
+        here.  This method is triggered by 'Enable state project' which can fire
+        many times during normal operation (surface load, scan operations, etc.).
+        Calling Show/Hide here caused a race condition: the state flag could still
+        be stale when this fires mid-way through a toggle, causing the cube to
+        appear for a brief moment and then disappear.
+
+        Instead, the cube visibility lifecycle is managed solely by:
+          1. viewer_volume.AddSurface  (auto-shows on first surface)
+          2. LayoutToolBar.ToggleOrientationCube  (user click on icon)
         """
         self.ontool_text = False
         self.ontool_ruler = True

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -253,7 +253,6 @@ class Frame(wx.Frame):
         # For all other keys, continue with the normal event handling (propagate the event).
         event.Skip()
 
-
     def __init_aui(self):
         """
         Build AUI manager and all panels inside InVesalius frame.
@@ -1722,7 +1721,6 @@ class MenuBar(wx.MenuBar):
         v = self.NavigationModeStatus()
         self.mode_menu.Check(const.ID_MODE_NAVIGATION, v)
 
-
     def AddPluginsItems(self, items):
         for menu_item in self.plugins_menu.GetMenuItems():
             if menu_item.GetId() != const.ID_PLUGINS_SHOW_PATH:
@@ -2810,7 +2808,6 @@ class LayoutToolBar(AuiToolBar):
             const.ID_ORIENTATION_CUBE,
             _("Hide orientation cube") if status else _("Show orientation cube"),
         )
-        Publisher.sendMessage("Update AUI")
 
     def SetStateProjectClose(self):
         """


### PR DESCRIPTION
### Fixes: #1334 

### Summary

This PR introduces a stable, user-controlled 3D Orientation Reference Cube to the Volume Viewer, fulfilling maintainer requests for usability.


### Changes 

**Toolbar Integration:** Added a dedicated toolbar button next to the Ruler tool to cleanly toggle the cube.
Default Loading behavior: The cube now unconditionally displays by default alongside any newly generated 3D surface (such as the skull).
**UX Guardrails:** Implemented a warning dialog if the user clicks the cube icon without a 3D surface loaded. The UI state is cleanly preserved and synced so that it still auto-shows if the user later loads the 3D surface.

**Mac / Pipeline Fixes:** Replaced synchronous initialisation with a 150ms wx.CallLater delay so the heavy UI render loop can unfreeze before placing the overlay widget on the screen, verifying it shows without user interaction.

**Exit Stability:** Stopped explicitly destroying vtkOrientationMarkerWidget's interactor on exit, completely eliminating the exit segmentation faults.

### Testing:

- Verified the orientation cube default visibility immediately upon 3D surface generation.
- Checked that premature clicks display the correct warning dialog and safely revert visually.
- Confirmed no flickering, double-toggles, or UI freezes across multiple manual toggles.
- Verified that closing projects/exiting does not cause terminal panics.


### After Changes:


https://github.com/user-attachments/assets/c2d1f02e-4126-4b4d-8c96-98d2d1a3be70




