### PR TITLE
test: Add test coverage for VTP export functionality

### DIFF
--- a/tests/test_vtp_export.py
+++ b/tests/test_vtp_export.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+import wx
+from vtkmodules.vtkIOXML import vtkXMLPolyDataReader
+
+import invesalius.constants as const
+from invesalius.data.surface import SurfaceManager
+from tests.test_stl_export import surface_manager_with_surfaces, clean_project
+
+
+@pytest.fixture(scope="module", autouse=True)
+def wx_app():
+    app = wx.GetApp() or wx.App(False)
+    yield app
+
+
+def test_export_surface_to_vtp(surface_manager_with_surfaces, tmp_path: Path) -> None:
+    surface_manager, _ = surface_manager_with_surfaces
+
+    filename = tmp_path / "exported_surface.vtp"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_VTP, convert_to_world=False)
+
+    assert os.path.exists(filename), f"VTP file not created: {filename}"
+    assert os.path.getsize(filename) > 0, f"VTP file is empty: {filename}"
+
+    reader = vtkXMLPolyDataReader()
+    reader.SetFileName(str(filename))
+    reader.Update()
+    mesh = reader.GetOutput()
+
+    assert mesh.GetNumberOfPoints() > 0, "Exported mesh has no points"
+    assert mesh.GetNumberOfCells() > 0, "Exported mesh has no cells"
+
+
+def test_export_surface_empty_project(clean_project, tmp_path: Path) -> None:
+    surface_manager = SurfaceManager()
+
+    filename = tmp_path / "empty_export.vtp"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_VTP, convert_to_world=False)
+
+    assert not os.path.exists(filename), "File should not be created when no surfaces are visible"
+
+
+def test_export_surface_multiple_visible(surface_manager_with_surfaces, tmp_path: Path) -> None:
+    surface_manager, project = surface_manager_with_surfaces
+
+    for index in project.surface_dict:
+        project.surface_dict[index].is_shown = True
+
+    filename = tmp_path / "multiple_surfaces.vtp"
+
+    surface_manager._export_surface(str(filename), const.FILETYPE_VTP, convert_to_world=False)
+
+    assert os.path.exists(filename), f"VTP file not created: {filename}"
+    assert os.path.getsize(filename) > 0, f"VTP file is empty: {filename}"
+
+    reader = vtkXMLPolyDataReader()
+    reader.SetFileName(str(filename))
+    reader.Update()
+    mesh = reader.GetOutput()
+
+    assert mesh.GetNumberOfPoints() > 0, "Exported mesh has no points"
+    assert mesh.GetNumberOfCells() > 0, "Exported mesh has no cells"


### PR DESCRIPTION
# Add Test Coverage for VTP Export Functionality

## Summary

This PR adds test coverage for the VTP (VTK PolyData XML) export functionality in InVesalius, following the same structure and approach used for STL and PLY export tests.

---

## Changes

- Added new test file: `tests/test_vtp_export.py`
- Implemented three test cases:
  - Export of a visible surface to VTP format  
  - Handling export when no surfaces are visible  
  - Export of multiple visible surfaces into a single VTP file  

---

## Implementation Details

- Reused existing fixtures:
  - `surface_manager_with_surfaces`
  - `clean_project`
- Used `vtkXMLPolyDataReader` to validate exported geometry
- Verified:
  - File creation
  - Non-zero file size
  - Mesh integrity (points and cells)
- Ensured tests run in a headless environment (CI-compatible)

---

## Test Results
tests/test_vtp_export.py::test_export_surface_to_vtp PASSED
tests/test_vtp_export.py::test_export_surface_empty_project PASSED
tests/test_vtp_export.py::test_export_surface_multiple_visible PASSED

==================== 3 passed in ~5s ====================


---

## Impact

- Improves reliability of VTP export functionality  
- Prevents regressions in future changes  
- Maintains consistency across export format tests (STL, PLY, VTP)  

---

## Notes

- No changes to production code (tests only)  
- Remaining formats without test coverage:
  - OBJ
  - VRML
  - X3D
  - RIB
  - IV  


