### PR TITLE
fix (#1349): Prevent multiple annotation edit dialogs on double-click in Measurements tab

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -149,6 +149,7 @@ class MeasurementManager:
     def __init__(self):
         self.current = None
         self.measures = MeasureData()
+        self._editing_annotation = False
         self._bind_events()
 
     def _bind_events(self):
@@ -174,6 +175,11 @@ class MeasurementManager:
         """Handle edit requests (e.g. double click in GUI list)."""
         if index < 0 or index >= len(self.measures):
             return
+
+        # Prevent re-entry while a dialog is already open
+        if self._editing_annotation:
+            return
+
         m, mr = self.measures[index]
 
         # Synchronize visualization: only update the slice where this measurement lives.
@@ -195,37 +201,43 @@ class MeasurementManager:
 
             from invesalius.gui.dialogs import AnnotationDialog
 
-            dlg = AnnotationDialog()
-            dlg.txt_annotation.SetValue(m.value)  # Pre-fill with existing text
-            result = dlg.ShowModal()
-            annotation_text = dlg.GetValue()
-            dlg.Destroy()
+            # Set flag to prevent re-entry
+            self._editing_annotation = True
+            try:
+                dlg = AnnotationDialog()
+                dlg.txt_annotation.SetValue(m.value)  # Pre-fill with existing text
+                result = dlg.ShowModal()
+                annotation_text = dlg.GetValue()
+                dlg.Destroy()
 
-            if result == wx.ID_OK and annotation_text and annotation_text != m.value:
-                m.value = annotation_text
-                mr.SetText(annotation_text)
+                if result == wx.ID_OK and annotation_text and annotation_text != m.value:
+                    m.value = annotation_text
+                    mr.SetText(annotation_text)
 
-                # Update GUI list
-                loc_ = LOCATION[m.location]
-                Publisher.sendMessage(
-                    "Update measurement info in GUI",
-                    index=m.index,
-                    name=m.name,
-                    colour=m.colour,
-                    location=loc_,
-                    type_=TYPE[m.type],
-                    value=annotation_text,
-                )
+                    # Update GUI list
+                    loc_ = LOCATION[m.location]
+                    Publisher.sendMessage(
+                        "Update measurement info in GUI",
+                        index=m.index,
+                        name=m.name,
+                        colour=m.colour,
+                        location=loc_,
+                        type_=TYPE[m.type],
+                        value=annotation_text,
+                    )
 
-                # Redraw
-                if m.location == const.SURFACE:
-                    Publisher.sendMessage("Render volume viewer")
-                else:
-                    Publisher.sendMessage("Redraw canvas")
+                    # Redraw
+                    if m.location == const.SURFACE:
+                        Publisher.sendMessage("Render volume viewer")
+                    else:
+                        Publisher.sendMessage("Redraw canvas")
 
-                # Mark project as modified
-                session = ses.Session()
-                session.ChangeProject()
+                    # Mark project as modified
+                    session = ses.Session()
+                    session.ChangeProject()
+            finally:
+                # Always clear the flag, even if an exception occurs
+                self._editing_annotation = False
 
     def _load_measurements(self, measurement_dict, spacing=(1.0, 1.0, 1.0)):
         for i in measurement_dict:

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -2025,6 +2025,8 @@ class MeasuresListCtrlPanel(InvListCtrl):
     ):
         super().__init__(parent, ID, pos, size, style=style)
         self._click_check = False
+        self._last_edit_index = None
+        self._last_edit_time = 0
         self.__init_columns()
         self.__init_image_list()
         self.__init_evt()
@@ -2068,10 +2070,17 @@ class MeasuresListCtrlPanel(InvListCtrl):
         evt.Skip()
 
     def OnDblClickItem(self, evt):
+        import time
+
         item_idx, flag = self.HitTest(evt.GetPosition())
         if item_idx > -1:
-            Publisher.sendMessage("Edit measurement", index=item_idx)
-        evt.Skip()
+            current_time = time.time()
+            # Prevent duplicate edit calls within 500ms for the same item
+            if self._last_edit_index != item_idx or current_time - self._last_edit_time > 0.5:
+                self._last_edit_index = item_idx
+                self._last_edit_time = current_time
+                Publisher.sendMessage("Edit measurement", index=item_idx)
+        # Don't call evt.Skip() to prevent the event from propagating to OnItemActivated
 
     def __init_evt(self):
         Publisher.subscribe(self.AddItem_, "Update measurement info in GUI")
@@ -2091,8 +2100,16 @@ class MeasuresListCtrlPanel(InvListCtrl):
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnItemActivated)
 
     def OnItemActivated(self, evt):
+        import time
+
         # Kept for redundancy on some platforms
-        Publisher.sendMessage("Edit measurement", index=evt.GetIndex())
+        item_idx = evt.GetIndex()
+        current_time = time.time()
+        # Prevent duplicate edit calls within 500ms for the same item
+        if self._last_edit_index != item_idx or current_time - self._last_edit_time > 0.5:
+            self._last_edit_index = item_idx
+            self._last_edit_time = current_time
+            Publisher.sendMessage("Edit measurement", index=item_idx)
 
     def OnKeyEvent(self, event):
         keycode = event.GetKeyCode()


### PR DESCRIPTION
### Fixes #1349

## Overview
This PR fixes an issue where the annotation edit dialog was opening multiple times (typically 3 times) when double-clicking an item in the Measurements tab.

## Root Cause
The issue was caused by:
1. Event propagation: `OnDblClickItem` was calling `evt.Skip()`, allowing the event to propagate and trigger `OnItemActivated`
2. Lack of re-entry protection in the edit handler, allowing multiple dialogs to be created

## Fix Implemented

### 1. Event Propagation Control
- Removed `evt.Skip()` from `OnDblClickItem` to prevent duplicate event triggering

### 2. Debounce Mechanism
- Added debounce logic (~500ms) in:
  - `OnDblClickItem`
  - `OnItemActivated`
- Introduced:
  - `_last_edit_index`
  - `_last_edit_time`

### 3. Re-entry Guard (Defense Layer)
- Added `_editing_annotation` flag in `MeasurementManager`
- Wrapped `_edit_measurement` with a `try/finally` block to prevent multiple dialog instances

## Files Modified
- `invesalius/gui/data_notebook.py`
- `invesalius/data/measures.py`

## Result
- The annotation edit dialog now opens exactly once per double-click
- Behavior is consistent across different platforms and wxPython versions

## Testing
- Verified double-click behavior in Measurements tab
- Confirmed no duplicate dialogs appear
- Ensured no regression in annotation editing functionality

## Notes
This fix uses a defense-in-depth approach:
1. Stop event propagation
2. Debounce duplicate triggers
3. Prevent handler re-entry

This ensures robustness even if future event handling changes occur.