### PR TITLE
fix (#1347): Preserve visibility (eye) icon for all measurements and annotations

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -1006,10 +1006,14 @@ class LinearMeasure:
         self.renderer = renderer
 
     def SetVisibility(self, v):
-        self.point_actor1.SetVisibility(v)
-        self.point_actor2.SetVisibility(v)
-        self.line_actor.SetVisibility(v)
-        self.text_actor.SetVisibility(v)
+        if self.point_actor1:
+            self.point_actor1.SetVisibility(v)
+        if self.point_actor2:
+            self.point_actor2.SetVisibility(v)
+        if self.line_actor:
+            self.line_actor.SetVisibility(v)
+        if self.text_actor:
+            self.text_actor.SetVisibility(v)
 
     def GetActors(self):
         """
@@ -1707,11 +1711,16 @@ class AngularMeasure:
             return 0.0
 
     def SetVisibility(self, v):
-        self.point_actor1.SetVisibility(v)
-        self.point_actor2.SetVisibility(v)
-        self.point_actor3.SetVisibility(v)
-        self.line_actor.SetVisibility(v)
-        self.text_actor.SetVisibility(v)
+        if self.point_actor1:
+            self.point_actor1.SetVisibility(v)
+        if self.point_actor2:
+            self.point_actor2.SetVisibility(v)
+        if self.point_actor3:
+            self.point_actor3.SetVisibility(v)
+        if self.line_actor:
+            self.line_actor.SetVisibility(v)
+        if self.text_actor:
+            self.text_actor.SetVisibility(v)
 
     def GetActors(self):
         """

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -2037,10 +2037,8 @@ class MeasuresListCtrlPanel(InvListCtrl):
         if image != -1:
             self.dict_visibility[item] = image
 
-        if self.IsSelected(item):
-            super().SetItemImage(item, image, info)
-        else:
-            super().SetItemImage(item, 0, info)
+        # Always show the visibility icon, regardless of selection state
+        super().SetItemImage(item, image, info)
 
     def OnClickItem(self, evt):
         self._click_check = False
@@ -2160,20 +2158,9 @@ class MeasuresListCtrlPanel(InvListCtrl):
         # Note: DON'T rename to OnItemSelected!!!
         # Otherwise the parent's method will be overwritten and other
         # things will stop working, e.g.: OnCheckItem
-
-        # last_index = evt.Index
-        #  Publisher.sendMessage('Change measurement selected',
-        #  last_index)
-
-        item = evt.GetIndex()
-        if item in self.dict_visibility:
-            super().SetItemImage(item, self.dict_visibility[item])
-
         evt.Skip()
 
     def OnItemDeselected_(self, evt):
-        item = evt.GetIndex()
-        super().SetItemImage(item, 0)
         evt.Skip()
 
     def GetSelected(self):


### PR DESCRIPTION
Fixes #1347 

## Overview

This PR fixes two related issues in the Measurements tab:

1. The visibility (eye) icon was only shown for the most recently created measurement/annotation
2. Toggling visibility could crash the application for incomplete measurements

Both issues affected usability and stability when working with multiple measurements.

---

## Issue 1: Eye Icon Not Persisting

### Root Cause

The visibility icon rendering was incorrectly tied to item selection in `MeasuresListCtrlPanel.SetItemImage`.

* Only selected items displayed the icon
* Creating a new measurement deselected previous ones → their icons disappeared

This coupled:

* Selection state (UI highlight)
* Visibility state (eye icon)

---

### Fix

* Updated `SetItemImage` to always display the correct icon, independent of selection
* Removed selection-based icon handling from:

  * `OnItemSelected_`
  * `OnItemDeselected_`

---

## Issue 2: Crash on Visibility Toggle

### Root Cause

Calling `SetVisibility` on measurements with uninitialized actors caused:

```
AttributeError: 'NoneType' object has no attribute 'SetVisibility'
```

This occurred in `LinearMeasure` and `AngularMeasure` when actors were `None`.

---

### Fix

* Added `None` checks before calling `SetVisibility`
* Applied consistent safety handling (aligned with `AnnotationMeasure`)

---

## Result

* All measurements and annotations consistently display their visibility (eye) icon
* Icon visibility is controlled only by user interaction (toggle)
* No crashes occur when toggling visibility, even for incomplete measurements
* Selection and visibility are now fully decoupled

---

## Files Modified

* `invesalius/gui/data_notebook.py` — Fixed visibility icon persistence
* `invesalius/data/measures.py` — Added None safety checks for actors

---

## Manual Testing

Tested with multiple scenarios:

* Created multiple measurements (5–10 items) → all retained eye icons
* Created multiple annotations → all retained eye icons
* Mixed measurements + annotations → consistent behavior
* Toggled visibility → works correctly without crashes
* Tested incomplete measurements → no crashes
* Changed selection → no impact on icon visibility

---

## Expected Behavior (Now Achieved)

* Every measurement/annotation always shows its eye icon
* Icon changes only when explicitly toggled by the user
* Selection does not affect icon visibility
* Visibility toggling is safe under all conditions

---

## Notes

This fix improves both UI consistency and application stability by:

* Decoupling selection from visibility rendering
* Adding defensive checks for partially initialized measurement objects
