### PR TITLE
Fix (#1354): Resolve Annotation Overwriting and Index Inconsistency in Measurements

### DIFF
--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -390,6 +390,7 @@ class MeasurementManager:
             return
         m, mr = self.current
         index = prj.Project().AddMeasurement(m)
+        m.index = index  # Update the measurement's index with the one from Project
         name = m.name
         colour = m.colour
         location = m.location
@@ -410,15 +411,19 @@ class MeasurementManager:
         else:
             value = str(m.value)
 
-        Publisher.sendMessage(
-            "Update measurement info in GUI",
-            index=index,
-            name=name,
-            colour=colour,
-            location=location_str,
-            type_=type_,
-            value=value,
-        )
+        # For annotations, don't send GUI update here - the dialog handler will do it
+        # This prevents duplicate entries in the measurements list
+        if type != const.ANNOTATION:
+            Publisher.sendMessage(
+                "Update measurement info in GUI",
+                index=index,
+                name=name,
+                colour=colour,
+                location=location_str,
+                type_=type_,
+                value=value,
+            )
+
         self.current = None
 
         if type == const.ANNOTATION and location == const.SURFACE:
@@ -638,7 +643,8 @@ class MeasurementManager:
 
         self.measures.append((m, density_measure))
 
-        # index = prj.Project().AddMeasurement(m)
+        index = prj.Project().AddMeasurement(m)
+        m.index = index  # Update with the correct index from Project
 
         msg = ("Update measurement info in GUI",)
         Publisher.sendMessage(


### PR DESCRIPTION
### Fixes #1354

### Summary

This PR fixes an index inconsistency where annotations could overwrite existing density measurements due to improper synchronization between the measures list and project dictionary.

---

### Problem

Creating measurements in order:

1. Linear
2. Density
3. Annotation

Resulted in the annotation overwriting the density measurement in the GUI.

---

### Root Cause

* Density measurements were not added to `project.measurement_dict`
* Annotations relied on dictionary length for index assignment
* This caused index collisions and UI inconsistency

---

### Solution

**1. Register Density Measurements**

```python
index = prj.Project().AddMeasurement(m)
m.index = index
```

**2. Prevent Duplicate GUI Updates (Annotations)**

```python
if type != const.ANNOTATION:
    Publisher.sendMessage(...)
```

**3. Ensure Index Synchronization**

```python
m.index = index
```

---

### Testing

* Linear → index 0
* Density → index 1
* Annotation → index 2

Verified:

* No overwriting
* No duplicate entries
* Correct ordering and data

---

### Impact

* Fixes index collision bug
* Ensures consistent measurement tracking
* Prevents UI data loss
* Improves system reliability
