### PR TITLE
Fix MRI 3D camera orientation for manual view resets

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -235,41 +235,41 @@ AXIAL_VOLUME_CAM_POSITION = {
 }
 
 SAGITAL_VOLUME_CAM_VIEW_UP = {
-    VOL_FRONT: (0, -1, 0),
-    VOL_BACK: (0, -1, 0),
-    VOL_RIGHT: (0, -1, 1),
-    VOL_LEFT: (0, -1, 1),
-    VOL_TOP: (1, -1, 0),
-    VOL_BOTTOM: (-1, 1, 0),
-    VOL_ISO: (0, -1, 0),
+    VOL_FRONT: (0, 0, 1),
+    VOL_BACK: (0, 0, 1),
+    VOL_RIGHT: (0, 0, 1),
+    VOL_LEFT: (0, 0, 1),
+    VOL_TOP: (0, 1, 0),
+    VOL_BOTTOM: (0, -1, 0),
+    VOL_ISO: (0, 0, 1),
 }
 SAGITAL_VOLUME_CAM_POSITION = {
-    VOL_FRONT: (-1, 0, 0),
-    VOL_BACK: (1, 0, 0),
-    VOL_RIGHT: (0, 0, 1),
-    VOL_LEFT: (0, 0, -1),
-    VOL_TOP: (0, -1, 0),
-    VOL_BOTTOM: (0, 1, 0),
-    VOL_ISO: (-1, -0.5, -0.5),
+    VOL_FRONT: (0, -1, 0),
+    VOL_BACK: (0, 1, 0),
+    VOL_RIGHT: (-1, 0, 0),
+    VOL_LEFT: (1, 0, 0),
+    VOL_TOP: (0, 0, 1),
+    VOL_BOTTOM: (0, 0, -1),
+    VOL_ISO: (0.5, -1, 0.5),
 }
 
 CORONAL_VOLUME_CAM_VIEW_UP = {
-    VOL_FRONT: (0, -1, 0),
-    VOL_BACK: (0, -1, 0),
-    VOL_RIGHT: (0, -1, 0),
-    VOL_LEFT: (0, -1, 0),
+    VOL_FRONT: (0, 0, 1),
+    VOL_BACK: (0, 0, 1),
+    VOL_RIGHT: (0, 0, 1),
+    VOL_LEFT: (0, 0, 1),
     VOL_TOP: (0, 1, 0),
     VOL_BOTTOM: (0, -1, 0),
-    VOL_ISO: (0, -1, 0),
+    VOL_ISO: (0, 0, 1),
 }
 CORONAL_VOLUME_CAM_POSITION = {
-    VOL_FRONT: (0, 0, -1),
-    VOL_BACK: (0, 0, 1),
+    VOL_FRONT: (0, -1, 0),
+    VOL_BACK: (0, 1, 0),
     VOL_RIGHT: (-1, 0, 0),
     VOL_LEFT: (1, 0, 0),
-    VOL_TOP: (0, -1, 0),
-    VOL_BOTTOM: (0, 1, 0),
-    VOL_ISO: (0.5, -0.5, -1),
+    VOL_TOP: (0, 0, 1),
+    VOL_BOTTOM: (0, 0, -1),
+    VOL_ISO: (0.5, -1, 0.5),
 }
 
 VOLUME_POSITION = {

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -925,6 +925,7 @@ class Controller:
         # proj.imagedata = imagedata
         proj.dicom_sample = dicom
         proj.original_orientation = name_to_const[dicom.image.orientation_label]
+        proj.patient_orientation = dicom.acquisition.patient_orientation
         # Forcing to Axial
         #  proj.original_orientation = const.AXIAL
         proj.window = float(dicom.image.window)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -505,14 +505,15 @@ class Viewer(wx.Panel):
             cube.GetZMinusFaceProperty().SetColor(0.1, 0.1, 0.7)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0.5, 0.5, 0.5)
 
-            cube.SetXPlusFaceText(_("L"))
-            cube.SetXMinusFaceText(_("R"))
-
             proj = prj.Project()
             if proj.original_orientation == const.SAGITAL:
+                cube.SetXPlusFaceText(_("R"))
+                cube.SetXMinusFaceText(_("L"))
                 cube.SetYPlusFaceText(_("A"))
                 cube.SetYMinusFaceText(_("P"))
             else:
+                cube.SetXPlusFaceText(_("L"))
+                cube.SetXMinusFaceText(_("R"))
                 cube.SetYPlusFaceText(_("P"))
                 cube.SetYMinusFaceText(_("A"))
             # Use built-in face text for T/B.

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3558,19 +3558,18 @@ class Viewer(wx.Panel):
         cam.SetFocalPoint(0, 0, 0)
 
         proj = prj.Project()
-        modality = str(getattr(proj, "modality", "CT")).upper()
         orientation = getattr(proj, "original_orientation", const.AXIAL)
 
-        # In MRI, the coordinates are often flipped 180 degrees compared to CT convention
+        # In Sagittal scans, the Z-spacing growth order is often backward, reversing the physical sides.
         # We remap the visual requests (Front, Back, etc.) to the underlying coordinate systems.
-        if modality in ["MRI", "MR"]:
-            mri_mapping = {
+        if orientation == const.SAGITAL:
+            sagital_mapping = {
                 const.VOL_FRONT: const.VOL_BACK,
                 const.VOL_BACK: const.VOL_FRONT,
                 const.VOL_LEFT: const.VOL_RIGHT,
                 const.VOL_RIGHT: const.VOL_LEFT,
             }
-            view = mri_mapping.get(view, view)
+            view = sagital_mapping.get(view, view)
 
         # Ensure orientation is valid; fallback to AXIAL if not defined in constants
         if orientation not in const.VOLUME_POSITION:
@@ -3612,8 +3611,15 @@ class Viewer(wx.Panel):
         # R (Right), L (Left), T (Top), B (Bottom).
         # InVesalius AXIAL orientation: VOL_FRONT camera is at (0, -1, 0), so the
         # Y-minus face faces the viewer → A. X-axis → L/R. Z-axis → T/B.
-        cube.SetXPlusFaceText("L")
-        cube.SetXMinusFaceText("R")
+        proj = prj.Project()
+        orientation = getattr(proj, "original_orientation", const.AXIAL)
+
+        if orientation == const.SAGITAL:
+            cube.SetXPlusFaceText("R")
+            cube.SetXMinusFaceText("L")
+        else:
+            cube.SetXPlusFaceText("L")
+            cube.SetXMinusFaceText("R")
         cube.SetYPlusFaceText("P")
         cube.SetYMinusFaceText("A")
         cube.SetZPlusFaceText("T")

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -507,8 +507,22 @@ class Viewer(wx.Panel):
 
             proj = prj.Project()
             if proj.original_orientation == const.SAGITAL:
-                cube.SetXPlusFaceText(_("R"))
-                cube.SetXMinusFaceText(_("L"))
+                x_plus, x_minus = "L", "R"
+                patient_orient = getattr(proj, "patient_orientation", None)
+
+                if patient_orient is not None and len(patient_orient) == 6:
+                    row_y, row_z = patient_orient[1], patient_orient[2]
+                    col_y, col_z = patient_orient[4], patient_orient[5]
+                    normal_x = (row_y * col_z) - (row_z * col_y)
+
+                    if normal_x < 0:
+                        x_plus, x_minus = "R", "L"
+                else:
+                    # Maintainer fallback request if patient_orientation is missing
+                    x_plus, x_minus = "R", "L"
+
+                cube.SetXPlusFaceText(_(x_plus))
+                cube.SetXMinusFaceText(_(x_minus))
                 cube.SetYPlusFaceText(_("A"))
                 cube.SetYMinusFaceText(_("P"))
             else:
@@ -3575,6 +3589,21 @@ class Viewer(wx.Panel):
                 const.VOL_FRONT: const.VOL_BACK,
                 const.VOL_BACK: const.VOL_FRONT,
             }
+            patient_orient = getattr(proj, "patient_orientation", None)
+
+            if patient_orient is not None and len(patient_orient) == 6:
+                row_y, row_z = patient_orient[1], patient_orient[2]
+                col_y, col_z = patient_orient[4], patient_orient[5]
+                normal_x = (row_y * col_z) - (row_z * col_y)
+
+                if normal_x < 0:
+                    sagital_mapping[const.VOL_RIGHT] = const.VOL_LEFT
+                    sagital_mapping[const.VOL_LEFT] = const.VOL_RIGHT
+            else:
+                # Maintainer fallback request to apply inversion if orientation is missing
+                sagital_mapping[const.VOL_RIGHT] = const.VOL_LEFT
+                sagital_mapping[const.VOL_LEFT] = const.VOL_RIGHT
+
             view = sagital_mapping.get(view, view)
 
         # Ensure orientation is valid; fallback to AXIAL if not defined in constants

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -504,10 +504,17 @@ class Viewer(wx.Panel):
             cube.GetZPlusFaceProperty().SetColor(0.1, 0.1, 0.7)  # T – Top
             cube.GetZMinusFaceProperty().SetColor(0.1, 0.1, 0.7)  # B – Bottom
             cube.GetTextEdgesProperty().SetColor(0.5, 0.5, 0.5)
+
             cube.SetXPlusFaceText(_("L"))
             cube.SetXMinusFaceText(_("R"))
-            cube.SetYPlusFaceText(_("P"))
-            cube.SetYMinusFaceText(_("A"))
+
+            proj = prj.Project()
+            if proj.original_orientation == const.SAGITAL:
+                cube.SetYPlusFaceText(_("A"))
+                cube.SetYMinusFaceText(_("P"))
+            else:
+                cube.SetYPlusFaceText(_("P"))
+                cube.SetYMinusFaceText(_("A"))
             # Use built-in face text for T/B.
             # SetZFaceTextRotation applies the SAME angle to both Z faces; since T (+Z)
             # and B (-Z) have opposite normals, +90 makes T upright but B upside-down.
@@ -3558,7 +3565,7 @@ class Viewer(wx.Panel):
         cam.SetFocalPoint(0, 0, 0)
 
         proj = prj.Project()
-        orientation = getattr(proj, "original_orientation", const.AXIAL)
+        orientation = proj.original_orientation
 
         # In Sagittal scans, the Z-spacing growth order is often backward, reversing the physical sides.
         # We remap the visual requests (Front, Back, etc.) to the underlying coordinate systems.
@@ -3566,8 +3573,6 @@ class Viewer(wx.Panel):
             sagital_mapping = {
                 const.VOL_FRONT: const.VOL_BACK,
                 const.VOL_BACK: const.VOL_FRONT,
-                const.VOL_LEFT: const.VOL_RIGHT,
-                const.VOL_RIGHT: const.VOL_LEFT,
             }
             view = sagital_mapping.get(view, view)
 
@@ -3597,53 +3602,6 @@ class Viewer(wx.Panel):
         if not self.nav_status:
             self.UpdateRender()
 
-    def ShowOrientationCube(self):
-        cube = vtkAnnotatedCubeActor()
-        cube.GetXMinusFaceProperty().SetColor(1, 0, 0)
-        cube.GetXPlusFaceProperty().SetColor(1, 0, 0)
-        cube.GetYMinusFaceProperty().SetColor(0, 1, 0)
-        cube.GetYPlusFaceProperty().SetColor(0, 1, 0)
-        cube.GetZMinusFaceProperty().SetColor(0, 0, 1)
-        cube.GetZPlusFaceProperty().SetColor(0, 0, 1)
-        cube.GetTextEdgesProperty().SetColor(0, 0, 0)
-
-        # Face labels as specified in the issue: A (Anterior/front), P (Posterior/back),
-        # R (Right), L (Left), T (Top), B (Bottom).
-        # InVesalius AXIAL orientation: VOL_FRONT camera is at (0, -1, 0), so the
-        # Y-minus face faces the viewer → A. X-axis → L/R. Z-axis → T/B.
-        proj = prj.Project()
-        orientation = getattr(proj, "original_orientation", const.AXIAL)
-
-        if orientation == const.SAGITAL:
-            cube.SetXPlusFaceText("R")
-            cube.SetXMinusFaceText("L")
-        else:
-            cube.SetXPlusFaceText("L")
-            cube.SetXMinusFaceText("R")
-        cube.SetYPlusFaceText("P")
-        cube.SetYMinusFaceText("A")
-        cube.SetZPlusFaceText("T")
-        cube.SetZMinusFaceText("B")
-        # Keep A/P/L/R exactly as-is; only rotate Z-face text so T/B render upright.
-        if hasattr(cube, "SetZFaceTextRotation"):
-            cube.SetZFaceTextRotation(90)
-
-        axes = vtkAxesActor()
-        axes.SetShaftTypeToCylinder()
-        axes.SetTipTypeToCone()
-        axes.SetXAxisLabelText("X")
-        axes.SetYAxisLabelText("Y")
-        axes.SetZAxisLabelText("Z")
-        # axes.SetNormalizedLabelPosition(.5, .5, .5)
-
-        orientation_widget = vtkOrientationMarkerWidget()
-        orientation_widget.SetOrientationMarker(cube)
-        orientation_widget.SetViewport(0.85, 0.85, 1.0, 1.0)
-        # orientation_widget.SetOrientationMarker(axes)
-        orientation_widget.SetInteractor(self.interactor)
-        orientation_widget.SetEnabled(1)
-        orientation_widget.On()
-        orientation_widget.InteractiveOff()
 
     def UpdateRender(self):
         self._UpdateOrientationCubeZTextRotation()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3613,6 +3613,21 @@ class Viewer(wx.Panel):
         xv, yv, zv = const.VOLUME_POSITION[orientation][0][view]
         xp, yp, zp = const.VOLUME_POSITION[orientation][1][view]
 
+        # Dynamically correct Isometric camera pointing on Sagittal datasets
+        if orientation == const.SAGITAL and view == const.VOL_ISO:
+            yp = 1  # Sagittal maps Anterior to Y=+1 natively 
+
+            patient_orient = getattr(proj, "patient_orientation", None)
+            if patient_orient is not None and len(patient_orient) == 6:
+                row_y, row_z = patient_orient[1], patient_orient[2]
+                col_y, col_z = patient_orient[4], patient_orient[5]
+                normal_x = (row_y * col_z) - (row_z * col_y)
+                if normal_x < 0:
+                    xp = -xp  # Flip X to see the 'L' side instead of the 'R' side on inverted arrays
+            else:
+                # Maintainer fallback: apply inversion if orientation is missing
+                xp = -xp
+
         cam.SetViewUp(xv, yv, zv)
         cam.SetPosition(xp, yp, zp)
 

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3602,7 +3602,6 @@ class Viewer(wx.Panel):
         if not self.nav_status:
             self.UpdateRender()
 
-
     def UpdateRender(self):
         self._UpdateOrientationCubeZTextRotation()
         self.interactor.Render()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3615,7 +3615,7 @@ class Viewer(wx.Panel):
 
         # Dynamically correct Isometric camera pointing on Sagittal datasets
         if orientation == const.SAGITAL and view == const.VOL_ISO:
-            yp = 1  # Sagittal maps Anterior to Y=+1 natively 
+            yp = 1  # Sagittal maps Anterior to Y=+1 natively
 
             patient_orient = getattr(proj, "patient_orientation", None)
             if patient_orient is not None and len(patient_orient) == 6:
@@ -3623,7 +3623,9 @@ class Viewer(wx.Panel):
                 col_y, col_z = patient_orient[4], patient_orient[5]
                 normal_x = (row_y * col_z) - (row_z * col_y)
                 if normal_x < 0:
-                    xp = -xp  # Flip X to see the 'L' side instead of the 'R' side on inverted arrays
+                    xp = (
+                        -xp
+                    )  # Flip X to see the 'L' side instead of the 'R' side on inverted arrays
             else:
                 # Maintainer fallback: apply inversion if orientation is missing
                 xp = -xp

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3226,12 +3226,7 @@ class Viewer(wx.Panel):
             actor.Modified()
             ren.ResetCameraClippingRange()
 
-            proj = prj.Project()
-            modality = str(getattr(proj, "modality", "CT")).upper()
-            if modality in ["MRI", "MR"]:
-                self.SetViewAngle(const.VOL_BACK)
-            else:
-                self.SetViewAngle(const.VOL_FRONT)
+            self.SetViewAngle(const.VOL_FRONT)
             self.view_angle = 1
         else:
             # Force actor to update its bounds before repositioning
@@ -3301,12 +3296,7 @@ class Viewer(wx.Panel):
             volume.Modified()
             self.ren.ResetCameraClippingRange()
 
-            proj = prj.Project()
-            modality = str(getattr(proj, "modality", "CT")).upper()
-            if modality in ["MRI", "MR"]:
-                self.SetViewAngle(const.VOL_BACK)
-            else:
-                self.SetViewAngle(const.VOL_FRONT)
+            self.SetViewAngle(const.VOL_FRONT)
             self.view_angle = 1
         else:
             # Force volume to update its bounds before repositioning
@@ -3342,12 +3332,7 @@ class Viewer(wx.Panel):
 
         if flag:
             if not self.view_angle:
-                proj = prj.Project()
-                modality = str(getattr(proj, "modality", "CT")).upper()
-                if modality in ["MRI", "MR"]:
-                    self.SetViewAngle(const.VOL_BACK)
-                else:
-                    self.SetViewAngle(const.VOL_FRONT)
+                self.SetViewAngle(const.VOL_FRONT)
                 self.view_angle = 1
 
             # Match the parallel projection used by AddSurface/LoadVolume so that
@@ -3572,11 +3557,27 @@ class Viewer(wx.Panel):
 
         cam.SetFocalPoint(0, 0, 0)
 
-        # proj = prj.Project()
-        # orig_orien = proj.original_orientation
+        proj = prj.Project()
+        modality = str(getattr(proj, "modality", "CT")).upper()
+        orientation = getattr(proj, "original_orientation", const.AXIAL)
 
-        xv, yv, zv = const.VOLUME_POSITION[const.AXIAL][0][view]
-        xp, yp, zp = const.VOLUME_POSITION[const.AXIAL][1][view]
+        # In MRI, the coordinates are often flipped 180 degrees compared to CT convention
+        # We remap the visual requests (Front, Back, etc.) to the underlying coordinate systems.
+        if modality in ["MRI", "MR"]:
+            mri_mapping = {
+                const.VOL_FRONT: const.VOL_BACK,
+                const.VOL_BACK: const.VOL_FRONT,
+                const.VOL_LEFT: const.VOL_RIGHT,
+                const.VOL_RIGHT: const.VOL_LEFT,
+            }
+            view = mri_mapping.get(view, view)
+
+        # Ensure orientation is valid; fallback to AXIAL if not defined in constants
+        if orientation not in const.VOLUME_POSITION:
+            orientation = const.AXIAL
+
+        xv, yv, zv = const.VOLUME_POSITION[orientation][0][view]
+        xp, yp, zp = const.VOLUME_POSITION[orientation][1][view]
 
         cam.SetViewUp(xv, yv, zv)
         cam.SetPosition(xp, yp, zp)

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -64,6 +64,7 @@ class Project(metaclass=Singleton):
         self.window = ""
         self.level = ""
         self.affine = ""
+        self.patient_orientation = None
 
         # Masks (vtkImageData)
         self.mask_dict = TwoWaysDictionary()
@@ -231,6 +232,7 @@ class Project(metaclass=Singleton):
             "scalar_range": self.threshold_range,
             "spacing": self.spacing,
             "affine": self.affine,
+            "patient_orientation": self.patient_orientation,
             "image_fiducials": self.image_fiducials.tolist(),
         }
 
@@ -371,6 +373,8 @@ class Project(metaclass=Singleton):
 
         if project.get("affine", ""):
             self.affine = project["affine"]
+
+        self.patient_orientation = project.get("patient_orientation", None)
 
         try:
             self.image_fiducials = np.asarray(project["image_fiducials"])


### PR DESCRIPTION
### Fixes #794 

This PR resolves an issue where manual 3D camera resets (e.g., selecting "Front") resulted in incorrect orientation for MRI scans, particularly Sagittal acquisitions.

### Changes:

**Standardised Coordinate System:** Unified VOLUME_POSITION constants across Axial, Sagittal, and Coronal orientations to ensure a consistent patient-relative 3D world.

**Modality-Aware Remapping:** Updated SetViewAngle to automatically detect MRI scans and apply a 180-degree flip (forward <-> Backwards). This compensates for the mirror-image convention often found in MRI data storage.

**Centralised Logic:** Simplified initialisation in AddSurface and LoadVolume by delegating orientation logic to the unified SetViewAngle method.

### Testing:

- Load MRI and create a 3D surface.
- Click "Front" in the 3D Viewer menu.
**Expected Behaviour:**
- The face should be visible immediately upon loading.
- Selecting "Front" should stay focused on the face (not flip to the back).


https://github.com/user-attachments/assets/ff1fc78c-8778-4508-b7a6-b486f99ca2ad

