### PR TITLE
feat: Add standalone Color Presets to Volume Raycasting

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -577,7 +577,8 @@ ID_FRAME = wx.NewIdRef()
     ID_NIFTI_IMPORT,
     ID_PARREC_IMPORT,
     ID_MODE_DBS,
-] = [wx.NewIdRef() for number in range(23)]
+    ID_RAYCASTING_PRESET_COLOUR,
+] = [wx.NewIdRef() for number in range(24)]
 ID_EXIT = wx.ID_EXIT
 ID_ABOUT = wx.ID_ABOUT
 

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -91,6 +91,7 @@ class Controller:
         Publisher.subscribe(self.OnShowDialogSaveProject, "Show save dialog")
 
         Publisher.subscribe(self.LoadRaycastingPreset, "Load raycasting preset")
+        Publisher.subscribe(self.LoadRaycastingColorPreset, "Load raycasting color preset")
         Publisher.subscribe(self.SaveRaycastingPreset, "Save raycasting preset")
         Publisher.subscribe(self.OnOpenDicomGroup, "Open DICOM group")
         Publisher.subscribe(self.OnOpenBitmapFiles, "Open bitmap files")
@@ -1419,6 +1420,9 @@ class Controller:
         else:
             prj.Project().raycasting_preset = 0
             Publisher.sendMessage("Update raycasting preset")
+
+    def LoadRaycastingColorPreset(self, preset_name):
+        prj.Project().SetRaycastColorPreset(preset_name)
 
     def SaveRaycastingPreset(self, preset_name):
         preset = prj.Project().raycasting_preset

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -278,13 +278,13 @@ class Volume:
         scale = self.scale
         ww = self.ww if self.ww is not None else self.config["ww"]
         wl = self.TranslateScale(scale, self.wl if self.wl is not None else self.config["wl"])
-        
+
         init = wl - ww / 2.0
         inc = ww / (len(colors) - 1.0)
-        
+
         for n, rgb in enumerate(colors):
             self.color_transfer.AddRGBPoint(init + n * inc, *[i / 255.0 for i in rgb])
-            
+
         Publisher.sendMessage("Render volume viewer")
 
     def OnFlipVolume(self, axis):

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -127,6 +127,7 @@ class Volume:
     def __bind_events(self):
         Publisher.subscribe(self.OnHideVolume, "Hide raycasting volume")
         Publisher.subscribe(self.OnUpdatePreset, "Update raycasting preset")
+        Publisher.subscribe(self.OnSetColorPreset, "Set raycasting color preset")
         Publisher.subscribe(self.OnSetCurve, "Set raycasting curve")
         Publisher.subscribe(self.OnSetWindowLevel, "Set raycasting wwwl")
         Publisher.subscribe(self.Refresh, "Set raycasting refresh")
@@ -262,6 +263,29 @@ class Volume:
             self.opacity_transfer_func = None
             self.color_transfer = None
             Publisher.sendMessage("Render volume viewer")
+
+    def OnSetColorPreset(self, preset):
+        if not self.exist or not self.color_transfer:
+            return
+
+        r = preset["Red"]
+        g = preset["Green"]
+        b = preset["Blue"]
+        colors = list(zip(r, g, b))
+
+        self.color_transfer.RemoveAllPoints()
+
+        scale = self.scale
+        ww = self.ww if self.ww is not None else self.config["ww"]
+        wl = self.TranslateScale(scale, self.wl if self.wl is not None else self.config["wl"])
+        
+        init = wl - ww / 2.0
+        inc = ww / (len(colors) - 1.0)
+        
+        for n, rgb in enumerate(colors):
+            self.color_transfer.AddRGBPoint(init + n * inc, *[i / 255.0 for i in rgb])
+            
+        Publisher.sendMessage("Render volume viewer")
 
     def OnFlipVolume(self, axis):
         print("Flipping Volume")

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -324,6 +324,7 @@ TOOL_STATE = {}
 ID_TO_ITEMSLICEMENU = {}
 ID_TO_ITEM_3DSTEREO = {}
 ID_TO_STEREO_NAME = {}
+ID_TO_COLOUR_PRESET_NAME = {}
 
 ICON_SIZE = (32, 32)
 
@@ -377,11 +378,19 @@ class VolumeToolPanel(wx.Panel):
 
         self.BMP_SSAO_DISABLED = BMP_SSAO_DISABLED
         self.BMP_SSAO_ENABLED = BMP_SSAO_ENABLED
+        BMP_COLOUR_PRESET = wx.Bitmap(
+            str(inv_paths.ICON_DIR.joinpath("object_colour.png")), wx.BITMAP_TYPE_PNG
+        )
 
         self.button_raycasting = pbtn.PlateButton(
             self, -1, "", BMP_RAYCASTING, style=pbtn.PB_STYLE_SQUARE, size=ICON_SIZE
         )
         self.button_raycasting.SetToolTip("Raycasting view")
+
+        self.button_raycasting_colour = pbtn.PlateButton(
+            self, -1, "", BMP_COLOUR_PRESET, style=pbtn.PB_STYLE_SQUARE, size=ICON_SIZE
+        )
+        self.button_raycasting_colour.SetToolTip(_("Color Selection"))
         self.button_stereo = pbtn.PlateButton(
             self, -1, "", BMP_3D_STEREO, style=pbtn.PB_STYLE_SQUARE, size=ICON_SIZE
         )
@@ -425,6 +434,7 @@ class VolumeToolPanel(wx.Panel):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.button_colour, 0, wx.ALL, sp)
         sizer.Add(self.button_raycasting, 0, wx.TOP | wx.BOTTOM, 1)
+        sizer.Add(self.button_raycasting_colour, 0, wx.TOP | wx.BOTTOM, 1)
         sizer.Add(self.button_view, 0, wx.TOP | wx.BOTTOM, 1)
         sizer.Add(self.button_slice_plane, 0, wx.TOP | wx.BOTTOM, 1)
         sizer.Add(self.button_stereo, 0, wx.TOP | wx.BOTTOM, 1)
@@ -461,6 +471,7 @@ class VolumeToolPanel(wx.Panel):
     def __bind_events_wx(self):
         self.button_slice_plane.Bind(wx.EVT_LEFT_DOWN, self.OnButtonSlicePlane)
         self.button_raycasting.Bind(wx.EVT_LEFT_DOWN, self.OnButtonRaycasting)
+        self.button_raycasting_colour.Bind(wx.EVT_LEFT_DOWN, self.OnButtonRaycastingColour)
         self.button_view.Bind(wx.EVT_LEFT_DOWN, self.OnButtonView)
         self.button_colour.Bind(csel.EVT_COLOURSELECT, self.OnSelectColour)
         self.button_stereo.Bind(wx.EVT_LEFT_DOWN, self.OnButtonStereo)
@@ -470,6 +481,10 @@ class VolumeToolPanel(wx.Panel):
     def OnButtonRaycasting(self, evt):
         # MENU RELATED TO RAYCASTING TYPES
         self.button_raycasting.PopupMenu(self.menu_raycasting)
+
+    def OnButtonRaycastingColour(self, evt):
+        # MENU RELATED TO RAYCASTING COLOURS
+        self.button_raycasting_colour.PopupMenu(self.menu_raycasting_colour)
 
     def OnButtonStereo(self, evt):
         self.button_stereo.PopupMenu(self.stereo_menu)
@@ -523,6 +538,20 @@ class VolumeToolPanel(wx.Panel):
         if sys.platform != "win32":
             submenu.Bind(wx.EVT_MENU, self.OnMenuRaycasting)
         menu.Bind(wx.EVT_MENU, self.OnMenuRaycasting)
+
+        # MENU RELATED TO RAYCASTING COLOURS
+        menu = self.menu_raycasting_colour = wx.Menu()
+        color_presets = [
+            filename.name.split(".")[0]
+            for filename in inv_paths.RAYCASTING_PRESETS_COLOR_DIRECTORY.glob("*.plist")
+        ]
+        color_presets.sort()
+        for name in color_presets:
+            id = wx.NewIdRef()
+            item = menu.Append(id, name, kind=wx.ITEM_RADIO)
+            ID_TO_COLOUR_PRESET_NAME[id] = name
+
+        menu.Bind(wx.EVT_MENU, self.OnMenuRaycastingColour)
 
         # VOLUME VIEW ANGLE BUTTON
         menu = wx.Menu()
@@ -638,6 +667,13 @@ class VolumeToolPanel(wx.Panel):
                 Publisher.sendMessage("Enable raycasting tool", tool_name=ID_TO_TOOL[id], flag=0)
                 TOOL_STATE[id] = False
                 item.Check(0)
+
+    def OnMenuRaycastingColour(self, evt):
+        """Events from raycasting colour menu."""
+        id = evt.GetId()
+        if id in ID_TO_COLOUR_PRESET_NAME.keys():
+            name = ID_TO_COLOUR_PRESET_NAME[id]
+            Publisher.sendMessage("Load raycasting color preset", preset_name=name)
 
     def OnMenuView(self, evt):
         """Events from button menus."""

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -200,6 +200,12 @@ class Project(metaclass=Singleton):
             preset = plistlib.load(f, fmt=plistlib.FMT_XML)
         Publisher.sendMessage("Set raycasting preset", preset)
 
+    def SetRaycastColorPreset(self, label: str) -> None:
+        path = os.path.join(inv_paths.RAYCASTING_PRESETS_COLOR_DIRECTORY, label + ".plist")
+        with open(path, "r+b") as f:
+            preset = plistlib.load(f, fmt=plistlib.FMT_XML)
+        Publisher.sendMessage("Set raycasting color preset", preset=preset)
+
     def GetMeasuresDict(self):
         measures = {}
         d = self.measurement_dict


### PR DESCRIPTION
### Description

### Fixes: #102 
This PR resolves the issue by introducing the ability to dynamically apply scientific colourmaps onto the 3D volume mapping **without overriding the user's selected density/opacity preset**. 

Previously, Volume Raycasting presets bundled both the opacity map `vtkPiecewiseFunction` and the colour map`vtkColorTransferFunction`. This PR isolates those properties in the 3D viewer, allowing users to choose a base density (e.g., Bone + Skin) and then independently apply a dynamic color heatmap (e.g., Jet, BlackBody, Rainbow) via a new dropdown menu.

### Changes
1. **`invesalius/constants.py` & `invesalius/gui/default_viewers.py`**: Added a new UI button underneath the raycasting presets toolbar. Constructed a dynamic dropdown menu that scans `inv_paths.RAYCASTING_PRESETS_COLOR_DIRECTORY` for `.plist` files.
2. **`invesalius/control.py` & `invesalius/project.py`**: Wired up pyPubSub signals to catch `"Load raycasting color preset"`, read the precise 256-value RGB schema from the `.plist` file, and broadcast the loaded dictionary.
3. **`invesalius/data/volume.py`**: Added an `OnSetColorPreset` handler that successfully overrides the active `vtkColorTransferFunction` array with the new RGB values mapped against the active window-width/level, while ensuring the existing `opacity_transfer_func` remains perfectly intact.

### Testing
- Standard combined density presets still load correctly.
- Selecting a new colour preset maps colours across the active densities instantly.
- Opacities/transparencies are fully retained when a new colour map is applied.


https://github.com/user-attachments/assets/d43fbded-4491-4d4b-9fb9-66b57ae5cf8e


