### PR TITLE
Fix ValueError crash when selecting Custom threshold in New Mask dialog

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -1471,7 +1471,7 @@ class NewMask(wx.Dialog):
         thresh = (thresh_min, thresh_max)
         proj = prj.Project()
         if thresh in proj.threshold_modes.values():
-            preset_name = proj.threshold_modes.get_key(thresh)[0]
+            preset_name = proj.threshold_modes.get_key(thresh)
             index = self.thresh_list.index(preset_name)
             self.combo_thresh.SetSelection(index)
         else:


### PR DESCRIPTION
Fixes #1361 
This PR fixes a `ValueError` crash in the New Mask dialog. The `get_key(thresh)` method returns a primitive string (e.g., `'Custom'`), but the code incorrectly appended `[0]` to it. This forced Python to extract only the first character (`"C"`), which caused a crash when searching for `"C"` in the list of full preset names. Removing the `[0]` ensures the full string is used, resolving the issue.
