### PR TITLE
fix: resolve layout artifacts and whitespace in task panels

### DIFF
--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -350,7 +350,7 @@ class UpperTaskPanel(wx.Panel):
         self.image_list = image_list
 
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(fold_panel, 1, wx.GROW | wx.EXPAND)
+        sizer.Add(fold_panel, 0, wx.EXPAND)
         self.sizer = sizer
         self.SetStateProjectClose()
         self.SetSizerAndFit(sizer)
@@ -361,6 +361,12 @@ class UpperTaskPanel(wx.Panel):
             self.fold_panel.Expand(self.fold_panel.GetFoldPanel(1))
         else:
             self.fold_panel.Expand(self.fold_panel.GetFoldPanel(0))
+
+        self.ResizeFPB()
+        # On macOS, native controls finalize their preferred sizes after the
+        # first event loop tick. A deferred call ensures the FoldPanelBar
+        # measures the true content heights and eliminates the white void.
+        wx.CallAfter(self.ResizeFPB)
 
     def __bind_events(self):
         session = ses.Session()
@@ -404,6 +410,7 @@ class UpperTaskPanel(wx.Panel):
             self.fold_panel.Expand(self.fold_panel.GetFoldPanel(1))
         for item in self.enable_items:
             item.Enable()
+        wx.CallAfter(self.ResizeFPB)
 
     def OnFoldPressCaption(self, evt):
         id = evt.GetTag().GetId()
@@ -425,10 +432,7 @@ class UpperTaskPanel(wx.Panel):
         # Check if the fold panel item is visually expanded
         is_expanded = item.IsExpanded()
 
-        if is_expanded:
-            y_needed = 240 if sys.platform != "win32" else 230
-        else:
-            y_needed = self.fold_panel.GetPanelsLength(0, 0)[2]
+        y_needed = self.fold_panel.GetPanelsLength(0, 0)[2]
 
         self.fold_panel.SetMinSize((-1, y_needed))
         self.fold_panel.SetSize((-1, y_needed))

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -107,7 +107,7 @@ class TaskPanel(wx.Panel):
         inner_panel = InnerTaskPanel(self)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(inner_panel, 1, wx.EXPAND | wx.GROW | wx.BOTTOM | wx.RIGHT | wx.LEFT, 7)
+        sizer.Add(inner_panel, 0, wx.EXPAND | wx.TOP | wx.RIGHT | wx.LEFT, 7)
         sizer.Fit(self)
 
         self.SetSizer(sizer)


### PR DESCRIPTION
### Description

### FIxes #1360 

This PR addresses several layout issues within the FoldPanelBar system, specifically regarding the "Export Data" and "Select region of interest" panels. It resolves vertical stretching, clipping of content, and UI artifacts on macOS.

### Changes
**Fixed Vertical Stretching:** Updated UpperTaskPanel in default_tasks.py to use a proportion of 0 for the FoldPanelBar. This prevents the panel from forcibly stretching to fill the entire application height, which previously created a large grey/white void.

**Resolved Content Clipping:** Removed a hardcoded 240px height limit in ResizeFPB. Height is now calculated dynamically based on actual content length, ensuring the "Select region of interest" panel displays all controls (including Watershed) and doesn't hide subsequent tabs.

**Fixed macOS Initial Layout:** Added an explicit ResizeFPB() call in UpperTaskPanel.__init__ and SetStateProjectOpen.
Implemented a deferred wx.CallAfter(self.ResizeFPB) to account for macOS-specific layout timing where native controls (like HyperLinkCtrl) only finalise their preferred sizes after the first event loop tick.

**Cleaned Up Artefacts:** Removed wx.BOTTOM borders and SetSizeHints in task_exporter.py that were forcing a minimum height and causing a thin white line to remain visible even when the "Export Data" tab was collapsed.

### macOS-Specific Technical Justification

On macOS, some widgets report inflated preferred sizes during construction. By using wx.CallAfter, we allow the system to complete its native layout validation pass before we measure and snap the FoldPanelBar to its tightest possible bounds.

### Before fix: 

https://github.com/user-attachments/assets/8d32fa58-1255-40cb-bdbc-f29eb0595c6a

________

### After fix:


https://github.com/user-attachments/assets/16e6d8a3-db1b-4808-a9a7-32f97744ceb9



