### PR TITLE
feat: added a Open image- project dialog when starting invesalius

### DIFF
--- a/app.py
+++ b/app.py
@@ -284,6 +284,28 @@ class Inv3SplashScreen(SplashScreen):
         session.SetConfig("project_status", const.PROJECT_STATUS_CHANGED)
         session._has_unsaved_changes = True
 
+    def ShowStartupDialog(self):
+        """
+        Show the startup dialog to guide users to their next action.
+        """
+        from invesalius.gui.dialogs import StartupDialog
+
+        dlg = StartupDialog(self.main)
+        result = dlg.ShowModal()
+
+        if result == wx.ID_OK:
+            action = dlg.GetAction()
+
+            # Execute the selected action
+            if action == StartupDialog.ACTION_IMPORT_DICOM:
+                # Directly open the DICOM folder selection dialog
+                wx.CallAfter(Publisher.sendMessage, "Show import directory dialog")
+            elif action == StartupDialog.ACTION_OPEN_PROJECT:
+                wx.CallAfter(self.main.ShowOpenProject)
+            # For ACTION_EMPTY_SESSION or ACTION_CANCEL, just continue normally
+
+        dlg.Destroy()
+
     def CheckCrashRecovery(self):
         if not session.ExitedSuccessfullyLastTime():
             # Check for auto-backup
@@ -319,6 +341,8 @@ class Inv3SplashScreen(SplashScreen):
                 else:
                     # User chose to discard backup
                     session.RemoveAutoBackup()
+                    # Show startup dialog after discarding backup
+                    wx.CallAfter(self.ShowStartupDialog)
             else:
                 # No backup exists, but we crashed. Ask the user to re-open
                 project_path = session.GetState("project_path")
@@ -346,11 +370,17 @@ class Inv3SplashScreen(SplashScreen):
                         else:
                             # User canceled reopening last project
                             session.CloseProject()
+                            # Show startup dialog after canceling
+                            wx.CallAfter(self.ShowStartupDialog)
                     else:
                         utils.debug(f"File doesn't exist: {filepath}")
                         session.CloseProject()
+                        # Show startup dialog when file doesn't exist
+                        wx.CallAfter(self.ShowStartupDialog)
                 else:
                     session.CloseProject()
+                    # Show startup dialog when no project path
+                    wx.CallAfter(self.ShowStartupDialog)
         else:
             # Last exit was clean. Check if the user closed with "Store session"
             # — in which case we should silently reopen the project, not show any dialog.
@@ -362,6 +392,11 @@ class Inv3SplashScreen(SplashScreen):
                         wx.CallAfter(Publisher.sendMessage, "Open project", filepath=filepath)
                     else:
                         utils.debug(f"Stored session project not found: {filepath}")
+                        # Show startup dialog when stored session project not found
+                        wx.CallAfter(self.ShowStartupDialog)
+            else:
+                # Normal startup - show startup dialog if enabled
+                wx.CallAfter(self.ShowStartupDialog)
             # Start fresh state for this new session (clears stored_session flag too)
             session.CreateState()
 

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -7967,3 +7967,111 @@ class AnnotationDialog(wx.Dialog):
     def GetValue(self):
         """Return the annotation text entered by the user."""
         return self.txt_annotation.GetValue().strip()
+
+
+class StartupDialog(wx.Dialog):
+    """
+    Startup dialog shown when InVesalius launches.
+    Guides users to their next action: import DICOM, open project, or start empty.
+    """
+
+    # Action constants
+    ACTION_IMPORT_DICOM = 1
+    ACTION_OPEN_PROJECT = 2
+    ACTION_EMPTY_SESSION = 3
+    ACTION_CANCEL = 0
+
+    def __init__(self, parent=None):
+        if parent is None:
+            parent = wx.GetApp().GetTopWindow()
+
+        wx.Dialog.__init__(
+            self,
+            parent,
+            -1,
+            _("InVesalius 3"),
+            style=wx.DEFAULT_DIALOG_STYLE,
+        )
+
+        self.action = self.ACTION_CANCEL
+        self._init_gui()
+        self.Centre()
+
+    def _init_gui(self):
+        """Initialize the dialog GUI."""
+        # Main vertical sizer
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Welcome message
+        label = wx.StaticText(self, -1, _("What would you like to do?"))
+        sizer.Add(label, 0, wx.ALIGN_CENTRE | wx.ALL, 10)
+
+        # Import DICOM button
+        btn_import = wx.Button(self, -1, _("Import DICOM files"))
+        btn_import.Bind(wx.EVT_BUTTON, self.OnImportDicom)
+        sizer.Add(btn_import, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Import DICOM description
+        desc_import = wx.StaticText(self, -1, _("Load medical images from DICOM files or folders"))
+        desc_import.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        sizer.Add(desc_import, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Open project button
+        btn_open = wx.Button(self, -1, _("Open existing project"))
+        btn_open.Bind(wx.EVT_BUTTON, self.OnOpenProject)
+        sizer.Add(btn_open, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Open project description
+        desc_open = wx.StaticText(self, -1, _("Open a previously saved InVesalius project (.inv3)"))
+        desc_open.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        sizer.Add(desc_open, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Empty session button
+        btn_empty = wx.Button(self, -1, _("Start with empty session"))
+        btn_empty.Bind(wx.EVT_BUTTON, self.OnEmptySession)
+        sizer.Add(btn_empty, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Empty session description
+        desc_empty = wx.StaticText(self, -1, _("Start InVesalius without loading any data"))
+        desc_empty.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        sizer.Add(desc_empty, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Separator
+        sizer.Add(wx.StaticLine(self), 0, wx.EXPAND | wx.ALL, 5)
+
+        # Standard button sizer with Cancel button
+        btn_cancel = wx.Button(self, wx.ID_CANCEL)
+        btn_cancel.SetHelpText("")
+
+        btnsizer = wx.StdDialogButtonSizer()
+        btnsizer.AddButton(btn_cancel)
+        btnsizer.Realize()
+
+        sizer.Add(btnsizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
+
+        self.SetSizer(sizer)
+        sizer.Fit(self)
+
+    def OnImportDicom(self, evt):
+        """Handle Import DICOM action."""
+        self.action = self.ACTION_IMPORT_DICOM
+        self.EndModal(wx.ID_OK)
+
+    def OnOpenProject(self, evt):
+        """Handle Open Project action."""
+        self.action = self.ACTION_OPEN_PROJECT
+        self.EndModal(wx.ID_OK)
+
+    def OnEmptySession(self, evt):
+        """Handle Empty Session action."""
+        self.action = self.ACTION_EMPTY_SESSION
+        self.EndModal(wx.ID_OK)
+
+    def GetAction(self):
+        """
+        Get the selected action.
+
+        Returns:
+            One of ACTION_IMPORT_DICOM, ACTION_OPEN_PROJECT, ACTION_EMPTY_SESSION, or ACTION_CANCEL
+        """
+        return self.action


### PR DESCRIPTION
### Implements #613 

## Summary

This PR introduces a startup dialog displayed on application launch to guide users toward common entry points such as importing DICOM data, opening an existing project, or starting a new session.

Previously, users were presented with an empty interface without clear next steps. This change provides a structured starting point and improves overall usability, particularly for first-time users.

---

## Motivation

The absence of guidance on startup can lead to confusion and unnecessary friction. Introducing a startup dialog aligns InVesalius with standard UX patterns used in professional applications, making the initial workflow more intuitive and accessible.

---

## Implementation Details

- Added a `StartupDialog` using standard wxPython components to ensure full UI consistency.
- Integrated into the application startup flow after splash screen handling.
- Displayed only when appropriate:
  - Normal startup without active session or recovery
  - After canceling recovery flows
- Skipped when:
  - Crash recovery is accepted
  - A valid session is restored

---

## Design Considerations

- Uses native wx widgets (`wx.Dialog`, `wx.BoxSizer`, etc.)
- No custom styling; follows existing UI patterns and system theme
- Layout and behavior consistent with current dialogs
- Strings prepared for internationalization

---

## Testing

- Verified dialog visibility across startup scenarios
- Confirmed correct behavior of all entry actions
- Ensured no regression in crash recovery or session restore flows
- Tested on supported platforms for layout consistency

---

## Impact

- Provides clear entry points on startup
- Reduces initial user confusion and improves onboarding
- Maintains full UI consistency with existing components
- No breaking changes or additional dependencies

---

## Files Modified

- `invesalius/gui/dialogs.py` – Added `StartupDialog`
- `app.py` – Integrated dialog into startup flow

---

## Dialog UI 


https://github.com/user-attachments/assets/c7a51ef9-c9ec-40ed-9e44-3479f1be62ed


