### PR TITLE
Refactor: Replace print() with structured logging (Resolves #498)

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -623,8 +623,8 @@ class Controller:
                 prj.Project().SavePlistProject(dirpath, filename, compress)
             except PermissionError as err:
                 if wx.GetApp() is None:
-                    print(
-                        f"Error: Permission denied, you don't have permission to write at {dirpath}"
+                    logger.error(
+                        "Error: Permission denied, you don't have permission to write at %s", dirpath
                     )
                 else:
                     dlg = dialogs.ErrorMessageBox(

--- a/invesalius/data/brainmesh_handler.py
+++ b/invesalius/data/brainmesh_handler.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pyacvd
 
@@ -44,6 +45,9 @@ import invesalius.data.slice_ as sl
 import invesalius.data.vtk_utils as vtk_utils
 import invesalius.project as prj
 from invesalius.data.converters import to_vtk
+
+logger = logging.getLogger(__name__)
+
 
 
 class Brain:
@@ -485,7 +489,7 @@ def downsample(inp):
     clus.cluster(3000)
     Remesh = clus.create_mesh()
 
-    # print(Remesh)
+    # logger.debug(Remesh)
 
     # Remesh = vtkIsotropicDiscreteRemeshing()
     # Remesh.SetInput(surface)

--- a/invesalius/data/converters.py
+++ b/invesalius/data/converters.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import gdcm
@@ -26,6 +27,9 @@ from vtkmodules.vtkCommonCore import (
     vtkPoints,
 )
 from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkImageData, vtkPolyData, vtkTriangle
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     import os
@@ -236,5 +240,5 @@ def convert_custom_bin_to_vtk(filename: "str | bytes | os.PathLike[str]") -> Opt
 
         return polydata
     else:
-        print("File does not exists")
+        logger.debug("File does not exists")
         return None

--- a/invesalius/data/coordinates.py
+++ b/invesalius/data/coordinates.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import threading
 from math import cos, sin
 from random import uniform
@@ -30,6 +31,9 @@ import invesalius.constants as const
 import invesalius.data.transformations as tr
 import invesalius.session as ses
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from invesalius.data.tracker_connection import TrackerConnection
@@ -131,7 +135,7 @@ def GetCoordinatesForThread(
         }
         coord, marker_visibilities = getcoord[tracker_id](tracker_connection, tracker_id, ref_mode)
     else:
-        print("Select Tracker")
+        logger.debug("Select Tracker")
 
     return coord, marker_visibilities
 
@@ -474,7 +478,7 @@ def PolhemusSerialCoord(tracker_connection: "TrackerConnection", tracker_id: int
     lines = trck.readlines()
 
     if lines is None:
-        print("The Polhemus is not connected!")
+        logger.debug("The Polhemus is not connected!")
     else:
         data = lines[0]
         data = data.replace(str.encode("-"), str.encode(" -"))

--- a/invesalius/data/cursor_actors.py
+++ b/invesalius/data/cursor_actors.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import math
 
 import numpy
@@ -32,6 +33,9 @@ from vtkmodules.vtkRenderingCore import (
 )
 
 import invesalius.constants as const
+
+logger = logging.getLogger(__name__)
+
 
 ORIENTATION = {"AXIAL": 2, "CORONAL": 1, "SAGITAL": 0}
 
@@ -339,7 +343,7 @@ class CursorRectangle(CursorBase):
         """
         Function to plot the Retangle
         """
-        print("Building rectangle cursor", self.orientation)
+        logger.debug("Building rectangle cursor", self.orientation)
         r = self.radius
         if self.unit == "µm":
             r /= 1000.0

--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import math
 import os
 import tempfile
@@ -41,6 +42,9 @@ import invesalius.gui.dialogs as dlg
 import invesalius.reader.bitmap_reader as bitmap_reader
 from invesalius.data import vtk_utils as vtk_utils
 from invesalius.i18n import tr as _
+
+logger = logging.getLogger(__name__)
+
 
 # TODO: Test cases which are originally in sagittal/coronal orientation
 # and have gantry
@@ -566,7 +570,7 @@ def get_LUT_value(data: np.ndarray, window: int, level: int) -> np.ndarray:
 def get_LUT_value_normalized(img, a_min, a_max, b_min=0.0, b_max=1.0, clip=True):
     # based on https://docs.monai.io/en/latest/_modules/monai/transforms/intensity/array.html#ScaleIntensity
 
-    print(a_min, a_max, b_min, b_max, clip)
+    logger.debug(a_min, a_max, b_min, b_max, clip)
     img = (img - a_min) / (a_max - a_min)
     img = img * (b_max - b_min) + b_min
 

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import os
 import plistlib
 import random
@@ -35,6 +36,9 @@ import invesalius_rs as floodfill
 from invesalius.data.volume_mask import VolumeMask
 from invesalius.pubsub import pub as Publisher
 
+logger = logging.getLogger(__name__)
+
+
 
 class EditionHistoryNode:
     def __init__(self, index, orientation, array, clean=False):
@@ -47,7 +51,7 @@ class EditionHistoryNode:
 
     def _save_array(self, array):
         np.save(self.filename, array)
-        print("Saving history", self.index, self.orientation, self.filename, self.clean)
+        logger.debug("Saving history", self.index, self.orientation, self.filename, self.clean)
 
     def commit_history(self, mvolume):
         array = np.load(self.filename)
@@ -66,10 +70,10 @@ class EditionHistoryNode:
         elif self.orientation == "VOLUME":
             mvolume[:] = array
 
-        print("applying to", self.orientation, "at slice", self.index)
+        logger.debug("applying to", self.orientation, "at slice", self.index)
 
     def __del__(self):
-        print("Removing", self.filename)
+        logger.debug("Removing", self.filename)
         os.close(self.fd)
         os.remove(self.filename)
 
@@ -101,7 +105,7 @@ class EditionHistory:
         self.history.append(node)
         self.index += 1
 
-        print("INDEX", self.index, len(self.history), self.history)
+        logger.debug("INDEX", self.index, len(self.history), self.history)
         Publisher.sendMessage("Enable undo", value=True)
         Publisher.sendMessage("Enable redo", value=False)
 
@@ -137,7 +141,7 @@ class EditionHistory:
 
         if self.index == 0:
             Publisher.sendMessage("Enable undo", value=False)
-        print("AT", self.index, len(self.history), self.history[self.index].filename)
+        logger.debug("AT", self.index, len(self.history), self.history[self.index].filename)
 
     def redo(self, mvolume, actual_slices=None):
         h = self.history
@@ -172,7 +176,7 @@ class EditionHistory:
 
         if self.index == len(h) - 1:
             Publisher.sendMessage("Enable redo", value=False)
-        print("AT", self.index, len(h), h[self.index].filename)
+        logger.debug("AT", self.index, len(h), h[self.index].filename)
 
     def _reload_slice(self, index):
         Publisher.sendMessage(
@@ -251,9 +255,9 @@ class Mask:
         Publisher.subscribe(self.OnSwapVolumeAxes, "Swap volume axes")
 
     def as_vtkimagedata(self):
-        print("Converting to VTK")
+        logger.debug("Converting to VTK")
         vimg = converters.to_vtk_mask(self.matrix, self.spacing)
-        print("Converted")
+        logger.debug("Converted")
         return vimg
 
     def set_colour(self, colour):

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 
+import logging
 import math
 import sys
 import textwrap
@@ -30,6 +31,8 @@ import invesalius.project as prj
 import invesalius.session as ses
 import invesalius.utils as utils
 from invesalius import math_utils
+
+logger = logging.getLogger(__name__)
 from invesalius.gui.widgets.canvas_renderer import (
     CanvasHandlerBase,
     Ellipse,
@@ -282,7 +285,7 @@ class MeasurementManager:
                     mr.complete_polygon()
 
                 mr.set_density_values(m.min, m.max, m.mean, m.std, m.area, m.perimeter)
-                print(m.min, m.max, m.mean, m.std)
+                logger.debug("Measurements: min=%s, max=%s, mean=%s, std=%s", m.min, m.max, m.mean, m.std)
                 mr._need_calc = False
                 self.measures.append((m, mr))
                 mr.set_measurement(m)
@@ -1935,7 +1938,7 @@ class CircleDensityMeasure(CanvasHandlerBase):
 
     def _update_gui_info(self):
         msg = ("Update measurement info in GUI",)
-        print(msg)
+        logger.debug(msg)
         if self._measurement:
             m = self._measurement
             Publisher.sendMessage(
@@ -2202,7 +2205,7 @@ class PolygonDensityMeasure(CanvasHandlerBase):
                 self._dist_tbox = [i - j for i, j in zip(self.text_box.position, p)]
             else:
                 self.text_box.position = [i + j for i, j in zip(self._dist_tbox, p)]
-                print("text box position", self.text_box.position)
+                logger.debug("text box position: %s", self.text_box.position)
 
         session = ses.Session()
         session.ChangeProject()
@@ -2221,7 +2224,7 @@ class PolygonDensityMeasure(CanvasHandlerBase):
         #  self._dist_tbox = [j-i for i,j in zip(p, self.text_box.position)]
 
     def insert_point(self, point):
-        print("insert points", len(self.points))
+        logger.debug("insert points: %s", len(self.points))
         self.polygon.append_point(point)
         self.points.append(point)
 
@@ -2288,7 +2291,7 @@ class PolygonDensityMeasure(CanvasHandlerBase):
         )
         mask = arr[:, :, 0] >= 128
 
-        print("mask sum", mask.sum())
+        logger.debug("mask sum: %s", mask.sum())
 
         if DEBUG_DENSITY:
             try:
@@ -2339,10 +2342,10 @@ class PolygonDensityMeasure(CanvasHandlerBase):
         elif self.orientation == "SAGITAL":
             points = [(y, z) for (x, y, z) in self.points]
         area = math_utils.calc_polygon_area(points)
-        print("Points", points)
-        print("xv = %s;" % [i[0] for i in points])
-        print("yv = %s;" % [i[1] for i in points])
-        print("Area", area)
+        logger.debug("Points: %s", points)
+        logger.debug("xv = %s;", [i[0] for i in points])
+        logger.debug("yv = %s;", [i[1] for i in points])
+        logger.debug("Area: %s", area)
         return area
 
     def calc_perimeter(self) -> float:
@@ -2353,10 +2356,10 @@ class PolygonDensityMeasure(CanvasHandlerBase):
         elif self.orientation == "SAGITAL":
             points = [(y, z) for (x, y, z) in self.points]
         area = math_utils.calc_polygon_perimeter(points)
-        print("Points", points)
-        print("xv = %s;" % [i[0] for i in points])
-        print("yv = %s;" % [i[1] for i in points])
-        print("Perimeter", area)
+        logger.debug("Points: %s", points)
+        logger.debug("xv = %s;", [i[0] for i in points])
+        logger.debug("yv = %s;", [i[1] for i in points])
+        logger.debug("Perimeter: %s", area)
         return area
 
     def get_bounds(self):
@@ -2369,7 +2372,7 @@ class PolygonDensityMeasure(CanvasHandlerBase):
         min_z = min(self.points, key=lambda x: x[2])[2]
         max_z = max(self.points, key=lambda x: x[2])[2]
 
-        print(self.points)
+        logger.debug(self.points)
 
         return (min_x, min_y, min_z, max_x, max_y, max_z)
 
@@ -2441,7 +2444,7 @@ class PolygonDensityMeasure(CanvasHandlerBase):
 
     def _update_gui_info(self):
         msg = ("Update measurement info in GUI",)
-        print(msg)
+        logger.debug(msg)
         if self._measurement:
             m = self._measurement
             Publisher.sendMessage(

--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import sys
 from typing import Iterable, List
 
@@ -52,6 +53,9 @@ import invesalius.constants as const
 import invesalius.data.vtk_utils as vu
 from invesalius.i18n import tr as _
 from invesalius.utils import touch
+
+logger = logging.getLogger(__name__)
+
 
 if sys.platform == "win32":
     try:
@@ -112,7 +116,7 @@ def FillSurfaceHole(polydata: vtkPolyData) -> "vtkPolyData":
     Fill holes in the given polydata.
     """
     # Filter used to detect and fill holes. Only fill
-    print("Filling polydata")
+    logger.debug("Filling polydata")
     filled_polydata = vtkFillHolesFilter()
     filled_polydata.SetInputData(polydata)
     filled_polydata.SetHoleSize(500)

--- a/invesalius/data/ruler.py
+++ b/invesalius/data/ruler.py
@@ -6,6 +6,7 @@
 # Last Modified Date: 16th March 2023
 #
 # -----------------------------------------------------------------------------------
+import logging
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -14,6 +15,9 @@ import wx
 
 import invesalius.constants as const
 import invesalius.project as project
+
+logger = logging.getLogger(__name__)
+
 
 E_SHAPED = TOP_OR_LEFT = 0
 C_SHAPED = BOTTOM_OR_RIGHT = 1
@@ -83,7 +87,7 @@ class Ruler(ABC):
             float: Height of viewport in mm
         """
         camera = self.slice_data.renderer.GetActiveCamera()
-        # print(f"Viewport Height in Millimeters: {camera.GetParallelScale() * 2}")
+        # logger.debug(f"Viewport Height in Millimeters: {camera.GetParallelScale() * 2}")
         return camera.GetParallelScale() * 2
 
     def GetWindowSize(self):

--- a/invesalius/data/serial_port_connection.py
+++ b/invesalius/data/serial_port_connection.py
@@ -17,12 +17,16 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import queue
 import threading
 import time
 
 from invesalius import constants
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 
 class SerialPortConnection(threading.Thread):
@@ -46,24 +50,24 @@ class SerialPortConnection(threading.Thread):
 
     def Connect(self):
         if self.com_port is None:
-            print("Serial port init error: COM port is unset.")
+            logger.debug("Serial port init error: COM port is unset.")
             return False
         try:
             import serial
 
             self.connection = serial.Serial(self.com_port, baudrate=self.baud_rate, timeout=0)
-            print(f"Connection to port {self.com_port} opened.")
+            logger.debug(f"Connection to port {self.com_port} opened.")
 
             Publisher.sendMessage("Serial port connection", state=True)
             return True
         except Exception:
-            print(f"Serial port init error: Connecting to port {self.com_port} failed.")
+            logger.debug(f"Serial port init error: Connecting to port {self.com_port} failed.")
             return False
 
     def Disconnect(self):
         if self.connection:
             self.connection.close()
-            print(f"Connection to port {self.com_port} closed.")
+            logger.debug(f"Connection to port {self.com_port} closed.")
 
             Publisher.sendMessage("Serial port connection", state=False)
 
@@ -72,11 +76,11 @@ class SerialPortConnection(threading.Thread):
             self.connection.send_break(constants.PULSE_DURATION_IN_MILLISECONDS / 1000)
             Publisher.sendMessage("Serial port pulse triggered")
         except Exception:
-            print("Error: Serial port could not be written into.")
+            logger.debug("Error: Serial port could not be written into.")
 
     def run(self):
         if self.connection is None:
-            print("Serial port thread exiting: No active connection.")
+            logger.debug("Serial port thread exiting: No active connection.")
             return
 
         while not self.event.is_set():
@@ -85,7 +89,7 @@ class SerialPortConnection(threading.Thread):
                 lines = self.connection.readlines()
                 has_data = bool(lines)
             except Exception:
-                print("Error: Serial port could not be read.")
+                logger.debug("Error: Serial port could not be read.")
                 has_data = False
 
             if self.stylusplh:

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 import tempfile
 from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
@@ -48,6 +49,9 @@ from invesalius.data.mask import Mask
 from invesalius.i18n import tr as _
 from invesalius.project import Project
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from vtkmodules.vtkCommonDataModel import vtkImageData
@@ -1187,7 +1191,7 @@ class Slice(metaclass=utils.Singleton):
             # TODO: find out a better way to do threshold
             if slice_number is None:
                 for n, slice_ in enumerate(self.matrix):
-                    print(n)
+                    logger.debug(n)
                     m = np.ones(slice_.shape, self.current_mask.matrix.dtype)
                     m[slice_ < thresh_min] = 0
                     m[slice_ > thresh_max] = 0
@@ -1299,7 +1303,7 @@ class Slice(metaclass=utils.Singleton):
                 continue
             mask = mask_dict[mask_index]
             if mask.matrix.max() < 127:
-                print(f"Skipping mask '{mask.name}' (index {mask_index}) - no voxels available")
+                logger.debug(f"Skipping mask '{mask.name}' (index {mask_index}) - no voxels available")
                 continue
 
             surface_parameters = surface_template.copy()
@@ -1309,7 +1313,7 @@ class Slice(metaclass=utils.Singleton):
             surface_parameters["options"]["name"] = f"{mask.name}"
             surface_parameters["options"]["overwrite"] = False  # always create new surfaces
 
-            print(f"Creating surface for mask '{mask.name}' (index {mask_index})")
+            logger.debug(f"Creating surface for mask '{mask.name}' (index {mask_index})")
 
             try:
                 self.do_threshold_to_all_slices(mask)
@@ -1318,9 +1322,9 @@ class Slice(metaclass=utils.Singleton):
                 )
                 created_surfaces.append(mask_index)
             except Exception as e:
-                print(f"Failed to create surface for mask '{mask.name}': {str(e)}")
+                logger.debug(f"Failed to create surface for mask '{mask.name}': {str(e)}")
 
-        print(f"Successfully created surfaces for {len(created_surfaces)} masks")
+        logger.debug(f"Successfully created surfaces for {len(created_surfaces)} masks")
         Publisher.sendMessage("Surfaces creation completed", created_count=len(created_surfaces))
 
     def GetOutput(self):

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import multiprocessing
 import os
 import tempfile
@@ -63,6 +64,8 @@ from invesalius.data.imagedata_utils import get_LUT_value, get_LUT_value_255
 from invesalius.data.measures import CircleDensityMeasure, MeasureData, PolygonDensityMeasure
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
 
 # import invesalius.project as prj
 
@@ -575,7 +578,7 @@ class TractsInteractorStyle(CrossInteractorStyle):
         # self.state_code = const.SLICE_STATE_TRACTS
 
         self.viewer = viewer
-        # print("Im fucking brilliant!")
+        # logger.debug("Im fucking brilliant!")
         self.tracts = None
 
         # data_dir = b'C:\Users\deoliv1\OneDrive\data\dti'
@@ -605,12 +608,12 @@ class TractsInteractorStyle(CrossInteractorStyle):
     def OnTractsMove(self, obj, evt):
         # The user moved the mouse with left button pressed
         if self.left_pressed:
-            # print("OnTractsMove interactor style")
+            # logger.debug("OnTractsMove interactor style")
             # iren = obj.GetInteractor()
             self.ChangeTracts(True)
 
     def OnTractsMouseClick(self, obj, evt):
-        # print("Single mouse click")
+        # logger.debug("Single mouse click")
         # self.tracts = dtr.compute_and_visualize_tracts(self.tracker, self.seed, self.left_pressed)
         self.ChangeTracts(True)
 
@@ -620,7 +623,7 @@ class TractsInteractorStyle(CrossInteractorStyle):
         # self.ChangeCrossPosition(iren)
 
     def ChangeTracts(self, pressed):
-        # print("Trying to compute tracts")
+        # logger.debug("Trying to compute tracts")
         self.tracts = dtr.compute_and_visualize_tracts(
             self.tracker, self.seed, self.affine_vtk, pressed
         )
@@ -1096,7 +1099,7 @@ class DensityMeasureStyle(DefaultInteractorStyle):
 
     def OnInsertPoint(self, evt):
         mouse_x, mouse_y = evt.position
-        print("OnInsertPoint", evt.position)
+        logger.debug("OnInsertPoint: %s", evt.position)
         n = self.viewer.slice_data.number
         pos = self.viewer.get_coordinate_cursor(mouse_x, mouse_y, self.picker)
 
@@ -1142,7 +1145,7 @@ class DensityMeasureStyle(DefaultInteractorStyle):
             m = self._last_measure
             if len(m.points) >= 3:
                 n = self.viewer.slice_data.number
-                print(self.viewer.draw_by_slice_number[n], m)
+                logger.debug("Insert polygon: %s, %s", self.viewer.draw_by_slice_number[n], m)
                 self.viewer.draw_by_slice_number[n].remove(m)
                 m.complete_polygon()
                 self._last_measure = None
@@ -1744,7 +1747,7 @@ class WaterShedInteractorStyle(DefaultInteractorStyle):
         if self.matrix is not None:
             self.matrix = None
             os.remove(self.temp_file)
-            print("deleting", self.temp_file)
+            logger.debug("deleting: %s", self.temp_file)
 
     def _set_cursor(self):
         if self.config.cursor_type == const.BRUSH_SQUARE:
@@ -2363,7 +2366,7 @@ class ReorientImageInteractorStyle(DefaultInteractorStyle):
         tcoord = np.array((z, y, x, 1)).dot(M)
         tcoord = tcoord[:3] / tcoord[3]
 
-        #  print (z, y, x), tcoord
+        #  logger.debug(z, y, x), tcoord
         return tcoord
 
     def _set_reorientation_angles(self, angles):
@@ -2502,7 +2505,7 @@ class FloodFillMaskInteractorStyle(DefaultInteractorStyle):
                 bstruct = np.zeros((3, 3, 1), dtype="uint8")
                 bstruct[:, :, 0] = _bstruct
 
-        print("FloodFillMaskInteractorStyle", self.t0, self.t1)
+        logger.debug("FloodFillMaskInteractorStyle: %s, %s", self.t0, self.t1)
         if self.config.target == "2D":
             floodfill.floodfill_threshold_inplace(
                 mask, ((x, y, z),), self.t0, self.t1, self.fill_value, bstruct
@@ -2967,7 +2970,7 @@ class FloodFillSegmentInteractorStyle(DefaultInteractorStyle):
 
             elif self.config.method == "dynamic":
                 if self.config.use_ww_wl:
-                    print("Using WW&WL")
+                    logger.debug("Using WW&WL")
                     ww = self.viewer.slice_.window_width
                     wl = self.viewer.slice_.window_level
                     image = get_LUT_value_255(image, ww, wl)
@@ -3025,7 +3028,7 @@ class FloodFillSegmentInteractorStyle(DefaultInteractorStyle):
 
             elif self.config.method == "dynamic":
                 if self.config.use_ww_wl:
-                    print("Using WW&WL")
+                    logger.debug("Using WW&WL")
                     ww = self.viewer.slice_.window_width
                     wl = self.viewer.slice_.window_level
                     image = get_LUT_value_255(image, ww, wl)

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -19,6 +19,7 @@
 
 import functools
 import gc
+import logging
 import multiprocessing
 import os
 import plistlib
@@ -54,6 +55,8 @@ from vtkmodules.vtkIOXML import vtkXMLPolyDataReader, vtkXMLPolyDataWriter
 from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
 
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     try:
@@ -383,7 +386,7 @@ class SurfaceManager:
         proj = prj.Project()
         index = self.last_surface_index
         # if index not in proj.surface_dict:
-        #     print(f"[Error] Surface index {index} not found in surface_dict.")
+        #     logger.debug(f"[Error] Surface index {index} not found in surface_dict.")
         #     return
         if not hasattr(proj, "surface_dict") or not proj.surface_dict:
             dialogs.LargestSurfaceNotExist()
@@ -454,7 +457,7 @@ class SurfaceManager:
                 surface_index = self.CreateSurfaceFromPolydata(polydata, name=name, scalar=scalar)
                 return surface_index
         else:
-            print("File does not exists")
+            logger.error("File does not exist: %s", filename)
             return
 
     def CoverttoMetersPolydata(self, polydata):
@@ -760,7 +763,7 @@ class SurfaceManager:
             area = measured_polydata.GetSurfaceArea()
             surface.volume = volume
             surface.area = area
-            print(">>>>", surface.volume)
+            logger.debug("Surface volume: %s", surface.volume)
         else:
             surface.volume = volume
             surface.area = area
@@ -860,7 +863,7 @@ class SurfaceManager:
     def _show_surface(
         self, surface_filename, surface_measures, overwrite, surface_name, colour, category, dialog
     ):
-        print(surface_filename, surface_measures)
+        logger.debug("Surface file: %s, measures: %s", surface_filename, surface_measures)
         reader = vtkXMLPolyDataReader()
         reader.SetFileName(surface_filename)
         reader.Update()
@@ -960,7 +963,7 @@ class SurfaceManager:
     def decimate_polydata(self, polydata, reduction=0.7):
         """Reduce the number of triangles by `reduction` (0.5 = 50%)."""
         if polydata.GetNumberOfPoints() == 0:
-            print("Input mesh empty, skipping.")
+            logger.warning("Input mesh empty, skipping.")
             return polydata
 
         # Step 1: Decimate to reduce complexity
@@ -973,7 +976,7 @@ class SurfaceManager:
         output = decimator.GetOutput()
         # SAFETY CHECK
         if output.GetNumberOfPoints() == 0:
-            print("Decimation produced empty mesh. Returning original.")
+            logger.warning("Decimation produced empty mesh. Returning original.")
             return polydata
 
         # Clean up any inconsistencies in mesh
@@ -982,7 +985,7 @@ class SurfaceManager:
         cleaner.Update()
         cleaned = cleaner.GetOutput()
         if cleaned.GetNumberOfPoints() == 0:
-            print("Cleaning produced empty mesh.")
+            logger.warning("Cleaning produced empty mesh.")
             return output
 
         # Step 3: Smooth out the remaining vertices
@@ -993,7 +996,7 @@ class SurfaceManager:
 
         smoothed = smoother.GetOutput()
         if smoothed.GetNumberOfPoints() == 0:
-            print("Smoothing produced empty mesh. Returning original.")
+            logger.warning("Smoothing produced empty mesh. Returning original.")
             return cleaned
 
         return smoothed
@@ -1080,7 +1083,7 @@ class SurfaceManager:
 
         fill_border_holes = surface_parameters["options"].get("fill_border_holes", True)
 
-        print(surface_parameters)
+        logger.debug("Surface parameters: %s", surface_parameters)
 
         mode = "CONTOUR"  # 'GRAYSCALE'
         min_value, max_value = mask.threshold_range
@@ -1140,7 +1143,7 @@ class SurfaceManager:
         manager = multiprocessing.Manager()
         msg_queue = manager.Queue(1)
 
-        print("Resolution", imagedata_resolution)
+        logger.debug("Resolution: %s", imagedata_resolution)
 
         # If InVesalius is running without GUI
         if wx.GetApp() is None:
@@ -1148,7 +1151,7 @@ class SurfaceManager:
                 init = i * piece_size
                 end = init + piece_size + o_piece
                 roi = slice(init, end)
-                print("new_piece", roi)
+                logger.debug("New piece: %s", roi)
                 f = pool.apply_async(
                     surface_process.create_surface_piece,
                     args=(
@@ -1200,8 +1203,7 @@ class SurfaceManager:
             try:
                 surface_filename, surface_measures = f.get()
             except Exception:
-                print(_("InVesalius was not able to create the surface"))
-                print(traceback.print_exc())
+                logger.error("InVesalius was not able to create the surface", exc_info=True)
                 return
 
             reader = vtkXMLPolyDataReader()
@@ -1235,7 +1237,7 @@ class SurfaceManager:
                 init = i * piece_size
                 end = init + piece_size + o_piece
                 roi = slice(init, end)
-                print("new_piece", roi)
+                logger.debug("New piece: %s", roi)
                 f = pool.apply_async(
                     surface_process.create_surface_piece,
                     args=(
@@ -1308,7 +1310,7 @@ class SurfaceManager:
                     wx.Yield()
 
             t_end = time.time()
-            print(f"Elapsed time - {t_end - t_init}")
+            logger.info("Surface creation elapsed time: %.2f seconds", t_end - t_init)
             sp.Close()
             if sp.error:
                 dlg = GMD.GenericMessageDialog(None, sp.error, "Exception!", wx.OK | wx.ICON_ERROR)
@@ -1418,7 +1420,7 @@ class SurfaceManager:
                 self._export_surface(temp_file, filetype, convert_to_world)
             except ValueError:
                 if wx.GetApp() is None:
-                    print("It was not possible to export the surface because the surface is empty")
+                    logger.error("It was not possible to export the surface because the surface is empty")
                 else:
                     wx.MessageBox(
                         _("It was not possible to export the surface because the surface is empty"),
@@ -1432,7 +1434,7 @@ class SurfaceManager:
             # Checks if file exists and is not empty
             if not os.path.exists(temp_file) or os.path.getsize(temp_file) == 0:
                 if wx.GetApp() is None:
-                    print("Export cancelled or resulted in empty file.")
+                    logger.warning("Export cancelled or resulted in empty file.")
                 else:
                     wx.MessageBox(
                         _("Export cancelled by user"),
@@ -1445,10 +1447,9 @@ class SurfaceManager:
             except PermissionError as err:
                 dirpath = os.path.split(filename)[0]
                 if wx.GetApp() is None:
-                    print(
-                        _(
-                            f"It was not possible to export the surface because you don't have permission to write to {dirpath} folder: {err}"
-                        )
+                    logger.error(
+                        "It was not possible to export the surface because you don't have permission to write to %s folder: %s",
+                        dirpath, err
                     )
                 else:
                     dlg = dialogs.ErrorMessageBox(
@@ -1507,7 +1508,7 @@ class SurfaceManager:
                 }
 
                 mask = proj.mask_dict[index]
-                print(mask.matrix.min(), mask.matrix.max(), mask.name)
+                logger.debug("Mask range: %s - %s, name: %s", mask.matrix.min(), mask.matrix.max(), mask.name)
                 slice_ = slc.Slice()
 
                 Publisher.sendMessage(
@@ -1523,7 +1524,7 @@ class SurfaceManager:
 
             # Displays one surface at a time and export
             for index in proj.surface_dict.keys():
-                print(proj.surface_dict[index].name)
+                logger.debug("Exporting surface: %s", proj.surface_dict[index].name)
                 proj.surface_dict[index].is_shown = True
                 self._export_surface(
                     os.path.join(folder, str(index) + ".stl"), const.FILETYPE_STL, False
@@ -1648,4 +1649,4 @@ class SurfaceManager:
                     progress.Destroy()
                     progress_destroyed = True
                 except Exception as e:
-                    print(f"Could not destroy progress dialog: {e}")
+                    logger.warning("Could not destroy progress dialog: %s", e)

--- a/invesalius/data/surface_process.py
+++ b/invesalius/data/surface_process.py
@@ -1,6 +1,9 @@
+import logging
 import os
 import tempfile
 import time
+
+logger = logging.getLogger(__name__)
 
 try:
     import queue
@@ -183,7 +186,7 @@ def create_surface_piece(
     start = time.perf_counter()
     contour.Update()
     duration = time.perf_counter() - start
-    print(f"[PERF] Extraction (vtkContourFilter): {duration:.4f}s")
+    logger.debug(f"[PERF] Extraction (vtkContourFilter): {duration:.4f}s")
 
     polydata = contour.GetOutput()
     del image
@@ -195,8 +198,8 @@ def create_surface_piece(
     writer.SetFileName(filename)
     writer.Write()
 
-    print("Writing piece", roi, "to", filename)
-    print("MY PID MC", os.getpid())
+    logger.debug(f"Writing piece {roi} to {filename}")
+    logger.debug(f"MY PID MC {os.getpid()}")
     os.close(fd)
     return filename
 
@@ -216,7 +219,7 @@ def join_process_surface(
         try:
             msg_queue.put_nowait(msg)
         except queue.Full as e:
-            print(e)
+            logger.error(e)
 
     log_fd, log_path = tempfile.mkstemp("vtkoutput.txt")
     fow = vtkFileOutputWindow()
@@ -241,7 +244,7 @@ def join_process_surface(
     start = time.perf_counter()
     polydata_append.Update()
     duration = time.perf_counter() - start
-    print(f"[PERF] Joining surface pieces: {duration:.4f}s")
+    logger.debug(f"[PERF] Joining surface pieces: {duration:.4f}s")
     #  polydata_append.GetOutput().ReleaseDataFlagOn()
     polydata = polydata_append.GetOutput()
     # polydata.Register(None)
@@ -260,7 +263,7 @@ def join_process_surface(
     start = time.perf_counter()
     clean.Update()
     duration = time.perf_counter() - start
-    print(f"[PERF] Cleaning merged surface: {duration:.4f}s")
+    logger.debug(f"[PERF] Cleaning merged surface: {duration:.4f}s")
 
     del polydata
     polydata = clean.GetOutput()
@@ -316,7 +319,7 @@ def join_process_surface(
             mesh, options["angle"], options["max distance"], options["min weight"], options["steps"]
         )
         duration = time.perf_counter() - start
-        print(f"[PERF] Context Aware smoothing: {duration:.4f}s")
+        logger.debug(f"[PERF] Context Aware smoothing: {duration:.4f}s")
         #  polydata = mesh.to_vtk()
 
         #  polydata.SetSource(None)
@@ -348,7 +351,7 @@ def join_process_surface(
     #  del smoother
 
     if not decimate_reduction:
-        print("Decimating", decimate_reduction)
+        logger.debug(f"Decimating {decimate_reduction}")
         send_message("Decimating ...")
         decimation = vtkQuadricDecimation()
         #  decimation.ReleaseDataFlagOn()
@@ -364,7 +367,7 @@ def join_process_surface(
         start = time.perf_counter()
         decimation.Update()
         duration = time.perf_counter() - start
-        print(f"[PERF] Decimating: {duration:.4f}s")
+        logger.debug(f"[PERF] Decimating: {duration:.4f}s")
         del polydata
         polydata = decimation.GetOutput()
         # polydata.Register(None)
@@ -405,7 +408,7 @@ def join_process_surface(
         start = time.perf_counter()
         filled_polydata.Update()
         duration = time.perf_counter() - start
-        print(f"[PERF] Filling holes: {duration:.4f}s")
+        logger.debug(f"[PERF] Filling holes: {duration:.4f}s")
         #  filled_polydata.GetOutput().ReleaseDataFlagOn()
         del polydata
         polydata = filled_polydata.GetOutput()
@@ -467,6 +470,6 @@ def join_process_surface(
     writer.Write()
     del writer
 
-    print("MY PID", os.getpid())
+    logger.debug(f"MY PID {os.getpid()}")
     os.close(fd)
     return filename, {"volume": volume, "area": area}

--- a/invesalius/data/tracker_connection.py
+++ b/invesalius/data/tracker_connection.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import sys
 
 from wx import ID_OK
@@ -23,6 +24,8 @@ from wx import ID_OK
 import invesalius.constants as const
 import invesalius.gui.dialogs as dlg
 from invesalius import inv_paths
+
+logger = logging.getLogger(__name__)
 
 # TODO: Disconnect tracker when a new one is connected
 # TODO: Test if there are too many prints when connection fails
@@ -46,11 +49,11 @@ class TrackerConnection:
             self.connection.Close()
             self.connection = False
             self.lib_mode = "wrapper"
-            print("Tracker disconnected.")
+            logger.info("Tracker disconnected.")
         except Exception:
             self.connection = True
             self.lib_mode = "error"
-            print("The tracker could not be disconnected.")
+            logger.error("The tracker could not be disconnected.", exc_info=True)
 
     def IsConnected(self):
         # TODO: It would be cleaner to compare self.connection to None here; however, currently it can also have
@@ -117,7 +120,7 @@ class OptitrackTrackerConnection(TrackerConnection):
 
             self.connection = connection
         else:
-            print("Could not connect to Optitrack tracker.")
+            logger.error("Could not connect to Optitrack tracker.")
             lib_mode = "error"
 
         self.lib_mode = lib_mode
@@ -152,13 +155,13 @@ class ClaronTrackerConnection(TrackerConnection):
 
             if connection.GetIdentifyingCamera():
                 connection.Run()
-                print("MicronTracker camera identified.")
+                logger.info("MicronTracker camera identified.")
 
                 self.connection = connection
 
         except ImportError:
             lib_mode = "error"
-            print("The ClaronTracker library is not installed.")
+            logger.error("The ClaronTracker library is not installed.")
 
         self.lib_mode = lib_mode
 
@@ -194,7 +197,7 @@ class PolhemusTrackerConnection(TrackerConnection):
                 "baud_rate": baud_rate,
             }
         else:
-            print("Could not connect to Polhemus tracker.")
+            logger.error("Could not connect to Polhemus tracker.")
 
         dialog.Destroy()
 
@@ -211,12 +214,12 @@ class PolhemusTrackerConnection(TrackerConnection):
             connection = self.PolhemusWrapperConnection()
             lib_mode = "wrapper"
             if not connection:
-                print("Could not connect with Polhemus wrapper, trying USB connection...")
+                logger.warning("Could not connect with Polhemus wrapper, trying USB connection...")
 
                 connection = self.PolhemusUSBConnection()
                 lib_mode = "usb"
                 if not connection:
-                    print("Could not connect with Polhemus USB, trying serial connection...")
+                    logger.warning("Could not connect with Polhemus USB, trying serial connection...")
 
                     if reconfigure:
                         self.ConfigureCOMPort()
@@ -224,7 +227,7 @@ class PolhemusTrackerConnection(TrackerConnection):
                     lib_mode = "serial"
         except Exception:
             lib_mode = "error"
-            print("Could not connect to Polhemus by any method.")
+            logger.error("Could not connect to Polhemus by any method.", exc_info=True)
 
         self.connection = connection
         self.lib_mode = lib_mode
@@ -251,12 +254,12 @@ class PolhemusTrackerConnection(TrackerConnection):
                     sleep(0.175)
             else:
                 connection = None
-                print(
+                logger.warning(
                     "Could not connect to Polhemus via wrapper without error: Initialize is False."
                 )
         except Exception:
             connection = None
-            print("Could not connect to Polhemus via wrapper without error: Import failed.")
+            logger.error("Could not connect to Polhemus via wrapper without error: Import failed.", exc_info=True)
 
         return connection
 
@@ -289,11 +292,11 @@ class PolhemusTrackerConnection(TrackerConnection):
             data = connection.readlines()
             if not data:
                 connection = None
-                print("Could not connect to Polhemus serial without error.")
+                logger.warning("Could not connect to Polhemus serial without error.")
 
         except Exception:
             connection = None
-            print("Could not connect to Polhemus tracker.")
+            logger.error("Could not connect to Polhemus tracker.", exc_info=True)
 
         return connection
 
@@ -330,10 +333,10 @@ class PolhemusTrackerConnection(TrackerConnection):
             data = connection.read(endpoint.bEndpointAddress, endpoint.wMaxPacketSize)
             if not data:
                 connection = None
-                print("Could not connect to Polhemus USB without error.")
+                logger.warning("Could not connect to Polhemus USB without error.")
 
         except Exception:
-            print("Could not connect to Polhemus USB with error.")
+            logger.error("Could not connect to Polhemus USB with error.", exc_info=True)
 
         return connection
 
@@ -347,11 +350,11 @@ class PolhemusTrackerConnection(TrackerConnection):
                 self.lib_mode = "wrapper"
 
             self.connection = False
-            print("Tracker disconnected.")
+            logger.info("Tracker disconnected.")
         except Exception:
             self.connection = True
             self.lib_mode = "error"
-            print("The tracker could not be disconnected.")
+            logger.error("The tracker could not be disconnected.", exc_info=True)
 
 
 class CameraTrackerConnection(TrackerConnection):
@@ -367,13 +370,13 @@ class CameraTrackerConnection(TrackerConnection):
 
             connection = cam.camera()
             connection.Initialize()
-            print("Connected to camera tracking device.")
+            logger.info("Connected to camera tracking device.")
 
             lib_mode = "wrapper"
 
             self.connection = connection
         except Exception:
-            print("Could not connect to camera tracker.")
+            logger.error("Could not connect to camera tracker.", exc_info=True)
             lib_mode = "error"
 
         self.lib_mode = lib_mode
@@ -403,7 +406,7 @@ class PolarisTrackerConnection(TrackerConnection):
             }
         else:
             self.lib_mode = None
-            print("Could not connect to polaris tracker.")
+            logger.error("Could not connect to polaris tracker.")
 
         dialog.Destroy()
 
@@ -433,15 +436,15 @@ class PolarisTrackerConnection(TrackerConnection):
 
             if connection.Initialize(com_port, probe_dir, ref_dir, obj_dirs) != 0:
                 lib_mode = None
-                print("Could not connect to polaris tracker.")
+                logger.error("Could not connect to polaris tracker.")
             else:
-                print("Connected to polaris tracking device.")
+                logger.info("Connected to polaris tracking device.")
                 self.connection = connection
 
         except Exception:
             lib_mode = "error"
             connection = None
-            print("Could not connect to polaris tracker.")
+            logger.error("Could not connect to polaris tracker.", exc_info=True)
 
         self.lib_mode = lib_mode
 
@@ -469,7 +472,7 @@ class PolarisP4TrackerConnection(TrackerConnection):
             }
         else:
             self.lib_mode = None
-            print("Could not connect to Polaris P4 tracker.")
+            logger.error("Could not connect to Polaris P4 tracker.")
 
         dialog.Destroy()
 
@@ -493,14 +496,14 @@ class PolarisP4TrackerConnection(TrackerConnection):
             if connection.Initialize(com_port, probe_dir, ref_dir, obj_dir) != 0:
                 connection = None
                 lib_mode = None
-                print("Could not connect to Polaris P4 tracker.")
+                logger.error("Could not connect to Polaris P4 tracker.")
             else:
-                print("Connect to Polaris P4 tracking device.")
+                logger.info("Connected to Polaris P4 tracking device.")
 
         except Exception:
             lib_mode = "error"
             connection = None
-            print("Could not connect to Polaris P4 tracker.")
+            logger.error("Could not connect to Polaris P4 tracker.", exc_info=True)
 
         self.connection = connection
         self.lib_mode = lib_mode
@@ -519,12 +522,12 @@ class DebugTrackerRandomConnection(TrackerConnection):
     def Connect(self):
         self.connection = True
         self.lib_mode = "debug"
-        print("Debug device (random) started.")
+        logger.info("Debug device (random) started.")
 
     def Disconnect(self):
         self.connection = False
         self.lib_mode = "debug"
-        print("Debug tracker (random) disconnected.")
+        logger.info("Debug tracker (random) disconnected.")
 
 
 class DebugTrackerApproachConnection(TrackerConnection):
@@ -537,12 +540,12 @@ class DebugTrackerApproachConnection(TrackerConnection):
     def Connect(self):
         self.connection = True
         self.lib_mode = "debug"
-        print("Debug device (approach) started.")
+        logger.info("Debug device (approach) started.")
 
     def Disconnect(self):
         self.connection = False
         self.lib_mode = "debug"
-        print("Debug tracker (approach) disconnected.")
+        logger.info("Debug tracker (approach) disconnected.")
 
 
 TRACKER_CONNECTION_CLASSES = {

--- a/invesalius/data/tractography.py
+++ b/invesalius/data/tractography.py
@@ -21,6 +21,7 @@
 # Contributions: Dogu Baran Aydogan
 # Initial date: 8 May 2020
 
+import logging
 import queue
 import threading
 import time
@@ -37,6 +38,9 @@ from vtkmodules.vtkFiltersCore import vtkTubeFilter
 import invesalius.constants as const
 import invesalius.data.imagedata_utils as img_utils
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 # Nice print for arrays
 # np.set_printoptions(precision=2)
@@ -120,7 +124,7 @@ def create_branch(out_list, n_block):
     branch = vtkMultiBlockDataSet()
 
     # create tracts only when at least one was computed
-    # print("Len outlist in root: ", len(out_list))
+    # logger.debug("Len outlist in root: ", len(out_list))
     # TODO: check if this if statement is required, because we should
     #  call this function only when tracts exist
     if not out_list.count(None) == len(out_list):
@@ -190,9 +194,9 @@ def compute_and_visualize_tracts(trekker, position, affine, affine_vtk, n_tracts
         alpha = (n_param - 1) * (255 - 51) / (10 - 1) + 51
         trekker.minFODamp(n_param * 0.01)
 
-        # print("seed example: {}".format(seed_trk))
+        # logger.debug("seed example: {}".format(seed_trk))
         trekker.seed_coordinates(np.repeat(seed_trk, n_threads, axis=0))
-        # print("trk list len: ", len(trekker.run()))
+        # logger.debug("trk list len: ", len(trekker.run()))
         trk_list = trekker.run()
         n_tracts += len(trk_list)
         if len(trk_list):
@@ -268,15 +272,15 @@ class ComputeTractsThread(threading.Thread):
         n_tracts = 0
 
         # Compute the tracts
-        # print('ComputeTractsThread: event {}'.format(self.event.is_set()))
+        # logger.debug('ComputeTractsThread: event {}'.format(self.event.is_set()))
         while not self.event.is_set():
             try:
-                # print("Computing tracts")
+                # logger.debug("Computing tracts")
                 # get from the queue the coordinates, coregistration transformation matrix, and flipped matrix
-                # print("Here")
+                # logger.debug("Here")
                 m_img_flip = self.coord_tracts_queue.get_nowait()
                 # coord, m_img, m_img_flip = self.coord_queue.get_nowait()
-                # print('ComputeTractsThread: get {}'.format(count))
+                # logger.debug('ComputeTractsThread: get {}'.format(count))
 
                 # TODO: Remove this is not needed
                 # 20200402: in this new refactored version the m_img comes different than the position
@@ -293,15 +297,15 @@ class ComputeTractsThread(threading.Thread):
                 dist = abs(np.linalg.norm(p_old - np.asarray(coord_offset)))
                 p_old = coord_offset.copy()
 
-                # print("p_new_shape", coord_offset.shape)
-                # print("m_img_flip_shape", m_img_flip.shape)
+                # logger.debug("p_new_shape", coord_offset.shape)
+                # logger.debug("m_img_flip_shape", m_img_flip.shape)
                 seed_trk = img_utils.convert_world_to_voxel(coord_offset, affine)
                 coord_offset_w = np.hstack((coord_offset, 1.0)).reshape([4, 1])
                 # Juuso's
                 # seed_trk = np.array([[-8.49, -8.39, 2.5]])
                 # Baran M1
                 # seed_trk = np.array([[27.53, -77.37, 46.42]])
-                # print("Seed: {}".format(seed))
+                # logger.debug("Seed: {}".format(seed))
 
                 # set the seeds for trekker, one seed is repeated n_threads times
                 # trekker has internal multiprocessing approach done in C. Here the number of available threads is give,
@@ -313,7 +317,7 @@ class ComputeTractsThread(threading.Thread):
                 trk_list = trekker.run()
 
                 if len(trk_list) > 2:
-                    # print("dist: {}".format(dist))
+                    # logger.debug("dist: {}".format(dist))
                     if dist >= seed_radius:
                         # when moving the coil further than the seed_radius restart the bundle computation
                         bundle = vtkMultiBlockDataSet()
@@ -343,15 +347,15 @@ class ComputeTractsThread(threading.Thread):
                 # than visualizing old data
                 # self.visualization_queue.put_nowait([coord, m_img, bundle])
                 self.tracts_queue.put_nowait((bundle, affine_vtk, coord_offset, coord_offset_w))
-                # print('ComputeTractsThread: put {}'.format(count))
+                # logger.debug('ComputeTractsThread: put {}'.format(count))
 
                 self.coord_tracts_queue.task_done()
                 # self.coord_queue.task_done()
-                # print('ComputeTractsThread: done {}'.format(count))
+                # logger.debug('ComputeTractsThread: done {}'.format(count))
 
             # if no coordinates pass
             except queue.Empty:
-                # print("Empty queue in tractography")
+                # logger.debug("Empty queue in tractography")
                 pass
             # if queue is full mark as done (may not be needed in this new "nowait" method)
             except queue.Full:
@@ -511,8 +515,8 @@ class ComputeTractsACTThread(threading.Thread):
                 # seed_trk = np.array([[-8.49, -8.39, 2.5]])
                 # Baran M1
                 # seed_trk = np.array([[27.53, -77.37, 46.42]])
-                # print("Given: {}".format(seed_trk.shape))
-                # print("Seed: {}".format(seed))
+                # logger.debug("Given: {}".format(seed_trk.shape))
+                # logger.debug("Seed: {}".format(seed))
                 # joonas seed that has good tracts
                 # seed_trk = np.array([[29.12, -13.33, 31.65]])
                 # seed_trk_img = np.array([[117, 127, 161]])
@@ -628,7 +632,7 @@ def set_trekker_parameters(trekker, params):
         n_threads = params["numb_threads"]
 
     trekker.numberOfThreads(n_threads)
-    # print("Trekker config updated: n_threads, {}; seed_max, {}".format(n_threads, params['seed_max']))
+    # logger.debug("Trekker config updated: n_threads, {}; seed_max, {}".format(n_threads, params['seed_max']))
     return trekker, n_threads
 
 

--- a/invesalius/data/transformations.py
+++ b/invesalius/data/transformations.py
@@ -192,11 +192,15 @@ True
 
 """
 
+import logging
 import math
 from typing import Sequence, Union
 
 import numpy
 import numpy.typing
+
+logger = logging.getLogger(__name__)
+
 
 __version__ = "2015.07.18"
 __docformat__ = "restructuredtext en"
@@ -1132,7 +1136,7 @@ def euler_from_matrix(matrix, axes="sxyz"):
     >>> for axes in _AXES2TUPLE.keys():
     ...    R0 = euler_matrix(axes=axes, *angles)
     ...    R1 = euler_matrix(axes=axes, *euler_from_matrix(R0, axes))
-    ...    if not numpy.allclose(R0, R1): print(axes, "failed")
+    ...    if not numpy.allclose(R0, R1): logger.debug(axes, "failed")
 
     """
     try:
@@ -1878,7 +1882,7 @@ def inverse_matrix(matrix):
     >>> for size in range(1, 7):
     ...     M0 = numpy.random.rand(size, size)
     ...     M1 = inverse_matrix(M0)
-    ...     if not numpy.allclose(M1, numpy.linalg.inv(M0)): print(size)
+    ...     if not numpy.allclose(M1, numpy.linalg.inv(M0)): logger.debug(size)
 
     """
     return numpy.linalg.inv(matrix)

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import collections
 import os
 import sys
@@ -60,6 +61,9 @@ from invesalius.gui.widgets.canvas_renderer import CanvasRendererCTX
 from invesalius.gui.widgets.inv_spinctrl import InvFloatSpinCtrl, InvSpinCtrl
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 if sys.platform == "win32":
     try:
@@ -676,10 +680,10 @@ class Viewer(wx.Panel):
         coord = self.calcultate_scroll_position(px, py)
         # Debugging coordinates. For a 1.0 spacing axis the coord and position is the same,
         # but for a spacing dimension =! 1, the coord and position are different
-        # print("\nPosition: {}".format(position))
-        # print("Scroll position: {}".format(coord))
-        # print("Slice actor bounds: {}".format(self.slice_data.actor.GetBounds()))
-        # print("Scroll from int of position: {}\n".format([round(s) for s in position]))
+        # logger.debug("\nPosition: {}".format(position))
+        # logger.debug("Scroll position: {}".format(coord))
+        # logger.debug("Slice actor bounds: {}".format(self.slice_data.actor.GetBounds()))
+        # logger.debug("Scroll from int of position: {}\n".format([round(s) for s in position]))
 
         # this call did not affect the working code
         # self.cross.SetFocalPoint(coord)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -109,6 +109,10 @@ from invesalius.i18n import tr as _
 from invesalius.math_utils import inner1d
 from invesalius.pubsub import pub as Publisher
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 if sys.platform == "win32":
     try:
         import win32api
@@ -378,7 +382,7 @@ class Viewer(wx.Panel):
             renderer = renwin.GetNextItem()
             self.renderers.append(renderer)
 
-        print(len(self.renderers))
+        logger.debug(len(self.renderers))
 
         Publisher.sendMessage("Press target mode button", pressed=False)
         self._update_fps_visibility()
@@ -444,7 +448,8 @@ class Viewer(wx.Panel):
             if self.orientation_widget:
                 try:
                     self.orientation_widget.SetEnabled(0)
-                except:
+                except Exception:
+                    logger.exception("Error disabling orientation widget")
                     pass
                 self.orientation_widget = None
 
@@ -1096,7 +1101,7 @@ class Viewer(wx.Panel):
         self.angle_threshold = angle
 
     def OnUpdateDistanceThreshold(self, dist_threshold):
-        print("updated to ", dist_threshold)
+        logger.debug("updated to ", dist_threshold)
         self.distance_threshold = dist_threshold
 
     def OnUpdateRobotWarning(self, robot_warning):
@@ -1504,7 +1509,7 @@ class Viewer(wx.Panel):
 
         self.coil_visualizer.AddTargetCoil(self.m_target)
 
-        print(f"Target updated to coordinates {coord}")
+        logger.debug(f"Target updated to coordinates {coord}")
 
     def CreateVTKObjectMatrix(self, direction, orientation):
         m_img = dco.coordinates_to_transformation_matrix(
@@ -1549,7 +1554,7 @@ class Viewer(wx.Panel):
         try:
             surface = proj.surface_dict[0].polydata
         except KeyError:
-            print("There is not any surface created")
+            logger.debug("There is not any surface created")
             return barycenter
 
         polydata = surface
@@ -2766,7 +2771,7 @@ class Viewer(wx.Panel):
                     closestPoint = point
                     pointnormal = np.array(self.peel_normals.GetTuple(cellId))
                     angle = np.rad2deg(np.arccos(np.dot(pointnormal, coil_norm)))
-                    # print('the angle:', angle)
+                    # logger.debug('the angle:', angle)
 
                     self.ren.AddActor(self.obj_projection_arrow_actor)
                     self.ren.AddActor(self.object_orientation_torus_actor)

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 import plistlib
 import weakref
@@ -48,6 +49,9 @@ import invesalius.session as ses
 from invesalius import inv_paths
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 Kernels = {
     "Basic Smooth 5x5": [
@@ -195,22 +199,22 @@ class Volume:
         self.LoadVolume()
 
     def OnHideVolume(self):
-        print("Hide Volume")
+        logger.debug("Hide Volume")
         self.volume.SetVisibility(0)
         if self.plane and self.plane_on:
             self.plane.Disable()
         Publisher.sendMessage("Render volume viewer")
 
     def OnShowVolume(self):
-        print("Show volume")
+        logger.debug("Show volume")
         if self.exist:
-            print("Volume exists")
+            logger.debug("Volume exists")
             self.volume.SetVisibility(1)
             if self.plane and self.plane_on:
                 self.plane.Enable()
             Publisher.sendMessage("Render volume viewer")
         else:
-            print("Volume doesnt exit")
+            logger.debug("Volume doesnt exit")
             Publisher.sendMessage("Load raycasting preset", preset_name=const.RAYCASTING_LABEL)
             self.LoadConfig()
             self.LoadVolume()
@@ -264,7 +268,7 @@ class Volume:
             Publisher.sendMessage("Render volume viewer")
 
     def OnFlipVolume(self, axis):
-        print("Flipping Volume")
+        logger.debug("Flipping Volume")
         self.loaded_image = False
         del self.image
         self.image = None

--- a/invesalius/data/volume_widgets.py
+++ b/invesalius/data/volume_widgets.py
@@ -17,9 +17,13 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 from vtkmodules.vtkFiltersSources import vtkPlaneSource
 from vtkmodules.vtkInteractionWidgets import vtkImagePlaneWidget
 from vtkmodules.vtkRenderingCore import vtkActor, vtkCellPicker, vtkPolyDataMapper
+
+logger = logging.getLogger(__name__)
+
 
 AXIAL, SAGITAL, CORONAL = 0, 1, 2
 PLANE_DATA = {AXIAL: ["z", (0, 0, 1)], SAGITAL: ["x", (1, 0, 0)], CORONAL: ["y", (0, 1, 0)]}
@@ -67,7 +71,7 @@ class Plane:
         else:
             self.Update()
             if self.widget.GetEnabled():
-                print("send signal - update slice info in panel and in 2d")
+                logger.debug("send signal - update slice info in panel and in 2d")
 
     def SetInput(self, imagedata):
         axes = PLANE_DATA[self.orientation][0]  # "x", "y" or "z"

--- a/invesalius/enhanced_logging.py
+++ b/invesalius/enhanced_logging.py
@@ -1042,7 +1042,7 @@ class EnhancedLogger:
                     config = json.load(f)
                     self._config = deep_merge_dict(self._config.copy(), config)
         except Exception as e:
-            print(f"Error reading log config: {e}")
+            logger.debug(f"Error reading log config: {e}")
 
     def _write_config(self) -> None:
         """Write the logging configuration to the config file."""
@@ -1050,7 +1050,7 @@ class EnhancedLogger:
             with open(LOG_CONFIG_PATH, "w") as f:
                 json.dump(self._config, f, indent=4)
         except Exception as e:
-            print(f"Error writing log config: {e}")
+            logger.debug(f"Error writing log config: {e}")
 
     def _configure_logging(self) -> None:
         """Configure logging based on the configuration."""
@@ -1095,7 +1095,7 @@ class EnhancedLogger:
             )
 
         except Exception as e:
-            print(f"Error configuring logging: {e}")
+            logger.debug(f"Error configuring logging: {e}")
             import traceback
 
             traceback.print_exc()
@@ -1226,7 +1226,7 @@ class EnhancedLogger:
                 # Log the cleanup
                 self._logger.info("Cleaning up enhanced logger resources")
         except Exception as e:
-            print(f"Error during enhanced logger cleanup: {e}")
+            logger.debug(f"Error during enhanced logger cleanup: {e}")
 
 
 # Create the enhanced logger instance

--- a/invesalius/error_handling.py
+++ b/invesalius/error_handling.py
@@ -373,9 +373,9 @@ def show_error_dialog(message: str, exception: Optional[InVesaliusException] = N
     """
     if wx.GetApp() is None:
         # No GUI available, just print the error
-        print(f"ERROR: {message}")
+        logger.debug(f"ERROR: {message}")
         if exception and exception.details.get("traceback"):
-            print(exception.details["traceback"])
+            logger.debug(exception.details["traceback"])
         return
 
     # Create a dialog with details that can be expanded
@@ -691,8 +691,8 @@ def global_exception_handler(exctype, value, tb):
         )
     else:
         # No GUI available, just print the error
-        print(f"CRITICAL ERROR: {str(value)}")
-        print(f"A crash report has been created at: {crash_report_path}")
+        logger.debug(f"CRITICAL ERROR: {str(value)}")
+        logger.debug(f"A crash report has been created at: {crash_report_path}")
 
 
 # Set the global exception handler

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -17,6 +17,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 import pathlib
 import sys
@@ -36,6 +37,9 @@ import invesalius.session as ses
 from invesalius import inv_paths, project
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 (
     BTN_NEW,
@@ -2462,9 +2466,9 @@ class AnnotationsListCtrlPanel(wx.ListCtrl):
     def OnCheckItem(self, index, flag):
         # TODO: use pubsub to communicate to models
         if flag:
-            print("checked, ", index)
+            logger.debug("checked, ", index)
         else:
-            print("unchecked, ", index)
+            logger.debug("unchecked, ", index)
 
     def InsertNewItem(self, index=0, name="Axial 1", type_="2d", value="bla", colour=None):
         self.InsertItem(index, "")

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import sys
 
 import wx
@@ -33,6 +34,9 @@ import invesalius.gui.task_surface as surface
 import invesalius.session as ses
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 FPB_DEFAULT_STYLE = 2621440
 
@@ -294,7 +298,7 @@ class UpperTaskPanel(wx.Panel):
         session = ses.Session()
         mode = session.GetConfig("mode")
 
-        print("Mode: ", mode)
+        logger.debug("Mode: ", mode)
 
         if mode == const.MODE_RP:
             tasks = [

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -20,6 +20,7 @@
 
 import datetime
 import itertools
+import logging
 import os
 import random
 import sys
@@ -106,6 +107,8 @@ from invesalius.gui.widgets.inv_spinctrl import InvFloatSpinCtrl, InvSpinCtrl
 from invesalius.i18n import tr as _
 from invesalius.math_utils import inner1d
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from invesalius.data.mask import Mask
@@ -3061,7 +3064,7 @@ class PanelFFillThreshold(wx.Panel):
     def OnSlideChanged(self, evt: wx.Event) -> None:
         self.config.t0 = int(self.threshold.GetMinValue())
         self.config.t1 = int(self.threshold.GetMaxValue())
-        print(self.config.t0, self.config.t1)
+        logger.debug("Threshold changed: %s, %s", self.config.t0, self.config.t1)
 
 
 class PanelFFillDynamic(wx.Panel):
@@ -3362,7 +3365,7 @@ class FFillOptionsDialog(wx.Dialog):
             self.config.con_3d = 26
 
     def OnClose(self, evt: wx.CloseEvent) -> None:
-        print("ONCLOSE")
+        logger.debug("PanelFFillDynamic ONCLOSE")
         if self.config.dlg_visible:
             Publisher.sendMessage("Disable style", style=const.SLICE_STATE_MASK_FFILL)
         evt.Skip()
@@ -4033,7 +4036,7 @@ class MaskDensityDialog(wx.Dialog):
         self.max_density.SetValue(str(_max))
         self.std_density.SetValue(str(_std))
 
-        print(">>>> Area of mask", slc.calc_mask_area(mask))
+        logger.debug("Area of mask: %s", slc.calc_mask_area(mask))
 
 
 class ObjectCalibrationDialog(wx.Dialog):
@@ -4906,13 +4909,13 @@ class ICPCorregistrationDialog(wx.Dialog):
         self.SetProgress(0.5)
 
         if self.icp_mode == 0:
-            print("Affine mode")
+            logger.info("Affine mode")
             icp.GetLandmarkTransform().SetModeToAffine()
         elif self.icp_mode == 1:
-            print("Similarity mode")
+            logger.info("Similarity mode")
             icp.GetLandmarkTransform().SetModeToSimilarity()
         elif self.icp_mode == 2:
-            print("Rigid mode")
+            logger.info("Rigid mode")
             icp.GetLandmarkTransform().SetModeToRigidBody()
 
         # icp.DebugOn()
@@ -5546,7 +5549,7 @@ class CreateBrainTargetDialog(wx.Dialog):
         brain_target_actor.GetProperty().SetColor([1, 1, 0])
         self.brain_target_actor_list.append(brain_target_actor)
 
-        print("Adding brain markers")
+        logger.info("Adding brain markers")
 
     def LoadTarget(self) -> vtkActor:
         coord_flip = list(self.marker)
@@ -5979,7 +5982,7 @@ class CreateBrainTargetDialog(wx.Dialog):
                 brain_target_actor.PickableOff()
                 brain_target_actor.GetProperty().SetColor([1, 1, 0])
                 self.brain_target_actor_list.append(brain_target_actor)
-                print("Adding brain markers")
+                logger.info("Adding brain markers")
 
     def OnSendMtms(self, evt: wx.CommandEvent | None = None) -> None:
         vtkmat = self.marker_actor.GetMatrix()
@@ -6230,7 +6233,7 @@ class SurfaceProgressWindow:
         self.dlg.Show()
 
     def WasCancelled(self) -> bool:
-        #  print("Cancelled?", self.dlg.WasCancelled())
+        #  logger.debug("Cancelled?", self.dlg.WasCancelled())
         return self.dlg.WasCancelled()
 
     def Update(self, msg: str | None = None, value=None) -> None:
@@ -7188,7 +7191,7 @@ class ConfigurePolarisDialog(wx.Dialog):
                 desc_list.append(p.description)
             port_selec = [i for i, e in enumerate(desc_list) if "NDI" in e]
 
-        # print("Here is the chosen port: {} with id {}".format(port_selec[0], port_selec[1]))
+        # logger.debug("Here is the chosen port: {} with id {}".format(port_selec[0], port_selec[1]))
 
         return port_list, port_selec
 

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -20,6 +20,7 @@
 # -*- coding: UTF-8 -*-
 
 # TODO: To create a beautiful API
+import logging
 import sys
 import time
 
@@ -39,6 +40,9 @@ from invesalius.data import converters, imagedata_utils
 from invesalius.gui.widgets.canvas_renderer import CanvasRendererCTX
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 if sys.platform == "win32":
     try:
@@ -553,7 +557,7 @@ class DicomPreviewSlice(wx.Panel):
             if isinstance(dicom.image.thumbnail_path, list):
                 _slice = 0
                 for thumbnail in dicom.image.thumbnail_path:
-                    print(thumbnail)
+                    logger.debug(thumbnail)
                     info = DicomInfo(
                         n, dicom, _("Image %d") % (n), f"{dicom.image.position[2]:.2f}", _slice
                     )
@@ -588,7 +592,7 @@ class DicomPreviewSlice(wx.Panel):
             if isinstance(dicom.image.thumbnail_path, list):
                 _slice = 0
                 for thumbnail in dicom.image.thumbnail_path:
-                    print(thumbnail)
+                    logger.debug(thumbnail)
                     info = DicomInfo(
                         n, dicom, _("Image %d") % int(n), f"{dicom.image.position[2]:.2f}", _slice
                     )

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------
 
+import logging
 import errno
 import os.path
 import platform
@@ -47,6 +48,9 @@ from invesalius.gui import project_properties
 from invesalius.gui.interactive_shell import InteractiveShellFrame
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 try:
     from wx.adv import TaskBarIcon as wx_TaskBarIcon
@@ -667,7 +671,7 @@ class Frame(wx.Frame):
                 import traceback
 
                 traceback.print_exc()
-                print(f"Error cleaning up log viewer: {e}")
+                logger.debug(f"Error cleaning up log viewer: {e}")
 
             if status == 1:
                 Publisher.sendMessage("Exit session")
@@ -1266,7 +1270,7 @@ class Frame(wx.Frame):
             enhanced_logging.show_log_viewer(self)
 
         except Exception as e:
-            print(f"Error showing log viewer: {e}")
+            logger.debug(f"Error showing log viewer: {e}")
             import traceback
 
             traceback.print_exc()
@@ -1718,10 +1722,10 @@ class MenuBar(wx.MenuBar):
         if id != const.ID_PLUGINS_SHOW_PATH:
             try:
                 plugin_name = self._plugins_menu_ids[id]["name"]
-                print("Loading plugin:", plugin_name)
+                logger.debug("Loading plugin:", plugin_name)
                 Publisher.sendMessage("Load plugin", plugin_name=plugin_name)
             except KeyError:
-                print("Invalid plugin")
+                logger.debug("Invalid plugin")
         evt.Skip()
 
     def SliceInterpolationStatus(self):
@@ -2072,7 +2076,7 @@ class ProjectToolBar(AuiToolBar):
             # Forward to parent's menu click handler
             wx.PostEvent(self.parent, evt)
         except Exception as e:
-            print(f"Error handling toolbar click: {e}")
+            logger.debug(f"Error handling toolbar click: {e}")
             import traceback
 
             traceback.print_exc()

--- a/invesalius/gui/log.py
+++ b/invesalius/gui/log.py
@@ -21,6 +21,7 @@
 import json
 import logging
 import logging.config
+import logging.handlers
 import os
 import sys
 from datetime import datetime
@@ -35,7 +36,7 @@ from invesalius.utils import deep_merge_dict
 
 LOG_CONFIG_PATH = os.path.join(inv_paths.USER_INV_DIR, "log_config.json")
 DEFAULT_LOGFILE = os.path.join(
-    inv_paths.USER_LOG_DIR, datetime.now().strftime("invlog-%Y_%m_%d-%I_%M_%S_%p.log")
+    inv_paths.USER_LOG_DIR, "invesalius.log"
 )
 
 actionDictionary00 = {
@@ -145,12 +146,12 @@ class InvesaliusLogger:  # metaclass=Singleton):
 
     def ReadConfigFile(self, fPath=LOG_CONFIG_PATH):
         try:
-            print(fPath, os.path.abspath(fPath))
+            self._logger.debug(f"{fPath} {os.path.abspath(fPath)}")
             self._read_config_from_json(fPath)
-            print("Reading Log config file ", fPath)
-            print(self._config)
+            self._logger.debug(f"Reading Log config file {fPath}")
+            self._logger.debug(self._config)
         except Exception as e1:
-            print("Error reading config file in ReadConfigFile:", e1)
+            self._logger.error(f"Error reading config file in ReadConfigFile: {e1}")
         return True
 
     def WriteConfigFile(self):
@@ -166,7 +167,7 @@ class InvesaliusLogger:  # metaclass=Singleton):
             config_dict = json.load(config_file)
             self._config = deep_merge_dict(self._config.copy(), config_dict)
         except Exception as e1:
-            print("Error in _read_config_from_json:", e1)
+            self._logger.error(f"Error in _read_config_from_json: {e1}")
 
     def getLogger(self, lname=__name__):
         # logger = logging.getLogger(lname)
@@ -191,14 +192,14 @@ class InvesaliusLogger:  # metaclass=Singleton):
         append_log_file = self._config["append_log_file"]
         logging_file = self._config["logging_file"]
         logging_file = os.path.abspath(logging_file)
-        print("logging_file:", logging_file)
+        self._logger.debug(f"logging_file: {logging_file}")
         console_logging = self._config["console_logging"]
         # console_logging_level = self._config["console_logging_level"]
 
         self._logger.setLevel(self._config["base_logging_level"])
 
         if (self._frame is None) & (console_logging != 0):
-            print("Initiating console logging ...")
+            self._logger.debug("Initiating console logging ...")
             # self._frame = ConsoleLogFrame(self.getLogger())
 
             formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -207,18 +208,18 @@ class InvesaliusLogger:  # metaclass=Singleton):
             ch.setFormatter(formatter)
             self._logger.addHandler(ch)
 
-            print("Initiated console logging ...")
+            self._logger.debug("Initiated console logging ...")
             self._logger.info("Initiated console logging ...")
 
         msg = f"file_logging: {file_logging}, console_logging: {console_logging}"
-        print(msg)
+        self._logger.debug(msg)
 
         self._logger.info(msg)
         self._logger.info("configureLogging called ...")
         self.logMessage("info", msg)
 
         if file_logging:
-            # print('file_logging called ...')
+            # logger.debug('file_logging called ...')
             self._logger.info("file_logging called ...")
             file_logging_level = getattr(
                 logging, const.LOGGING_LEVEL_TYPES[file_logging_level].upper(), None
@@ -250,13 +251,13 @@ class InvesaliusLogger:  # metaclass=Singleton):
                             self._logger.info(msg)
                             self._logger.removeHandler(handler)
                             msg = f"Removed existing FILE handler {handler.baseFilename}"
-                            print(msg)
+                            self._logger.debug(msg)
                             self._logger.info(msg)
                 if addFileHandler:
-                    if os.path.exists(logging_file) & append_log_file:
-                        fh = logging.FileHandler(os.path.abspath(logging_file), "a", encoding=None)
+                    if append_log_file:
+                        fh = logging.handlers.RotatingFileHandler(os.path.abspath(logging_file), "a", maxBytes=5*1024*1024, backupCount=5, encoding=None)
                     else:
-                        fh = logging.FileHandler(os.path.abspath(logging_file), "w", encoding=None)
+                        fh = logging.handlers.RotatingFileHandler(os.path.abspath(logging_file), "w", maxBytes=5*1024*1024, backupCount=5, encoding=None)
 
                     fh.setFormatter(formatter)
                     self._logger.addHandler(fh)
@@ -312,7 +313,7 @@ def error_handling_decorator01(func: Callable[[str], None]):
         try:
             msg = f"Function {func.__name__} called"
             invLogger._logger.info(msg)
-            # print(f"{func.__name__} called")
+            # logger.debug(f"{func.__name__} called")
             func(*args, **kwargs)
         except Exception as e:
             invLogger._logger.error(f"Exception {e} encountered in Function {func.__name__} call")
@@ -347,7 +348,7 @@ def error_handling_decorator03(errorList: Dict[str, str]):
             msg = f"Function {func.__name__} called"
             invLogger._logger.info(msg)
             keys = [key for key in errorList]
-            print("keys:", keys)
+            invLogger._logger.debug(f"keys: {keys}")
             values = [errorList[key] for key in errorList]
             # keys, values = zip(*errorList.items())
             invLogger._logger.error(keys)
@@ -356,7 +357,7 @@ def error_handling_decorator03(errorList: Dict[str, str]):
                 func(*args, **kwargs)
             except (TypeError, ZeroDivisionError) as e:  # keys as e: #
                 invLogger._logger.error(f"Exception {e} found in {func.__name__} call")
-                # print('e:',e, type(e).__name__) #, e.__str__, e.args)
+                # logger.debug('e:',e, type(e).__name__) #, e.__str__, e.args)
                 exec(errorList[type(e).__name__])
             # else:
             # invLogger._logger.error(f"{func.__name__} ran successfully.")
@@ -374,7 +375,7 @@ def get_decorator(errors=(Exception,), default_value=""):
             try:
                 return func(*args, **kwargs)
             except errors:
-                print("Got error! ")  # , repr(e)
+                invLogger._logger.error("Got error! ")  # , repr(e)
                 return default_value
 
         return new_func

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -24,6 +24,10 @@ from invesalius.net.neuronavigation_api import NeuronavigationApi
 from invesalius.net.pedal_connection import PedalConnector
 from invesalius.pubsub import pub as Publisher
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Preferences(wx.Dialog):
     def __init__(
@@ -1558,7 +1562,8 @@ class ObjectTab(wx.Panel):
 
                 msg = _("Object file successfully loaded")
                 wx.MessageBox(msg, _("InVesalius 3"))
-        except:
+        except Exception:
+            logger.exception("Object registration file incompatible.")
             wx.MessageBox(_("Object registration file incompatible."), _("InVesalius 3"))
             Publisher.sendMessage("Update status text in GUI", label="")
 
@@ -2223,7 +2228,7 @@ class TrackerTab(wx.Panel):
 
     def OnTogglePressureSensor(self, evt):
         if not self.robot.robot_init_config:
-            print("Robot init config not loaded")
+            logger.debug("Robot init config not loaded")
             Publisher.sendMessage("Neuronavigation to Robot: Request config")
             self.chk_enable_pressure.SetValue(False)
             return

--- a/invesalius/gui/task_fmrisupport.py
+++ b/invesalius/gui/task_fmrisupport.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import matplotlib.pyplot as plt
 import nibabel as nb
 import numpy as np
@@ -31,6 +32,9 @@ import invesalius.utils as utils
 from invesalius.data.slice_ import Slice
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 
 class TaskPanel(wx.Panel):
@@ -225,6 +229,6 @@ class InnerTaskPanel(wx.Panel):
         if zero_value in self.slc.aux_matrices_colours["color_overlay"]:
             self.slc.aux_matrices_colours["color_overlay"][zero_value] = (0.0, 0.0, 0.0, 0.0)
         else:
-            print("Zero value not found in color_overlay. No data is set as transparent.")
+            logger.debug("Zero value not found in color_overlay. No data is set as transparent.")
 
         Publisher.sendMessage("Reload actual slice")

--- a/invesalius/gui/task_importer.py
+++ b/invesalius/gui/task_importer.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 
 import wx
@@ -30,6 +31,9 @@ import invesalius.constants as const
 from invesalius import inv_paths
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 BTN_IMPORT_LOCAL = wx.NewIdRef()
 BTN_IMPORT_PACS = wx.NewIdRef()
@@ -244,7 +248,7 @@ class InnerTaskPanel(wx.Panel):
         event.Skip()
 
     def ImportPACS(self):
-        print("TODO: Send Signal - Import DICOM files from PACS")
+        logger.debug("TODO: Send Signal - Import DICOM files from PACS")
 
     #######
     def ImportDicom(self):

--- a/invesalius/gui/task_mepmapping.py
+++ b/invesalius/gui/task_mepmapping.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import sys
 
 import matplotlib.pyplot as plt
@@ -34,6 +35,9 @@ import invesalius.utils as utils
 from invesalius.data.slice_ import Slice
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 
 class TaskPanel(wx.Panel):
@@ -195,7 +199,7 @@ class InnerTaskPanel(wx.Panel):
         if zero_value in self.slc.aux_matrices_colours["color_overlay"]:
             self.slc.aux_matrices_colours["color_overlay"][zero_value] = (0.0, 0.0, 0.0, 0.0)
         else:
-            print("Zero value not found in color_overlay. No data is set as transparent.")
+            logger.debug("Zero value not found in color_overlay. No data is set as transparent.")
 
         Publisher.sendMessage("Reload actual slice")
 
@@ -322,7 +326,7 @@ class SurfaceProperties(scrolled.ScrolledPanel):
         self.combo_surface_name.SetItems([n[0] for n in self.surface_list])
         self.combo_surface_name.SetSelection(i)
         # transparency = 100*surface.transparency
-        # print("Button color: ", colour)
+        # logger.debug("Button color: ", colour)
         self.button_colour.SetColour(colour)
         # self.slider_transparency.SetValue(int(transparency))
         #  Publisher.sendMessage('Update surface data', (index))

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -66,6 +66,10 @@ from invesalius.navigation.navigation import NavigationHub
 from invesalius.navigation.robot import RobotObjective
 from invesalius.pubsub import pub as Publisher
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 BTN_NEW = wx.NewIdRef()
 BTN_IMPORT_LOCAL = wx.NewIdRef()
 
@@ -2841,7 +2845,8 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         # In the future, it would be better if the panel could initialize itself based on markers in MarkersControl
         try:
             self.markers.LoadState()
-        except:
+        except Exception:
+            logger.exception("Failed to load state in task_navigator.py")
             self.session.DeleteStateFile()  # Delete state file if it is erroneous
 
         # Add all lines into main sizer
@@ -2943,7 +2948,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         deleted_marker_uuid = marker.marker_uuid
         idx = self.__find_marker_index(deleted_marker_id)
         self.marker_list_ctrl.DeleteItem(idx)
-        print("_DeleteMarker:", deleted_marker_uuid)
+        logger.debug("_DeleteMarker:", deleted_marker_uuid)
 
         # Delete the marker from itemDataMap
         for key, data in self.itemDataMap.items():
@@ -2988,7 +2993,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             try:
                 self.itemDataMap.pop(key)
             except KeyError:
-                print("Invalid itemDataMap key:", key)
+                logger.debug("Invalid itemDataMap key:", key)
 
         for idx in range(self.marker_list_ctrl.GetItemCount()):
             self.marker_list_ctrl.SetItem(idx, const.ID_COLUMN, str(idx))
@@ -4091,11 +4096,11 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             if self.navigation.coil_at_target:
                 self.mTMS.UpdateTarget(coil_pose, brain_target)
                 # wx.CallAfter(Publisher.sendMessage, 'Send brain target to mTMS API', coil_pose=coil_pose, brain_target=brain_target)
-                print("Send brain target to mTMS API")
+                logger.debug("Send brain target to mTMS API")
             else:
-                print("The coil is not at the target")
+                logger.debug("The coil is not at the target")
         else:
-            print("Target not set")
+            logger.debug("Target not set")
 
     def OnSessionChanged(self, evt, ctrl):
         value = ctrl.GetValue()

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 import sys
 
@@ -42,6 +43,9 @@ from invesalius.gui.widgets.inv_spinctrl import InvSpinCtrl
 from invesalius.i18n import tr as _
 from invesalius.project import Project
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 BTN_NEW = wx.NewIdRef()
 
@@ -963,7 +967,7 @@ class EditionTools(wx.Panel):
         Publisher.sendMessage("Set edition brush size", size=self.spin.GetValue())
 
     def OnContextMenu(self, evt):
-        print("Context")
+        logger.debug("Context")
         menu = wx.Menu()
         mm_item = menu.AppendRadioItem(MENU_UNIT_MM, "mm")
         um_item = menu.AppendRadioItem(MENU_UNIT_UM, "µm")
@@ -1212,7 +1216,7 @@ class WatershedTool(EditionTools):
         Publisher.sendMessage("Set watershed brush size", size=self.spin.GetValue())
 
     def OnContextMenu(self, evt):
-        print("Context")
+        logger.debug("Context")
         menu = wx.Menu()
         mm_item = menu.AppendRadioItem(MENU_UNIT_MM, "mm")
         um_item = menu.AppendRadioItem(MENU_UNIT_UM, "µm")

--- a/invesalius/gui/task_surface.py
+++ b/invesalius/gui/task_surface.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------------
+import logging
 import os
 import sys
 
@@ -39,6 +40,9 @@ from invesalius import inv_paths
 from invesalius.gui.widgets.inv_spinctrl import InvSpinCtrl
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 # INTERPOLATION_MODE_LIST = ["Cubic", "Linear", "NearestNeighbor"]
 MIN_TRANSPARENCY = 0
@@ -436,12 +440,12 @@ class SurfaceTools(wx.Panel):
             self.EndSeeding()
 
     def StartSeeding(self):
-        print("Start Seeding")
+        logger.debug("Start Seeding")
         Publisher.sendMessage("Enable style", style=const.VOLUME_STATE_SEED)
         Publisher.sendMessage("Create surface by seeding - start")
 
     def EndSeeding(self):
-        print("End Seeding")
+        logger.debug("End Seeding")
         Publisher.sendMessage("Disable style", style=const.VOLUME_STATE_SEED)
         Publisher.sendMessage("Create surface by seeding - end")
 
@@ -581,7 +585,7 @@ class SurfaceProperties(scrolled.ScrolledPanel):
         self.combo_surface_name.SetItems([n[0] for n in self.surface_list])
         self.combo_surface_name.SetSelection(i)
         transparency = 100 * surface.transparency
-        # print("Button color: ", colour)
+        # logger.debug("Button color: ", colour)
         self.button_colour.SetColour(colour)
         self.slider_transparency.SetValue(int(transparency))
         #  Publisher.sendMessage('Update surface data', (index))
@@ -686,4 +690,4 @@ class QualityAdjustment(wx.Panel):
         self.SetAutoLayout(1)
 
     def OnComboQuality(self, evt):
-        print(f"TODO: Send Signal - Change surface quality: {evt.GetString()}")
+        logger.debug(f"TODO: Send Signal - Change surface quality: {evt.GetString()}")

--- a/invesalius/gui/task_tools.py
+++ b/invesalius/gui/task_tools.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import os
 
 import wx
@@ -28,6 +29,9 @@ from invesalius import inv_paths
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
 from invesalius.session import Session
+
+logger = logging.getLogger(__name__)
+
 
 ID_BTN_MEASURE_LINEAR = wx.NewIdRef()
 ID_BTN_MEASURE_ANGULAR = wx.NewIdRef()
@@ -133,7 +137,7 @@ class InnerTaskPanel(wx.Panel):
         self.Fit()
 
     def OnTextAnnotation(self, evt=None):
-        print("TODO: Send Signal - Add text annotation (both 2d and 3d)")
+        logger.debug("TODO: Send Signal - Add text annotation (both 2d and 3d)")
 
     def OnLinkLinearMeasure(self):
         Publisher.sendMessage("Enable style", style=constants.STATE_MEASURE_DISTANCE)

--- a/invesalius/gui/task_tractography.py
+++ b/invesalius/gui/task_tractography.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import time
 from functools import partial
 
@@ -56,6 +57,9 @@ import invesalius.project as prj
 import invesalius.utils as utils
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 
 class TaskPanel(wx.Panel):
@@ -410,7 +414,7 @@ class InnerTaskPanel(wx.Panel):
                 self.tp.running = False
 
             t_end = time.time()
-            print(f"Elapsed time - {t_end - t_init}")
+            logger.debug(f"Elapsed time - {t_end - t_init}")
             self.tp.Close()
             if self.tp.error:
                 dlgg = GMD.GenericMessageDialog(
@@ -474,7 +478,7 @@ class InnerTaskPanel(wx.Panel):
                     self.TrekkerCallback(completed_future)
 
                 t_end = time.time()
-                print(f"Elapsed time - {t_end - t_init}")
+                logger.debug(f"Elapsed time - {t_end - t_init}")
                 self.tp.Close()
                 if self.tp.error:
                     dlgg = GMD.GenericMessageDialog(
@@ -493,7 +497,7 @@ class InnerTaskPanel(wx.Panel):
 
     def TrekkerCallback(self, trekker):
         self.tp.running = False
-        print("Import Complete")
+        logger.debug("Import Complete")
         if trekker is not None:
             self.trekker = trekker.result()
             self.trekker, n_threads = dti.set_trekker_parameters(self.trekker, self.trekker_cfg)
@@ -536,7 +540,7 @@ class InnerTaskPanel(wx.Panel):
                         self.tp.running = False
 
                     t_end = time.time()
-                    print(f"Elapsed time - {t_end - t_init}")
+                    logger.debug(f"Elapsed time - {t_end - t_init}")
                     self.tp.Close()
                     if self.tp.error:
                         dlgg = GMD.GenericMessageDialog(
@@ -614,7 +618,7 @@ class InnerTaskPanel(wx.Panel):
         # It updates when cross updates
         # pass
         if self.view_tracts and not self.nav_status:
-            # print("Running during navigation")
+            # logger.debug("Running during navigation")
             coord_flip = list(position[:3])
             coord_flip[1] = -coord_flip[1]
             dti.compute_and_visualize_tracts(

--- a/invesalius/gui/widgets/canvas_renderer.py
+++ b/invesalius/gui/widgets/canvas_renderer.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import sys
 from abc import ABC, abstractmethod
 from typing import (
@@ -39,6 +40,9 @@ from typing_extensions import Self
 from vtkmodules.vtkRenderingCore import vtkActor2D, vtkCoordinate, vtkImageMapper
 
 from invesalius.data import converters
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from vtkmodules.vtkRenderingCore import vtkRenderer
@@ -137,19 +141,19 @@ class CanvasRendererCTX:
     def unsubscribe_event(self, event: str, callback: Callable) -> None:
         for n, cb in enumerate(self._callback_events[event]):
             if cb() == callback:
-                print("removed")
+                logger.debug("removed")
                 self._callback_events[event].pop(n)
                 return
 
     def propagate_event(self, root: Optional["CanvasObjects"], event: CanvasEvent) -> None:
-        print("propagating", event.event_name, "from", root)
+        logger.debug("propagating", event.event_name, "from", root)
         node = root
         callback_name = f"on_{event.event_name}"
         while node:
             try:
                 getattr(node, callback_name)(event)
             except AttributeError as e:
-                print("errror", node, e)
+                logger.debug("errror", node, e)
             node = node.parent
 
     def _init_canvas(self) -> None:
@@ -206,7 +210,7 @@ class CanvasRendererCTX:
                 obj = i.is_over(x, y)
                 self._over_obj = obj
                 if obj:
-                    print("is over at", n, i)
+                    logger.debug("is over at", n, i)
                     return True
             except AttributeError:
                 pass
@@ -1244,7 +1248,7 @@ class Polygon(CanvasHandlerBase):
     def on_select(self, evt: CanvasEvent) -> None:
         mx, my = evt.position
         self.interactive = True
-        print("on_select", self.interactive)
+        logger.debug("on_select", self.interactive)
         if self.is_3d:
             x, y, z = evt.viewer.get_coordinate_cursor(mx, my)
             self._last_position = (x, y, z)

--- a/invesalius/inv_paths.py
+++ b/invesalius/inv_paths.py
@@ -16,6 +16,7 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # --------------------------------------------------------------------
+import logging
 import os
 import pathlib
 import shutil
@@ -23,6 +24,7 @@ import sys
 import tempfile
 
 HOME_DIR = pathlib.Path().home()
+logger = logging.getLogger(__name__)
 CONF_DIR = pathlib.Path(os.environ.get("XDG_CONFIG_HOME", HOME_DIR.joinpath(".config")))
 USER_INV_DIR = CONF_DIR.joinpath("invesalius")
 USER_PRESET_DIR = USER_INV_DIR.joinpath("presets")
@@ -103,9 +105,10 @@ def create_conf_folders() -> None:
 def copy_old_files() -> None:
     for f in OLD_USER_INV_DIR.glob("*"):
         if f.is_file():
-            print(
-                shutil.copy(
-                    f,
-                    USER_INV_DIR.joinpath(str(f).replace(str(OLD_USER_INV_DIR) + "/", "")),
+                logger.info(
+                    "Copied: %s",
+                    shutil.copy(
+                        f,
+                        USER_INV_DIR.joinpath(str(f).replace(str(OLD_USER_INV_DIR) + "/", "")),
+                    )
                 )
-            )

--- a/invesalius/navigation/image.py
+++ b/invesalius/navigation/image.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 from typing import Any, Dict, Sequence, Union
 
 import numpy as np
@@ -27,6 +28,8 @@ import invesalius.project as prj
 import invesalius.session as ses
 from invesalius.data.markers.marker import MarkerType
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
 
 
 class Image:
@@ -67,7 +70,7 @@ class Image:
         self.fiducials[fiducial_index, :] = position
         self.UpdateFiducialMarker(fiducial_index)
 
-        print(f"Image fiducial {fiducial_index} set to coordinates {position}")
+        logger.debug(f"Image fiducial {fiducial_index} set to coordinates {position}")
         ses.Session().ChangeProject()
         self.SaveState()
 
@@ -136,7 +139,8 @@ class Image:
                 self.load_from_state = False
                 try:
                     self.LoadState()
-                except:
+                except Exception:
+                    logger.exception("Failed to load state in image.py")
                     ses.Session.DeleteStateFile()
                     self.LoadProject()  # Load project if failed to load from state
             else:

--- a/invesalius/navigation/iterativeclosestpoint.py
+++ b/invesalius/navigation/iterativeclosestpoint.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -26,6 +27,9 @@ import invesalius.data.bases as db
 import invesalius.gui.dialogs as dlg
 import invesalius.session as ses
 from invesalius.utils import Singleton
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from invesalius.navigation.navigation import Navigation
@@ -40,7 +44,8 @@ class IterativeClosestPoint(metaclass=Singleton):
 
         try:
             self.LoadState()
-        except:  # noqa: E722
+        except Exception:
+            logger.exception("Caught exception")
             ses.Session().DeleteStateFile()
 
     def SaveState(self) -> None:

--- a/invesalius/navigation/mtms.py
+++ b/invesalius/navigation/mtms.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import time
 
@@ -6,6 +7,9 @@ import pandas as pd
 import win32com.client
 
 import invesalius.data.coregistration as dcr
+
+logger = logging.getLogger(__name__)
+
 
 
 class mTMS:
@@ -36,7 +40,7 @@ class mTMS:
             offset = self.GetOffset(distance)
             mTMS_target, mTMS_index_target = self.FindmTMSParameters(offset)
             if not len(mTMS_index_target[0]):
-                print("Not possible to stimulate the target: ", offset)
+                logger.debug("Not possible to stimulate the target: ", offset)
                 return False
         return True
 
@@ -73,7 +77,7 @@ class mTMS:
             }
             self.df = self.df.append(pd.DataFrame([new_row], columns=self.df.columns))
         else:
-            print("Target is not valid. The offset is: ", offset)
+            logger.debug("Target is not valid. The offset is: ", offset)
 
     def GetOffset(self, distance):
         offset_xy = [int(np.round(x)) for x in distance[:2]]
@@ -98,23 +102,23 @@ class mTMS:
     def SendToMTMS(self, target):
         # Manipulate intensity
         self.intensity = self.vi.GetControlValue("Get Intensity")
-        print("Intensity: ", str(self.intensity))
+        logger.debug("Intensity: ", str(self.intensity))
         # self.vi.SetControlValue('New Intensity', 40)
         # self.vi.SetControlValue('Set Intensity', True)
 
         # Update the Pulse - parameters row and wait until the change has been processed
         self.vi.SetControlValue("New Pulse-parameters row", int(target))
         self.vi.SetControlValue("Set Pulse-parameters row", True)
-        print("Updating brain target: ", int(target))
+        logger.debug("Updating brain target: ", int(target))
         while self.vi.GetControlValue("Set Pulse-parameters row"):
             pass
         time.sleep(0.3)
-        print("Charging capacitors...")
+        logger.debug("Charging capacitors...")
         while not self.vi.GetControlValue("Get Ready to stimulate"):
             pass
         # TODO: remove stimulation from here. The user should use the mtms interface to perform the stimuli
         # Stimulate
-        print("Stimulating")
+        logger.debug("Stimulating")
         self.vi.SetControlValue("Stimulate", True)
 
     def SaveSequence(self):

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import queue
 import threading
 import time
@@ -49,6 +50,9 @@ from invesalius.net.neuronavigation_api import NeuronavigationApi
 from invesalius.net.pedal_connection import PedalConnector
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton
+
+logger = logging.getLogger(__name__)
+
 
 
 class NavigationHub(metaclass=Singleton):
@@ -708,7 +712,7 @@ class Navigation(metaclass=Singleton):
                     affine_vtk,
                     img_shift,
                 )
-                # print("Appending the tract computation thread!")
+                # logger.debug("Appending the tract computation thread!")
                 queues = [self.coord_tracts_queue, self.tracts_queue]
                 if self.enable_act:
                     jobs_list.append(

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 from enum import Enum
 
 import numpy as np
@@ -28,6 +29,9 @@ import invesalius.session as ses
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton
+
+logger = logging.getLogger(__name__)
+
 
 
 class RobotObjective(Enum):
@@ -182,14 +186,14 @@ class Robot(metaclass=Singleton):
         # Ensure we fetch the robot-side config early so features like the force/pressure
         # overlay can be initialized without requiring the Preferences dialog to be opened.
         Publisher.sendMessage("Neuronavigation to Robot: Request config")
-        print("Connected to robot")
+        logger.debug("Connected to robot")
 
     def InitializeRobot(self):
         Publisher.sendMessage(
             "Neuronavigation to Robot: Set robot transformation matrix",
             data=self.matrix_tracker_to_robot.tolist(),
         )
-        print("Robot initialized")
+        logger.debug("Robot initialized")
 
     def GetCoilName(self):
         return self.coil_name

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import threading
 from typing import Dict, List, Optional, Tuple, cast
 
@@ -32,6 +33,9 @@ import invesalius.session as ses
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton
+
+logger = logging.getLogger(__name__)
+
 
 
 # Only one tracker will be initialized per time. Therefore, we use
@@ -55,7 +59,8 @@ class Tracker(metaclass=Singleton):
 
         try:
             self.LoadState()
-        except:  # noqa: E722
+        except Exception:
+            logger.exception("Caught exception")
             ses.Session().DeleteStateFile()
 
     def SaveState(self) -> None:
@@ -173,12 +178,12 @@ class Tracker(metaclass=Singleton):
                 self.tracker_id = 0
 
                 Publisher.sendMessage("Update status text in GUI", label=_("Tracker disconnected"))
-                print("Tracker disconnected!")
+                logger.debug("Tracker disconnected!")
             else:
                 Publisher.sendMessage(
                     "Update status text in GUI", label=_("Tracker still connected")
                 )
-                print("Tracker still connected!")
+                logger.debug("Tracker still connected!")
 
     def IsTrackerInitialized(self) -> bool:
         return bool(self.tracker_connection and self.tracker_id and self.tracker_connected)
@@ -244,7 +249,7 @@ class Tracker(metaclass=Singleton):
             coord_raw, 1
         )
 
-        print(f"Set tracker fiducial {fiducial_index} to coordinates {coord[0:3]}.")
+        logger.debug(f"Set tracker fiducial {fiducial_index} to coordinates {coord[0:3]}.")
 
         self.SaveState()
 

--- a/invesalius/net/dicom.py
+++ b/invesalius/net/dicom.py
@@ -1,6 +1,10 @@
+import logging
 import gdcm
 
 import invesalius.utils as utils
+
+logger = logging.getLogger(__name__)
+
 
 
 class DicomNet:
@@ -166,7 +170,7 @@ class DicomNet:
         const char *call=NULL, 
         const char *outputdir=NULL)"""
 
-        print(
+        logger.debug(
             ">>>>>",
             self.address,
             int(self.port),
@@ -187,7 +191,7 @@ class DicomNet:
             "/home/phamorim/Desktop/",
         )
 
-        print("BAIXOUUUUUUUU")
+        logger.debug("BAIXOUUUUUUUU")
         # ret = gdcm.DataSetArrayType()
 
         # cnf.CFind(self.address, int(self.port), theQuery, ret, self.aetitle,\

--- a/invesalius/net/pedal_connection.py
+++ b/invesalius/net/pedal_connection.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import logging
 import time
 from functools import partial
 from threading import Thread
@@ -26,6 +27,9 @@ import wx
 import invesalius.constants as const
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton, debug
+
+logger = logging.getLogger(__name__)
+
 
 HAS_PEDAL_CONNECTION = True
 try:
@@ -133,7 +137,7 @@ class MidiPedal(Thread, metaclass=Singleton):
             state = False
 
         else:
-            print("Unknown message type received from MIDI device")
+            logger.debug("Unknown message type received from MIDI device")
             return
 
         Publisher.sendMessage("Pedal state changed", state=state)
@@ -157,7 +161,7 @@ class MidiPedal(Thread, metaclass=Singleton):
 
             Publisher.sendMessage("Pedal connection", state=True)
 
-            print("Connected to MIDI device")
+            logger.debug("Connected to MIDI device")
 
     def _check_disconnected(self):
         if self._midi_in is not None:
@@ -166,7 +170,7 @@ class MidiPedal(Thread, metaclass=Singleton):
 
                 Publisher.sendMessage("Pedal connection", state=False)
 
-                print("Disconnected from MIDI device")
+                logger.debug("Disconnected from MIDI device")
 
     def _update_midi_inputs(self):
         self._midi_inputs = mido.get_input_names()

--- a/invesalius/net/remote_control.py
+++ b/invesalius/net/remote_control.py
@@ -18,12 +18,16 @@
 #    detalhes.
 # -------------------------------------------------------------------------
 
+import logging
 import time
 
 import socketio
 import wx
 
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
+
 
 
 class RemoteControl:
@@ -33,11 +37,11 @@ class RemoteControl:
         self._sio = None
 
     def _on_connect(self):
-        print("Connected to {}".format(self._remote_host))
+        logger.debug("Connected to {}".format(self._remote_host))
         self._connected = True
 
     def _on_disconnect(self):
-        print("Disconnected")
+        logger.debug("Disconnected")
         self._connected = False
 
     def _to_neuronavigation(self, msg):
@@ -46,7 +50,7 @@ class RemoteControl:
         if data is None:
             data = {}
 
-        # print("Received an event into topic '{}' with data {}".format(topic, str(data)))
+        # logger.debug("Received an event into topic '{}' with data {}".format(topic, str(data)))
         Publisher.sendMessage_no_hook(topicName=topic, **data)
 
     def _to_neuronavigation_wrapper(self, msg):
@@ -65,11 +69,11 @@ class RemoteControl:
         self._sio.emit("restart_robot_main_loop")
 
         while not self._connected:
-            print("Connecting...")
+            logger.debug("Connecting...")
             time.sleep(1.0)
 
         def _emit(topic, data):
-            # print("Emitting data {} to topic {}".format(data, topic))
+            # logger.debug("Emitting data {} to topic {}".format(data, topic))
             try:
                 if isinstance(topic, str):
                     self._sio.emit(

--- a/invesalius/plugins.py
+++ b/invesalius/plugins.py
@@ -18,6 +18,7 @@
 # --------------------------------------------------------------------
 
 import glob
+import logging
 import importlib.util
 import json
 import pathlib
@@ -28,6 +29,8 @@ from typing import TYPE_CHECKING
 
 from invesalius import inv_paths
 from invesalius.pubsub import pub as Publisher
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import os
@@ -75,7 +78,7 @@ class PluginManager:
                         "enable_startup": enable_startup,
                     }
             except Exception as err:
-                print(f"It was not possible to load plugin. Error: {err}")
+                logger.error("It was not possible to load plugin. Error: %s", err, exc_info=True)
 
         Publisher.sendMessage("Add plugins menu items", items=self.plugins)
 

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -18,6 +18,7 @@
 # --------------------------------------------------------------------------
 
 import datetime
+import logging
 import os
 import plistlib
 import shutil
@@ -38,6 +39,8 @@ from invesalius.gui.dialogs import ErrorMessageBox
 from invesalius.presets import Presets
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton, TwoWaysDictionary, debug, decode
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from invesalius.data.mask import Mask
@@ -644,7 +647,7 @@ def Extract_(
             tar.extract(member, path=folder)
             filelist.append(fname)
         else:
-            print(f"Skipping potential unsafe file: {member.name}")
+            logger.warning("Skipping potential unsafe file: %s", member.name)
     # tar.list(verbose=True)
     tar.close()
     return filelist

--- a/invesalius/reader/dicom.py
+++ b/invesalius/reader/dicom.py
@@ -17,9 +17,12 @@
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
 # ---------------------------------------------------------------------
+import logging
 import time
 
 import gdcm
+
+logger = logging.getLogger(__name__)
 
 import invesalius.constants as const
 import invesalius.utils as utils
@@ -1236,7 +1239,7 @@ class Parser:
         try:
             data = data.encode(encoding, errors="surrogateescape").decode(encoding)
         except Exception as err:
-            print(err)
+            logger.exception(err)
         return data
 
     def GetPatientID(self):
@@ -1508,7 +1511,7 @@ class Parser:
         try:
             data = data.encode(encoding, errors="surrogateescape").decode(encoding)
         except Exception as err:
-            print(err)
+            logger.exception(err)
 
         if data == "None":
             return _("unnamed")
@@ -1767,22 +1770,22 @@ if __name__ == "__main__":
 
         parser = Parser()
         if parser.SetFileName(filename):
-            print("p:", parser.GetPatientName())
-            print("l:", parser.GetImageLocation())
-            print("o:", parser.GetImagePatientOrientation())
-            print("t:", parser.GetImageThickness())
-            print("s:", parser.GetPixelSpacing())
-            print("x:", parser.GetDimensionX())
-            print("y:", parser.GetDimensionY())
-            print("z:", parser.GetDimensionZ())
+            logger.debug(f"p: {parser.GetPatientName()}")
+            logger.debug(f"l: {parser.GetImageLocation()}")
+            logger.debug(f"o: {parser.GetImagePatientOrientation()}")
+            logger.debug(f"t: {parser.GetImageThickness()}")
+            logger.debug(f"s: {parser.GetPixelSpacing()}")
+            logger.debug(f"x: {parser.GetDimensionX()}")
+            logger.debug(f"y: {parser.GetDimensionY()}")
+            logger.debug(f"z: {parser.GetDimensionZ()}")
         else:
-            print("--------------------------------------------------")
+            logger.debug("--------------------------------------------------")
             total -= 1
             fail_count += 1
 
-    print("\nREPORT:")
-    print("failed: ", fail_count)
-    print("sucess: ", total)
+    logger.debug("\\nREPORT:")
+    logger.debug(f"failed:  {fail_count}")
+    logger.debug(f"sucess:  {total}")
 
     # Example of how to use auxiliary functions
     total = 38

--- a/invesalius/segmentation/deep_learning/fastsurfer_subpart/data_process.py
+++ b/invesalius/segmentation/deep_learning/fastsurfer_subpart/data_process.py
@@ -31,6 +31,9 @@ from torch.utils.data import Dataset
 from . import misc
 from .misc import Config
 
+logger = logging.getLogger(__name__)
+
+
 SUPPORTED_OUTPUT_FILE_FORMATS = ("mgz", "nii", "nii.gz")
 LOGGER = logging.getLogger(__name__)
 
@@ -703,7 +706,7 @@ def scalecrop(
 
     # clip
     data_new = np.clip(data_new, dst_min, dst_max)
-    print("Output:   min: " + format(data_new.min()) + "  max: " + format(data_new.max()))
+    logger.debug("Output:   min: " + format(data_new.min()) + "  max: " + format(data_new.max()))
 
     return data_new
 
@@ -976,7 +979,7 @@ def conform(
             raise
         dtype_codes = mghformat.data_type_codes.code.keys()
         codes = set(k.name for k in dtype_codes if isinstance(k, np.dtype))
-        print(
+        logger.debug(
             f"The data type '{dtype}' is not recognized for MGH images, "
             f"switching to '{new_img.get_data_dtype()}' (supported: {tuple(codes)})."
         )
@@ -988,7 +991,7 @@ def reduce_to_aseg(data_inseg: np.ndarray) -> np.ndarray:
     """
     Reduce the input segmentation to a simpler segmentation.
     """
-    print("Reducing to aseg ...")
+    logger.debug("Reducing to aseg ...")
     # replace 2000... with 42
     data_inseg[data_inseg >= 2000] = 42
     # replace 1000... with 3
@@ -1000,13 +1003,13 @@ def create_mask(aseg_data, dnum, enum):
     """
     Create dilated mask.
     """
-    print("Creating dilated mask ...")
+    logger.debug("Creating dilated mask ...")
 
     # treat lateral orbital frontal and parsorbitalis special to avoid capturing too much of eye nerve
     lat_orb_front_mask = np.logical_or(aseg_data == 2012, aseg_data == 1012)
     parsorbitalis_mask = np.logical_or(aseg_data == 2019, aseg_data == 1019)
     frontal_mask = np.logical_or(lat_orb_front_mask, parsorbitalis_mask)
-    print("Frontal region special treatment: ", format(np.sum(frontal_mask)))
+    logger.debug("Frontal region special treatment: ", format(np.sum(frontal_mask)))
 
     # reduce to binary
     datab = aseg_data > 0
@@ -1016,10 +1019,10 @@ def create_mask(aseg_data, dnum, enum):
 
     labels = label(datab)
     assert labels.max() != 0
-    print(f"  Found {labels.max()} connected component(s)!")
+    logger.debug(f"  Found {labels.max()} connected component(s)!")
 
     if labels.max() > 1:
-        print("  Selecting largest component!")
+        logger.debug("  Selecting largest component!")
         datab = labels == np.argmax(np.bincount(labels.flat)[1:]) + 1
 
     # add frontal regions back to mask
@@ -1067,6 +1070,6 @@ def flip_wm_islands(aseg_data: np.ndarray) -> np.ndarray:
     flip_data = aseg_data.copy()
     flip_data[rhswap] = lh_wm
     flip_data[lhswap] = rh_wm
-    print(f"FlipWM: rh {rhswap.sum()} and lh {lhswap.sum()} flipped.")
+    logger.debug(f"FlipWM: rh {rhswap.sum()} and lh {lhswap.sum()} flipped.")
 
     return flip_data

--- a/invesalius/segmentation/deep_learning/fastsurfer_subpart/inference.py
+++ b/invesalius/segmentation/deep_learning/fastsurfer_subpart/inference.py
@@ -187,7 +187,7 @@ class TinyGradInference:
                 or (isinstance(device, str) and "cuda" in device.lower())
             )
         ):
-            print("*" * 100)
+            logger.debug("*" * 100)
             # Check if CUDA is available for ONNX Runtime
             available_providers = ort.get_available_providers() if ONNX_AVAILABLE else []
             self.use_gpu = "CUDAExecutionProvider" in available_providers

--- a/invesalius/segmentation/deep_learning/model.py
+++ b/invesalius/segmentation/deep_learning/model.py
@@ -1,7 +1,11 @@
+import logging
 from collections import OrderedDict
 
 import torch
 import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
 
 SIZE = 48
 
@@ -130,7 +134,7 @@ def main():
     model = Unet3D()
     model.to(dev)
     model.eval()
-    print(next(model.parameters()).is_cuda)  # True
+    logger.debug(next(model.parameters()).is_cuda)  # True
     img = torch.randn(1, SIZE, SIZE, SIZE, 1).to(dev)
     out = model(img)
     dot = torchviz.make_dot(
@@ -138,7 +142,7 @@ def main():
     )
     dot.render("unet", format="png")
     torch.save(model, "model.pth")
-    print(dot)
+    logger.debug(dot)
 
 
 if __name__ == "__main__":

--- a/invesalius/segmentation/deep_learning/segment.py
+++ b/invesalius/segmentation/deep_learning/segment.py
@@ -1,3 +1,4 @@
+import logging
 import itertools
 import multiprocessing
 import os
@@ -23,6 +24,9 @@ from invesalius.segmentation.deep_learning.fastsurfer_subpart.pipeline import ru
 from invesalius.utils import new_name_by_pattern
 
 from . import utils
+
+logger = logging.getLogger(__name__)
+
 
 SIZE = 48
 
@@ -241,8 +245,8 @@ def segment_torch_jit(
 
     from .model import WrapModel
 
-    print(f"\n\n\n{image_spacing}\n\n\n")
-    print("Patch size:", patch_size)
+    logger.debug(f"\n\n\n{image_spacing}\n\n\n")
+    logger.debug("Patch size:", patch_size)
 
     if resize_by_spacing:
         old_shape = image.shape
@@ -625,7 +629,7 @@ class SubpartSegmentProcess(SegmentProcess):
         # create temporary directory for output
         with tempfile.TemporaryDirectory() as temp_output_dir:
             try:
-                print("Starting subpart prediction pipeline...")
+                logger.debug("Starting subpart prediction pipeline...")
 
                 comm_array = np.memmap(
                     self._comm_array_filename, dtype=np.float32, shape=(1,), mode="r+"
@@ -680,11 +684,11 @@ class SubpartSegmentProcess(SegmentProcess):
                 final_segmentation = np.asarray(resampled_segmentation_img.dataobj)
                 final_segmentation = np.fliplr(np.swapaxes(final_segmentation, 0, 2))
 
-                print(
+                logger.debug(
                     f"Segmentation data range: [{final_segmentation.min()}, {final_segmentation.max()}]"
                 )
-                print(f"Segmentation unique values: {len(np.unique(final_segmentation))}")
-                print(f"Non-zero segmentation pixels: {np.count_nonzero(final_segmentation)}")
+                logger.debug(f"Segmentation unique values: {len(np.unique(final_segmentation))}")
+                logger.debug(f"Non-zero segmentation pixels: {np.count_nonzero(final_segmentation)}")
 
                 probability_array = np.memmap(
                     self._prob_array_filename,
@@ -845,7 +849,7 @@ class SubpartSegmentProcess(SegmentProcess):
         for category in self.selected_mask_types:
             regions = pick_regions(category)
             if not regions:
-                print(f"No regions found for category '{category}'. Skipping.")
+                logger.debug(f"No regions found for category '{category}'. Skipping.")
                 continue
 
             for rec in regions:
@@ -853,7 +857,7 @@ class SubpartSegmentProcess(SegmentProcess):
                 name = std_name(rec["LabelName"])
                 binmask = (seg == lid).astype(np.uint8) * 255
                 if not np.any(binmask):
-                    print(f"No voxels found for label ID {lid} ('{name}'). Skipping mask creation.")
+                    logger.debug(f"No voxels found for label ID {lid} ('{name}'). Skipping mask creation.")
                     continue
 
                 m = slc.Slice().create_new_mask(

--- a/invesalius/segmentation/tinygrad_extra/onnx.py
+++ b/invesalius/segmentation/tinygrad_extra/onnx.py
@@ -1,3 +1,4 @@
+import logging
 import dataclasses
 import functools
 import io
@@ -13,6 +14,9 @@ from tinygrad.device import is_dtype_supported
 from tinygrad.dtype import ConstType, DType, ImageDType, dtypes
 from tinygrad.helpers import DEBUG, all_same, flatten, getenv, make_tuple, prod
 from tinygrad.tensor import ReductionStr, Tensor, _broadcast_shape
+
+logger = logging.getLogger(__name__)
+
 
 
 def dtype_parse(onnx_dtype: int) -> DType:
@@ -204,7 +208,7 @@ def to_python_const(t: Any, op: str, idx: int) -> list[ConstType] | ConstType | 
     global cache_misses
     ret = _cached_to_python_const(t)
     if (info := _cached_to_python_const.cache_info()).misses > cache_misses and DEBUG >= 3:
-        print(f"Cache miss for {t}")
+        logger.debug(f"Cache miss for {t}")
         cache_misses = info.misses
     return ret
 
@@ -311,15 +315,15 @@ class OnnxRunner:
                 opts["intermediate_tensors"] = self.graph_values
 
             if debug >= 1:
-                print(f"{node.num}: op '{node.op}' opt {opts}")
+                logger.debug(f"{node.num}: op '{node.op}' opt {opts}")
             if debug >= 2 and node.inputs:
-                print(
+                logger.debug(
                     "\tinputs:\n" + "\n".join(f"\t\t{x} - {i!r}" for x, i in zip(node.inputs, inps))
                 )
             ret = self._dispatch_op(node.op, inps, opts)
             ret = ret if isinstance(ret, tuple) else (ret,)
             if debug >= 2:
-                print(
+                logger.debug(
                     "\toutputs:\n"
                     + "\n".join(f"\t\t{x} - {o!r}" for x, o in zip(node.outputs, ret))
                 )

--- a/invesalius/session.py
+++ b/invesalius/session.py
@@ -21,6 +21,7 @@
 import codecs
 import configparser as ConfigParser
 import json
+import logging
 import os
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -30,6 +31,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 from invesalius import inv_paths
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton, debug, deep_merge_dict
+
+logger = logging.getLogger(__name__)
 
 CONFIG_PATH = os.path.join(inv_paths.USER_INV_DIR, "config.json")
 OLD_CONFIG_PATH = os.path.join(inv_paths.USER_INV_DIR, "config.cfg")
@@ -130,9 +133,9 @@ class Session(metaclass=Singleton):
     def DeleteStateFile(self) -> None:
         if os.path.exists(STATE_PATH):
             os.remove(STATE_PATH)
-            print("Successfully deleted state file.")
+            logger.info("Successfully deleted state file.")
         else:
-            print("State file does not exist.")
+            logger.debug("State file does not exist.")
 
     def ExitedSuccessfullyLastTime(self) -> bool:
         return self._exited_successfully_last_time
@@ -356,8 +359,8 @@ class Session(metaclass=Singleton):
     def _ReadState(self) -> bool:
         success = False
         if os.path.exists(STATE_PATH):
-            print("Restoring a previous state...")
-            print("State file found.", STATE_PATH)
+            logger.info("Restoring a previous state...")
+            logger.info("State file found: %s", STATE_PATH)
 
             state_file = open(STATE_PATH)
             try:
@@ -365,7 +368,7 @@ class Session(metaclass=Singleton):
                 success = True
 
             except JSONDecodeError:
-                print("State file is corrupted. Deleting...")
+                logger.warning("State file is corrupted. Deleting...")
 
                 state_file.close()
                 self.DeleteStateFile()

--- a/invesalius/utils.py
+++ b/invesalius/utils.py
@@ -18,6 +18,7 @@
 # --------------------------------------------------------------------------
 import collections.abc
 import locale
+import logging
 import math
 import platform
 import re
@@ -31,6 +32,8 @@ import numpy as np
 from packaging.version import Version
 
 import invesalius
+
+logger = logging.getLogger(__name__)
 
 
 def format_time(value: str) -> str:
@@ -82,7 +85,7 @@ def debug(error_str: str) -> None:
 
     session = Session()
     if session.GetConfig("debug"):
-        print(error_str)
+        logger.debug(error_str)
 
 
 def next_copy_name(original_name: str, names_list: List[str]) -> str:
@@ -270,13 +273,13 @@ def calculate_resizing_tofitmemory(x_size, y_size, n_slices, byte):
             ram_total = psutil.phymem_usage().total
             swap_free = psutil.virtmem_usage().free
     except Exception:
-        print("Exception! psutil version < 0.3 (not recommended)")
+        logger.warning("Exception! psutil version < 0.3 (not recommended)")
         ram_total = psutil.TOTAL_PHYMEM  # this is for psutil < 0.3
         ram_free = 0.8 * psutil.TOTAL_PHYMEM
         swap_free = psutil.avail_virtmem()
 
-    print("RAM_FREE=", ram_free)
-    print("RAM_TOTAL=", ram_total)
+    logger.debug("RAM_FREE=%s", ram_free)
+    logger.debug("RAM_TOTAL=%s", ram_total)
 
     if sys.platform == "win32":
         if platform.architecture()[0] == "32bit":
@@ -328,7 +331,7 @@ def UpdateCheck() -> None:
         msgdlg.Show()
         # msgdlg.Destroy()
 
-    print("Checking updates...")
+    logger.info("Checking updates...")
 
     # Check if a language has been set.
     session = ses.Session()
@@ -358,7 +361,7 @@ def UpdateCheck() -> None:
             return
 
         if last_ver > actual_ver:
-            print("  ...New update found!!! -> version:", last)
+            logger.info("New update found! -> version: %s", last)
             wx.CallAfter(wx.CallLater, 1000, _show_update_info)
 
 
@@ -395,7 +398,7 @@ def timing(f):
         start = time.time()
         result = f(*args, **kwargs)
         end = time.time()
-        print(f"{f.__name__} elapsed time: {end - start}")
+        logger.debug("%s elapsed time: %s", f.__name__, end - start)
         return result
 
     return wrapper


### PR DESCRIPTION
This PR addresses Issue #498. I systematically replaced approximately 300 bare print() statements across 60 files with Python's native logging module so users can now actively route their logs. Additionally, I bound RotatingFileHandler locally so logs rotate sequentially in the user's data directory without overwhelming disk space, and secured several bare except: blocks into logger.exception().