### PR TITLE
fix (#1369): fixed delete all not restoring default marker view

### DIFF
--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3426,6 +3426,22 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         self.brain_targets_list_ctrl.SetSize((self.marker_list_ctrl.GetSize()[0], width))
         self.marker_list_ctrl.SetSize((self.marker_list_ctrl.GetSize()[0], width))
 
+    def __restore_default_marker_view(self):
+        """
+        Restore the marker list to its default view state.
+
+        This hides the brain targets list, disables the vector field assembly,
+        and resizes the marker list control to full height. Called when all
+        markers are deleted or when the last marker with brain targets is removed.
+        """
+        self.currently_focused_marker = None
+        Publisher.sendMessage("Set vector field assembly visibility", enabled=False)
+        self.brain_targets_list_ctrl.DeleteAllItems()
+        self.brain_targets_list_ctrl.Hide()
+        self.ResizeListCtrl(self.marker_list_height)
+        Publisher.sendMessage("Update navigation panel")
+        self.Update()
+
     # Called when a marker on the list gets the focus by the user left-clicking on it.
     def OnMarkerFocused(self, evt):
         idx = self.marker_list_ctrl.GetFocusedItem()
@@ -4137,9 +4153,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
                 return
         self.markers.Clear()
         self.itemDataMap.clear()
-        Publisher.sendMessage("Set vector field assembly visibility", enabled=False)
-        self.brain_targets_list_ctrl.DeleteAllItems()
-        self.brain_targets_list_ctrl.Hide()
+        self.__restore_default_marker_view()
 
     def OnDeleteFiducialMarker(self, label):
         indexes = []
@@ -4173,7 +4187,8 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             focus_index = min(indexes[0], remaining_count - 1)
             self.FocusOnMarker(focus_index)
         else:
-            self.currently_focused_marker = None  # disable focus if no markers left
+            # No markers left - restore the default view
+            self.__restore_default_marker_view()
 
     def OnDeleteSelectedBrainTarget(self, evt):
         if not self.currently_focused_marker:


### PR DESCRIPTION
## Fix #1369  marker view not restoring after deleting all / last marker with brain targets

### Summary

Fixes an issue where the UI did not return to the default marker view after deleting all markers or deleting the last marker when brain targets were visible.

### Fix

* Introduced a helper method `__restore_default_marker_view()` to centralize UI reset logic
* Ensures:

  * `currently_focused_marker` is cleared
  * Brain targets list is cleared and hidden
  * Marker list is resized to full height
  * Vector field assembly is disabled
  * UI layout is refreshed (`Update()`)
* Applied the helper in both deletion flows:

  * `OnDeleteAllMarkers`
  * `OnDeleteSelectedMarkers` (when no markers remain)

### Result

The UI now consistently resets to the default marker view with no residual split layout or empty space.

### Testing

Manually verified:

* Delete All with brain targets visible
* Deleting the last marker with brain targets
* Normal deletion flow with remaining markers

Confirmed correct UI restoration in all scenarios.

### Visual Verification


https://github.com/user-attachments/assets/5d6a0518-9671-4938-9f91-eccb30b71e4e




