### PR TITLE
Navigation Mode Crash Fix

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -833,6 +833,11 @@ class Controller:
     def LoadProject(self, create_default_mask=True, end_busy_cursor=True):
         proj = prj.Project()
 
+        if not proj.threshold_range or not hasattr(proj, 'matrix_shape'):
+            if end_busy_cursor:
+                Publisher.sendMessage("End busy cursor")
+            return
+
         const.THRESHOLD_OUTVALUE = proj.threshold_range[0]
         const.THRESHOLD_INVALUE = proj.threshold_range[1]
         const.THRESHOLD_RANGE = proj.threshold_modes[_("Bone")]

--- a/invesalius/session.py
+++ b/invesalius/session.py
@@ -279,7 +279,7 @@ class Session(metaclass=Singleton):
 
         # Do not reading project status from the config file, since there
         # isn't a recover session tool in InVesalius yet.
-        self.project_status = 3
+        self._config["project_status"] = 3
 
     def _read_config_from_ini(self, config_filename: str) -> None:
         file = codecs.open(config_filename, "rb", SESSION_ENCODING)


### PR DESCRIPTION
Fixes #1373 
## 1. Fixed Configuration Initialization (`invesalius/session.py`)

Corrected a typo that caused the app to falsely believe a project was still open from a previous session.

```diff
- self.project_status = 3
+ self._config["project_status"] = 3
```

## 2. Added Safety Guard (`invesalius/control.py`)

Added an early-return check in `LoadProject()` to prevent crashes when triggered without valid project data.

```diff
+ if not proj.threshold_range or not hasattr(proj, 'matrix_shape'):
+     if end_busy_cursor:
+         Publisher.sendMessage("End busy cursor")
+     return
```