### PR TITLE
Fix: Surface Colour/Transparency KeyError Crash

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -1382,6 +1382,8 @@ class SurfaceManager:
         Set actor transparency (oposite to opacity) according to given actor
         index and value.
         """
+        if surface_index not in self.actors_dict:
+            return
         self.actors_dict[surface_index].GetProperty().SetOpacity(1 - transparency)
         # Update value in project's surface_dict
         proj = prj.Project()
@@ -1390,6 +1392,8 @@ class SurfaceManager:
 
     def SetActorColour(self, surface_index, colour):
         """ """
+        if surface_index not in self.actors_dict:
+            return
         self.actors_dict[surface_index].GetProperty().SetColor(colour[:3])
         # Update value in project's surface_dict
         proj = prj.Project()


### PR DESCRIPTION
Fixes #1375 
Added early-return guards in both `SetActorTransparency()` and `SetActorColour()` to skip the operation when `surface_index` is not present in `actors_dict`.

```diff
  def SetActorTransparency(self, surface_index, transparency):
+     if surface_index not in self.actors_dict:
+         return
      self.actors_dict[surface_index].GetProperty().SetOpacity(1 - transparency)

  def SetActorColour(self, surface_index, colour):
+     if surface_index not in self.actors_dict:
+         return
      self.actors_dict[surface_index].GetProperty().SetColor(colour[:3])
```