### PR TITLE
Fix SetTargetTransparency: set opacity to 0.4 when transparent instead of 1.0

### DIFF
--- a/invesalius/data/visualization/marker_visualizer.py
+++ b/invesalius/data/visualization/marker_visualizer.py
@@ -381,11 +381,18 @@ class MarkerVisualizer:
         if not self.is_navigating:
             self.interactor.Render()
 
+
+
+
+
+
+
+
+
     def SetTargetTransparency(self, marker, transparent):
         actor = marker.visualization["actor"]
         if transparent:
-            actor.GetProperty().SetOpacity(1)
-            # actor.GetProperty().SetOpacity(0.4)
+            actor.GetProperty().SetOpacity(0.4)
         else:
             actor.GetProperty().SetOpacity(1)
 


### PR DESCRIPTION
## Bug

`SetTargetTransparency` in `marker_visualizer.py` was a no-op — both the
`transparent=True` and `transparent=False` branches set opacity to 1.0.
The correct value (0.4) was present but commented out.

## Fix

Set `SetOpacity(0.4)` when `transparent` is `True`, keeping `SetOpacity(1)` 
when `False`. Also removed the commented-out line.

## How I found it

The intended opacity value was visible in a comment on the line directly 
below the incorrect `SetOpacity(1)` call, introduced in commit c1a961f.