### PR TITLE
fix (#1379): fixed Crash when using window/level in the volume view

### DIFF
--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -460,6 +460,10 @@ class WWWLInteractorStyle(DefaultInteractorStyle):
 
     def OnWindowLevelMove(self, obj, evt):
         if self.changing_wwwl:
+            # Check if volume rendering is active before processing window/level changes
+            if not self.viewer.raycasting_volume:
+                return
+
             mouse_x, mouse_y = self.viewer.get_vtk_mouse_position()
             diff_x = mouse_x - self.last_x
             diff_y = mouse_y - self.last_y

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -302,6 +302,10 @@ class Volume:
         Publisher.sendMessage("Set volume window and level text", ww=ww, wl=wl)
 
     def OnSetRelativeWindowLevel(self, diff_wl, diff_ww):
+        # Defensive check: ensure ww and wl are initialized (volume rendering must be active)
+        if self.ww is None or self.wl is None:
+            return
+
         ww = self.ww + diff_ww
         wl = self.wl + diff_wl
         Publisher.sendMessage("Set volume window and level text", ww=ww, wl=wl)


### PR DESCRIPTION
### Fixes #1379 

### Problem

Using the Window/Level (WW/WL) tool in the 3D view without active volume rendering (empty view or surface-only) caused a crash:
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

This happened because `ww` and `wl` were `None` but still used in arithmetic operations.

### Solution

Implemented a two-layer defense:

1. UI Layer (styles_3d.py)

   * Added a check for `viewer.raycasting_volume` in `OnWindowLevelMove`
   * Prevents sending the event when no volume rendering is active

2. Core Layer (volume.py)

   * Added a guard in `OnSetRelativeWindowLevel` to return if `ww` or `wl` is `None`
   * Ensures no crash even if the event is triggered from other sources

### Result

* No crash when volume rendering is inactive
* Window/Level tool works correctly when volume rendering is active
* Improves overall robustness with defensive programming

### How to Test

1. No volume / surface-only → Use tool → No crash, no effect
2. Volume rendering enabled → Use tool → Works normally
