### PR TITLE
ENH (#301) : Save As dialog now opens in project directory

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -574,7 +574,7 @@ class Controller:
             self.LoadProject(end_busy_cursor=False)
 
             session = ses.Session()
-            session.OpenProject(filepath)
+            session.OpenProject(path)  # Use absolute path, not original filepath
             Publisher.sendMessage("Enable state project", state=True)
             
             # Complete - dialog will auto-hide at 100%

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -560,18 +560,34 @@ def ShowSaveAsProjectDialog(default_filename: str) -> tuple[str | None, bool]:
     current_dir = os.path.abspath(".")
 
     session = ses.Session()
-    last_directory = session.GetConfig("last_directory_inv3", "")
 
-    # Never pre-fill with the temp backup directory: if the user recovered
-    # from a crash, last_directory may point inside the backup folder.
-    # Reset it so the dialog opens somewhere sensible instead.
-    if last_directory and "temp_backup" in str(last_directory):
-        last_directory = ""
+    # Try to use the project's original directory first
+    default_dir = ""
+
+    # Don't use project_path if it's a temporary project (not yet saved)
+    # temp_item is True for: newly imported DICOM, recovered backups, etc.
+    if not session.temp_item:
+        project_path = session.GetState("project_path")
+        if (
+            project_path
+            and isinstance(project_path, tuple)
+            and len(project_path) == 2
+            and project_path[0]
+        ):
+            default_dir = project_path[0]
+
+    # Fallback to last used directory if no valid project directory
+    if not default_dir:
+        default_dir = session.GetConfig("last_directory_inv3", "")
+
+    # Never pre-fill with the temp backup directory
+    if default_dir and "temp_backup" in str(default_dir):
+        default_dir = ""
 
     dlg = wx.FileDialog(
         None,
         _("Save project as..."),  # title
-        last_directory,  # last used directory
+        default_dir,  # default directory
         default_filename,
         WILDCARD_INV_SAVE,
         wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,


### PR DESCRIPTION
### Implements #301 

## Summary

This PR improves the "Save As" dialog behavior by ensuring it opens in the directory where the project was originally opened, instead of a random or last-used location.

## Changes

- Use `project_path` from session state to set the default directory for saved projects
- Skip temporary projects using `temp_item` flag to avoid opening in system temp folders
- Fix incorrect directory issue caused by relative paths by passing absolute paths to `OpenProject()`

## Root Cause

1. `OpenProject()` was receiving relative paths, leading to incorrect directory resolution
2. Temporary projects (e.g., DICOM imports) were setting `project_path` to system temp directories

## Fix

- Converted project file path to absolute before calling `OpenProject()`
- Added condition to ignore `project_path` when `temp_item` is True
- Ensured fallback to `last_directory_inv3` when no valid project directory is available

## Behavior

- Opened `.inv3` projects → "Save As" defaults to project directory
- New/unsaved (DICOM) projects → fallback to last used directory
- Temp/backup projects → fallback to last used directory

## Testing

- Verified with projects saved on Desktop and inside subfolders
- Confirmed correct directory is used in all scenarios
- Ensured no regression in fallback behavior

## Impact

Improves user experience by reducing unnecessary navigation and ensuring consistent, intuitive behavior for the "Save As" dialog.