### PR TITLE
Fix #505: Add Enter key support for threshold inputs and ensure 2D slices update immediately

### DIFF
--- a/invesalius/gui/widgets/gradient.py
+++ b/invesalius/gui/widgets/gradient.py
@@ -729,6 +729,7 @@ class GradientCtrl(wx.Panel):
         """
         v = self.spin_min.GetValue()
         self.SetMinValue(v)
+        self._GenerateEvent(myEVT_THRESHOLD_CHANGING)
         self._GenerateEvent(myEVT_THRESHOLD_CHANGED)
 
     def OnMaxMouseWheel(self, e: wx.SpinEvent) -> None:
@@ -737,6 +738,7 @@ class GradientCtrl(wx.Panel):
         """
         v = self.spin_max.GetValue()
         self.SetMaxValue(v)
+        self._GenerateEvent(myEVT_THRESHOLD_CHANGING)
         self._GenerateEvent(myEVT_THRESHOLD_CHANGED)
 
     def SetColour(self, colour: Sequence[SupportsInt]) -> None:

--- a/invesalius/gui/widgets/inv_spinctrl.py
+++ b/invesalius/gui/widgets/inv_spinctrl.py
@@ -38,6 +38,7 @@ class InvSpinCtrl(wx.Panel):
     ):
         super().__init__(parent, id, size=size)
 
+        style = style | wx.TE_PROCESS_ENTER
         self._textctrl = wx.TextCtrl(self, -1, style=style)
         self._spinbtn: Optional[wx.SpinButton] = None
         if spin_button and wx.Platform != "__WXGTK__":
@@ -69,6 +70,7 @@ class InvSpinCtrl(wx.Panel):
     def __bind_events(self) -> None:
         self.Bind(wx.EVT_MOUSEWHEEL, self.OnMouseWheel)
         self._textctrl.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)
+        self._textctrl.Bind(wx.EVT_TEXT_ENTER, self.OnEnter)
         if self._spinbtn:
             self._spinbtn.Bind(wx.EVT_SPIN_UP, self.OnSpinUp)
             self._spinbtn.Bind(wx.EVT_SPIN_DOWN, self.OnSpinDown)
@@ -160,6 +162,12 @@ class InvSpinCtrl(wx.Panel):
         self.raise_event()
         evt.Skip()
 
+    def OnEnter(self, evt: wx.Event) -> None:
+        value = self._textctrl.GetValue()
+        self.SetValue(value)
+        self.raise_event()
+        evt.Skip()
+
     def OnSpinDown(self, evt: wx.SpinEvent) -> None:
         self.SetValue(self.GetValue() - self._increment)
         self.raise_event()
@@ -191,6 +199,7 @@ class InvFloatSpinCtrl(wx.Panel):
     ):
         super().__init__(parent, id, size=size)
 
+        style = style | wx.TE_PROCESS_ENTER
         self._textctrl = wx.TextCtrl(self, -1, style=style)
         self._spinbtn: Optional[wx.SpinButton] = None
         if spin_button and wx.Platform != "__WXGTK__":
@@ -223,6 +232,7 @@ class InvFloatSpinCtrl(wx.Panel):
     def __bind_events(self) -> None:
         self.Bind(wx.EVT_MOUSEWHEEL, self.OnMouseWheel)
         self._textctrl.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)
+        self._textctrl.Bind(wx.EVT_TEXT_ENTER, self.OnEnter)
         if self._spinbtn:
             self._spinbtn.Bind(wx.EVT_SPIN_UP, self.OnSpinUp)
             self._spinbtn.Bind(wx.EVT_SPIN_DOWN, self.OnSpinDown)
@@ -322,6 +332,12 @@ class InvFloatSpinCtrl(wx.Panel):
         evt.Skip()
 
     def OnKillFocus(self, evt: wx.FocusEvent) -> None:
+        value = self._textctrl.GetValue()
+        self.SetValue(value)
+        self.raise_event()
+        evt.Skip()
+
+    def OnEnter(self, evt: wx.Event) -> None:
         value = self._textctrl.GetValue()
         self.SetValue(value)
         self.raise_event()


### PR DESCRIPTION
## Description: 
### Fixes #505

This PR resolves two interconnected issues regarding the manual entry of threshold values in the "Select Region of Interest" panel


### Changes:

**Enter Key Support:** The InvSpinCtrl and InvFloatSpinCtrl widgets previously lacked the wx.TE_PROCESS_ENTER style flag and did not handle wx.EVT_TEXT_ENTER. Users had to explicitly click away to trigger a focus-loss event to commit values. I added the necessary flags and bound the OnEnter method to successfully capture and apply the threshold when the Enter key is pressed.

**Immediate 2D Slice Updates:** When manually typing a value (or using the spin arrows), the OnMinMouseWheel and OnMaxMouseWheel methods in GradientCtrl only emitted a myEVT_THRESHOLD_CHANGED event. Because the myEVT_THRESHOLD_CHANGING event was skipped, the 2D slices (Axial, Coronal, Sagittal) did not visually update their colors to reflect the new mask until the user manually scrolled the viewer. I updated these methods to correctly emit both CHANGING and CHANGED events, perfectly mirroring the visual slider's behavior and forcing an immediate redraw of the 2D viewers.

### Testing:

Open the application and load any dataset.
Go to the "Select Region of Interest" task panel.
Under "Mask properties", click inside either the minimum or maximum threshold text box.
Type a new value and press Enter.
Verify that the threshold slider moves immediately AND the colored mask overlay on the 2D slices instantly updates without requiring any extra mouse clicks or scrolling.

### After fix:


https://github.com/user-attachments/assets/01187a51-90a9-4048-a359-3e1764167928


