### PR TITLE
feat: Add 2D/3D selection for Image Filters and Properties context menu

### DIFF
--- a/invesalius/data/filters.py
+++ b/invesalius/data/filters.py
@@ -36,7 +36,7 @@ def despeckle_filter(matrix: np.ndarray, value: float) -> np.ndarray:
     return ndimage.gaussian_filter(matrix, sigma=value)
 
 
-def border_detection_filter(matrix: np.ndarray, value: float = 1.0) -> np.ndarray:
+def border_detection_filter(matrix: np.ndarray, value: float = 1.0, normalize: bool = True) -> np.ndarray:
     """Sobel gradient magnitude with Gaussian pre-smoothing.
     Uses 'value' as the sigma for the pre-smoothing step to control noise sensitivity.
     """
@@ -46,8 +46,14 @@ def border_detection_filter(matrix: np.ndarray, value: float = 1.0) -> np.ndarra
 
     sx = ndimage.sobel(float_matrix, axis=0)
     sy = ndimage.sobel(float_matrix, axis=1)
-    sz = ndimage.sobel(float_matrix, axis=2)
-    magnitude = np.sqrt(sx**2 + sy**2 + sz**2)
+    if float_matrix.ndim == 3:
+        sz = ndimage.sobel(float_matrix, axis=2)
+        magnitude = np.sqrt(sx**2 + sy**2 + sz**2)
+    else:
+        magnitude = np.sqrt(sx**2 + sy**2)
+
+    if not normalize:
+        return magnitude.astype(dtype)
 
     min_val, max_val = float(matrix.min()), float(matrix.max())
     mag_min = magnitude.min()

--- a/invesalius/data/filters.py
+++ b/invesalius/data/filters.py
@@ -36,7 +36,9 @@ def despeckle_filter(matrix: np.ndarray, value: float) -> np.ndarray:
     return ndimage.gaussian_filter(matrix, sigma=value)
 
 
-def border_detection_filter(matrix: np.ndarray, value: float = 1.0, normalize: bool = True) -> np.ndarray:
+def border_detection_filter(
+    matrix: np.ndarray, value: float = 1.0, normalize: bool = True
+) -> np.ndarray:
     """Sobel gradient magnitude with Gaussian pre-smoothing.
     Uses 'value' as the sigma for the pre-smoothing step to control noise sensitivity.
     """

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -2065,7 +2065,7 @@ class Slice(metaclass=utils.Singleton):
     def update_selected_masks(self, indices):
         self.selected_mask_indices = indices
 
-    def __apply_image_filter(self, filter_type, value):
+    def __apply_image_filter(self, filter_type, value, dimension="3D", orientation="Axial"):
         if self.matrix is None:
             return
 
@@ -2104,20 +2104,58 @@ class Slice(metaclass=utils.Singleton):
             dtype = matrix.dtype
 
             try:
-                if filter_type == 0:  # Gaussian Blur
-                    result = filters.gaussian_blur_filter(matrix, sigma=value)
-                elif filter_type == 1:  # Median Filter
-                    result = filters.median_blur_filter(matrix, value)
-                elif filter_type == 2:  # Mean Filter
-                    result = filters.mean_blur_filter(matrix, value)
-                elif filter_type == 3:  # Sharpening
-                    result = filters.sharpening_filter(matrix, value)
-                elif filter_type == 4:  # Despeckle
-                    result = filters.despeckle_filter(matrix, value)
-                elif filter_type == 5:  # Border Detection
-                    result = filters.border_detection_filter(matrix, value=value)
-                else:
-                    return
+                if dimension == "3D":
+                    if filter_type == 0:  # Gaussian Blur
+                        result = filters.gaussian_blur_filter(matrix, sigma=value)
+                    elif filter_type == 1:  # Median Filter
+                        result = filters.median_blur_filter(matrix, value)
+                    elif filter_type == 2:  # Mean Filter
+                        result = filters.mean_blur_filter(matrix, value)
+                    elif filter_type == 3:  # Sharpening
+                        result = filters.sharpening_filter(matrix, value)
+                    elif filter_type == 4:  # Despeckle
+                        result = filters.despeckle_filter(matrix, value)
+                    elif filter_type == 5:  # Border Detection
+                        result = filters.border_detection_filter(matrix, value=value)
+                    else:
+                        return
+                else:  # 2D filtering
+                    axis_map = {"Axial": 0, "Coronal": 1, "Sagittal": 2}
+                    axis = axis_map.get(orientation, 0)
+
+                    result = np.zeros_like(matrix)
+                    for i in range(matrix.shape[axis]):
+                        # Extract the 2D slice
+                        if axis == 0:
+                            slice_2d = matrix[i, :, :]
+                        elif axis == 1:
+                            slice_2d = matrix[:, i, :]
+                        else:
+                            slice_2d = matrix[:, :, i]
+
+                        # Apply filter to the 2D slice
+                        if filter_type == 0:
+                            res_2d = filters.gaussian_blur_filter(slice_2d, sigma=value)
+                        elif filter_type == 1:
+                            res_2d = filters.median_blur_filter(slice_2d, value)
+                        elif filter_type == 2:
+                            res_2d = filters.mean_blur_filter(slice_2d, value)
+                        elif filter_type == 3:
+                            res_2d = filters.sharpening_filter(slice_2d, value)
+                        elif filter_type == 4:
+                            res_2d = filters.despeckle_filter(slice_2d, value)
+                        elif filter_type == 5:
+                            res_2d = filters.border_detection_filter(slice_2d, value=value)
+                        else:
+                            return
+
+                        # Place it back
+                        if axis == 0:
+                            result[i, :, :] = res_2d
+                        elif axis == 1:
+                            result[:, i, :] = res_2d
+                        else:
+                            result[:, :, i] = res_2d
 
                 # Don't set self.matrix here - that would overwrite self._matrix
                 # (the original image). Instead, stash the result for _after_filter.
@@ -2125,12 +2163,12 @@ class Slice(metaclass=utils.Singleton):
             finally:
                 import wx
 
-                wx.CallAfter(self._after_filter, filter_type, value)
+                wx.CallAfter(self._after_filter, filter_type, value, dimension, orientation)
 
         thread = threading.Thread(target=_run_filter, daemon=True)
         thread.start()
 
-    def _after_filter(self, filter_type=None, value=None):
+    def _after_filter(self, filter_type=None, value=None, dimension="3D", orientation="Axial"):
         """Called on the main thread after filter completes."""
         self._is_filtering = False
 
@@ -2176,6 +2214,8 @@ class Slice(metaclass=utils.Singleton):
                 "applied_filter": fname,
                 "sigma_smooth": str(value),
                 "derived": derived_from,
+                "dimension": dimension,
+                "orientation": orientation,
             }
 
         import wx

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -2908,6 +2908,7 @@ class ImagesListCtrl(InvListCtrl):
         # Bind selection event directly here — the double-underscore __bind_events_wx
         # in the parent uses name-mangling and cannot be overridden from a subclass.
         self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnSelectionChanged)
+        self.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnRightClick)
 
     def OnCheckItem(self, index, flag):
         """Handle single-click on the eye icon (column 0).
@@ -2943,6 +2944,61 @@ class ImagesListCtrl(InvListCtrl):
 
             label, _ = proj.image_versions[idx]
             Publisher.sendMessage("Switch active image by label", label=label)
+
+    def OnRightClick(self, evt):
+        self.right_clicked_idx = evt.GetIndex()
+        if self.right_clicked_idx < 0:
+            return
+
+        menu = wx.Menu()
+        prop_item = menu.Append(wx.ID_ANY, _("Properties"))
+        self.Bind(wx.EVT_MENU, self.OnShowProperties, prop_item)
+
+        self.PopupMenu(menu)
+        menu.Destroy()
+
+    def OnShowProperties(self, evt):
+        proj = Project()
+        if not (0 <= self.right_clicked_idx < len(proj.image_versions)):
+            return
+
+        label, _mat = proj.image_versions[self.right_clicked_idx]
+
+        # Original image has no metadata
+        if label == "original":
+            wx.MessageBox(
+                _("This is the original unfiltered image."),
+                _("Image Properties"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return
+
+        meta = getattr(proj, "image_versions_meta", {}).get(label)
+        if not meta:
+            wx.MessageBox(
+                _("No properties found for this image."),
+                _("Image Properties"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return
+
+        # Construct properties string
+        filter_name = meta.get("applied_filter", _("Unknown"))
+        derived = meta.get("derived", _("Unknown"))
+
+        msg = f"{_('Filter Applied')}: {filter_name}\n"
+        msg += f"{_('Derived From')}: {derived}\n"
+
+        # Add filter-specific parameters if they exist
+        if "sigma_smooth" in meta:
+            msg += f"{_('Parameter (Sigma/Kernel/Value)')}: {meta['sigma_smooth']}\n"
+
+        if "dimension" in meta:
+            msg += f"{_('Dimension')}: {meta['dimension']}\n"
+            if meta["dimension"] == "2D" and "orientation" in meta:
+                msg += f"{_('Orientation')}: {meta['orientation']}\n"
+
+        wx.MessageBox(msg, _("Image Properties"), wx.OK | wx.ICON_INFORMATION)
 
     def __bind_events_wx(self):
         """Not called due to name-mangling — binding is done in __init__ instead."""

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -8041,6 +8041,33 @@ class ImageFilterDialog(wx.Dialog):
             self, -1, value=1.0, min_value=0.1, max_value=10.0, increment=0.1
         )
 
+        # Dimension selection
+        self.rb_dimension = wx.RadioBox(
+            self,
+            -1,
+            _("Dimension:"),
+            choices=[_("3D"), _("2D")],
+            majorDimension=2,
+            style=wx.RA_SPECIFY_COLS,
+        )
+        self.rb_dimension.SetSelection(0)
+
+        # Orientation selection (only for 2D)
+        self.lbl_orientation = wx.StaticText(self, -1, _("Orientation:"))
+        self.cb_orientation = wx.ComboBox(
+            self,
+            -1,
+            choices=[_("Axial"), _("Coronal"), _("Sagittal")],
+            style=wx.CB_READONLY,
+        )
+        self.cb_orientation.SetSelection(0)
+        if sys.platform != "win32":
+            self.cb_orientation.SetWindowVariant(wx.WINDOW_VARIANT_SMALL)
+
+        # Hide orientation initially (since default is 3D)
+        self.lbl_orientation.Hide()
+        self.cb_orientation.Hide()
+
         # Buttons
         self.btn_apply = wx.Button(self, wx.ID_APPLY, _("Apply"))
         self.btn_close = wx.Button(self, wx.ID_CLOSE, _("Close"))
@@ -8059,6 +8086,17 @@ class ImageFilterDialog(wx.Dialog):
         sizer.Add(self.lbl_param, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
         sizer.AddSpacer(5)
         sizer.Add(self.spin_param, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
+        sizer.AddSpacer(12)
+        sizer.Add(self.rb_dimension, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
+        sizer.AddSpacer(12)
+
+        # We need a sizer for orientation so we can easily hide/show it without breaking layout
+        self.orientation_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.orientation_sizer.Add(self.lbl_orientation, 0, wx.EXPAND)
+        self.orientation_sizer.AddSpacer(5)
+        self.orientation_sizer.Add(self.cb_orientation, 0, wx.EXPAND)
+        sizer.Add(self.orientation_sizer, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
+
         sizer.AddSpacer(15)
 
         btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -8074,6 +8112,7 @@ class ImageFilterDialog(wx.Dialog):
     def _bind_events(self):
         self.cb_volume.Bind(wx.EVT_COMBOBOX, self._on_select_volume)
         self.cb_filter.Bind(wx.EVT_COMBOBOX, self._on_select_filter)
+        self.rb_dimension.Bind(wx.EVT_RADIOBOX, self._on_select_dimension)
         self.btn_apply.Bind(wx.EVT_BUTTON, self._on_apply)
         self.btn_close.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
         self.Bind(wx.EVT_CLOSE, self._on_close)
@@ -8124,15 +8163,40 @@ class ImageFilterDialog(wx.Dialog):
         self.GetSizer().Layout()
         self.Fit()
 
+    def _on_select_dimension(self, evt):
+        sel = self.rb_dimension.GetSelection()
+        if sel == 1:  # 2D
+            self.lbl_orientation.Show()
+            self.cb_orientation.Show()
+        else:  # 3D
+            self.lbl_orientation.Hide()
+            self.cb_orientation.Hide()
+        self.GetSizer().Layout()
+        self.Fit()
+
     def _on_apply(self, evt):
         sel = self.cb_filter.GetSelection()
         # 0->Despeckle(4), 1->BorderDetection(5), 2->Mean(2), 3->Median(1)
         filter_map = {0: 4, 1: 5, 2: 2, 3: 1}
         filter_type = filter_map.get(sel, 4)
         value = self.spin_param.GetValue()
+
+        dimension_idx = self.rb_dimension.GetSelection()
+        dimension = "2D" if dimension_idx == 1 else "3D"
+
+        orientation_idx = self.cb_orientation.GetSelection()
+        orientations = ["Axial", "Coronal", "Sagittal"]
+        orientation = orientations[orientation_idx]
+
         self.btn_apply.Disable()
         self.btn_apply.SetLabel(_("Applying..."))
-        Publisher.sendMessage("Apply image filter", filter_type=filter_type, value=value)
+        Publisher.sendMessage(
+            "Apply image filter",
+            filter_type=filter_type,
+            value=value,
+            dimension=dimension,
+            orientation=orientation,
+        )
 
     def _on_filter_done(self):
         if self.btn_apply:


### PR DESCRIPTION
# Description

### Fixes: #1383
This PR improves the Image Filter Tool by implementing 2D/3D orientation selection capabilities and adding a new context menu for inspecting filtered images.

### Changes
1. **2D/3D Dimension Selection:**
   - Added a `Dimension` radio box (3D/2D) to `ImageFilterDialog`.
   - Added an `Orientation` dropdown (Axial, Coronal, Sagittal) that dynamically appears when 2D is selected.
   - Updated the filtering thread logic in `slice_.__apply_image_filter` to gracefully handle 2D slice-by-slice processing along the specified orientation axis.

2. **Properties Context Menu:**
   - Added a right-click context menu listener (`EVT_LIST_ITEM_RIGHT_CLICK`) to the "Images" tab list (`ImagesListCtrl`).
   - Clicking "Properties" on a filtered image now displays a dialog containing metadata saved during the filtering process, including the applied filter, parameter value (sigma), dimension, and orientation.

3. **2D Filter:**
   - Updated the `border_detection_filter` (Sobel) in `filters.py` to check the matrix dimensions and safely process 2D arrays without throwing an `IndexError`.

### Testing
- Tested applying 3D filters to ensure behaviour remained unchanged.
- Tested applying 2D filters across Axial, Coronal, and Sagittal orientations and verified the expected slice-by-slice visual output.
- Verified that the right-click "Properties" menu correctly fetches and displays metadata for newly generated filter variants without crashing.
