### PR TITLE
Fix:ensure tracker median sampling uses fresh coordinates

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -1037,6 +1037,12 @@ EFIELD_ROI_SIZE = 40
 SLEEP_NAVIGATION = 0.1
 SLEEP_COORDINATES = 0.1
 
+# Delay between consecutive tracker coordinate samples when computing the median
+# for calibration. Without this delay, the sampling loop runs faster than the
+# tracker's update rate, causing duplicate readings that defeat the purpose of
+# median filtering. See: https://github.com/invesalius/invesalius3/issues/380
+SLEEP_BETWEEN_TRACKER_SAMPLES = 0.01
+
 BRAIN_OPACITY = 0.6
 N_CPU = psutil.cpu_count()
 # the max_sampling_step can be set to something different as well. Above 100 is probably not necessary

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -18,6 +18,7 @@
 # --------------------------------------------------------------------------
 
 import threading
+from time import sleep
 from typing import Dict, List, Optional, Tuple, cast
 
 import numpy as np
@@ -195,17 +196,43 @@ class Tracker(metaclass=Singleton):
         coord_raw_samples: Dict[int, NDArray[np.float64]] = {}
         coord_samples: Dict[int, NDArray[np.float64]] = {}
 
-        for i in range(n_samples):
+        # The delay between samples ensures each reading captures a genuinely
+        # updated coordinate from the tracker hardware.  Without this, the loop
+        # runs faster than the tracker's update rate (e.g. Optitrack at
+        # ~120-240 Hz), producing duplicate values that make np.median useless.
+        # See: https://github.com/invesalius/invesalius3/issues/380
+        sample_delay: float = const.SLEEP_BETWEEN_TRACKER_SAMPLES
+
+        prev_coord_raw: Optional[NDArray[np.float64]] = None
+        collected: int = 0
+        max_attempts: int = n_samples * 10  # prevent infinite loop
+        attempts: int = 0
+
+        while collected < n_samples and attempts < max_attempts:
             coord_raw, marker_visibilities = self.TrackerCoordinates.GetCoordinates()
+
+            # Skip duplicate readings — if the tracker has not updated yet,
+            # the raw coordinate will be identical to the previous one.
+            if prev_coord_raw is not None and coord_raw is not None and np.array_equal(coord_raw, prev_coord_raw):
+                attempts += 1
+                sleep(sample_delay)
+                continue
 
             if ref_mode_id == const.DYNAMIC_REF:
                 coord = dco.dynamic_reference_m(coord_raw[0, :], coord_raw[1, :])
             else:
-                coord = coord_raw[0, :]
+                coord = coord_raw[0, :].copy()
                 coord[2] = -coord[2]
 
-            coord_raw_samples[i] = coord_raw
-            coord_samples[i] = coord
+            coord_raw_samples[collected] = coord_raw
+            coord_samples[collected] = coord
+            prev_coord_raw = coord_raw.copy() if coord_raw is not None else None
+            collected += 1
+            attempts += 1
+
+            # Sleep between samples to allow the tracker to refresh.
+            if collected < n_samples:
+                sleep(sample_delay)
 
         coord_raw_avg: NDArray[np.float64] = np.median(list(coord_raw_samples.values()), axis=0)
         coord_avg: NDArray[np.float64] = np.median(list(coord_samples.values()), axis=0)

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -213,7 +213,11 @@ class Tracker(metaclass=Singleton):
 
             # Skip duplicate readings — if the tracker has not updated yet,
             # the raw coordinate will be identical to the previous one.
-            if prev_coord_raw is not None and coord_raw is not None and np.array_equal(coord_raw, prev_coord_raw):
+            if (
+                prev_coord_raw is not None
+                and coord_raw is not None
+                and np.array_equal(coord_raw, prev_coord_raw)
+            ):
                 attempts += 1
                 sleep(sample_delay)
                 continue

--- a/invesalius/navigation/tracker.py
+++ b/invesalius/navigation/tracker.py
@@ -205,7 +205,7 @@ class Tracker(metaclass=Singleton):
 
         prev_coord_raw: Optional[NDArray[np.float64]] = None
         collected: int = 0
-        max_attempts: int = n_samples * 10  # prevent infinite loop
+        max_attempts: int = n_samples * 3  # prevent infinite loop
         attempts: int = 0
 
         while collected < n_samples and attempts < max_attempts:

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -98,7 +98,9 @@ def test_get_tracker_coordinates(mocker, tracker):
 
     assert visibilities == (True, True, True)
     assert np.allclose(coord_avg, np.array([1.5, 2.5, -3.5]), atol=1e-6)
-    assert np.allclose(coord_raw_avg, np.array([[1.5, 2.5, -3.5], [4.5, 5.5, 6.5]]), atol=1e-6)
+    # coord_raw_avg should contain the unmodified raw coordinates (no Z-flip).
+    # The Z-flip is only applied to coord_avg (the processed coordinate).
+    assert np.allclose(coord_raw_avg, np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]]), atol=1e-6)
 
 
 def test_set_tracker(mocker, tracker):


### PR DESCRIPTION
## Summary
- Fixes #380 by adding a small delay between tracker coordinate samples so median filtering operates on fresh hardware updates instead of repeated stale values.
- Skips duplicate consecutive raw samples and bounds retry attempts to avoid getting stuck when tracker updates are not changing.
- Preserves raw coordinate data by copying processed slices, and updates tracker test expectations accordingly.

## Why this change
The previous sampling loop could run faster than tracker update frequency (notably with Optitrack), which caused repeated identical samples and made median filtering ineffective. This patch ensures sampled points are meaningfully distinct and keeps calibration behavior robust.

## Test plan
- [x] Run pre-commit hooks on touched files:
  - `python3 -m pre_commit run --files invesalius/constants.py invesalius/navigation/tracker.py tests/test_tracker.py`
- [x] Let GitHub Actions run full CI on this PR
- [ ] (Optional) Validate tracker calibration behavior with Optitrack hardware by checking reduced jitter during coordinate acquisition

## Notes
- Branch: `fix/380-optitrack-median-sampling-delay-v2`
- Includes a follow-up formatting commit so `pre-commit` CI passes.