### PR TITLE
fix (#1387): Masks not aligned after image reorientation

### DIFF
--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -435,6 +435,33 @@ class Mask:
         shape = shape[0] + 1, shape[1] + 1, shape[2] + 1
         self.matrix = np.memmap(self.temp_file, mode="w+", dtype="uint8", shape=shape)
 
+    def _recreate_mask_matrix(self, new_shape):
+        """
+        Recreates the mask matrix with a new shape, preserving the temp file.
+        Used when image dimensions change (e.g., after reorientation).
+
+        Parameters:
+            new_shape(int, int, int): The new shape for the mask matrix.
+        """
+        old_temp_file = self.temp_file
+        old_temp_fd = self.temp_fd
+
+        new_temp_fd, new_temp_file = tempfile.mkstemp()
+        new_matrix = np.memmap(new_temp_file, mode="w+", dtype="uint8", shape=new_shape)
+        new_matrix[:] = 0
+
+        del self.matrix
+
+        try:
+            os.close(old_temp_fd)
+            os.remove(old_temp_file)
+        except (OSError, ValueError):
+            pass
+
+        self.temp_fd = new_temp_fd
+        self.temp_file = new_temp_file
+        self.matrix = new_matrix
+
     def modified(self, all_volume=False):
         if all_volume:
             self.matrix[0] = 1

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -446,10 +446,6 @@ class Mask:
         old_temp_file = self.temp_file
         old_temp_fd = self.temp_fd
 
-        new_temp_fd, new_temp_file = tempfile.mkstemp()
-        new_matrix = np.memmap(new_temp_file, mode="w+", dtype="uint8", shape=new_shape)
-        new_matrix[:] = 0
-
         del self.matrix
 
         try:
@@ -457,6 +453,12 @@ class Mask:
             os.remove(old_temp_file)
         except (OSError, ValueError):
             pass
+
+        new_temp_fd, new_temp_file = tempfile.mkstemp()
+        new_matrix = np.memmap(new_temp_file, mode="w+", dtype="uint8", shape=new_shape)
+        new_matrix[:] = 0
+        new_matrix.flush()
+        os.fsync(new_temp_fd)
 
         self.temp_fd = new_temp_fd
         self.temp_file = new_temp_file

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1122,9 +1122,6 @@ class Slice(metaclass=utils.Singleton):
         """
         It gets the from actual mask the given slice from given orientation
         """
-        # It's necessary because the first position for each dimension from
-        # mask matrix is used as flags to control if the mask in the
-        # slice_number position has been generated.
         if (
             self.buffer_slices[orientation].index == slice_number
             and self.buffer_slices[orientation].mask is not None
@@ -1134,17 +1131,24 @@ class Slice(metaclass=utils.Singleton):
 
         target_matrix = self.matrix
         if self.current_mask:
-            derived = getattr(self.current_mask, "derived_from", "Original")
-            proj = Project()
-            for lbl, mat in proj.image_versions:
-                if lbl == derived:
-                    target_matrix = mat
-                    break
+            derived = getattr(self.current_mask, "derived_from", "original")
+            if derived.lower() != "original":
+                proj = Project()
+                for lbl, mat in proj.image_versions:
+                    if lbl == derived:
+                        target_matrix = mat
+                        break
 
         if orientation == "AXIAL":
             if self.current_mask.matrix[n, 0, 0] == 0:
                 mask = self.current_mask.matrix[n, 1:, 1:]
-                mask[:] = self.do_threshold_to_a_slice(target_matrix[slice_number], mask)
+                if np.any(self.q_orientation[1::]):
+                    image_slice = self.buffer_slices[orientation].image
+                    if image_slice is None:
+                        image_slice = self.get_image_slice(orientation, slice_number)
+                else:
+                    image_slice = target_matrix[slice_number]
+                mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[n, 0, 0] = 1
             n_mask = np.array(
                 self.current_mask.matrix[n, 1:, 1:],
@@ -1154,7 +1158,13 @@ class Slice(metaclass=utils.Singleton):
         elif orientation == "CORONAL":
             if self.current_mask.matrix[0, n, 0] == 0:
                 mask = self.current_mask.matrix[1:, n, 1:]
-                mask[:] = self.do_threshold_to_a_slice(target_matrix[:, slice_number, :], mask)
+                if np.any(self.q_orientation[1::]):
+                    image_slice = self.buffer_slices[orientation].image
+                    if image_slice is None:
+                        image_slice = self.get_image_slice(orientation, slice_number)
+                else:
+                    image_slice = target_matrix[:, slice_number, :]
+                mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[0, n, 0] = 1
             n_mask = np.array(
                 self.current_mask.matrix[1:, n, 1:],
@@ -1164,7 +1174,13 @@ class Slice(metaclass=utils.Singleton):
         elif orientation == "SAGITAL":
             if self.current_mask.matrix[0, 0, n] == 0:
                 mask = self.current_mask.matrix[1:, 1:, n]
-                mask[:] = self.do_threshold_to_a_slice(target_matrix[:, :, slice_number], mask)
+                if np.any(self.q_orientation[1::]):
+                    image_slice = self.buffer_slices[orientation].image
+                    if image_slice is None:
+                        image_slice = self.get_image_slice(orientation, slice_number)
+                else:
+                    image_slice = target_matrix[:, :, slice_number]
+                mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[0, 0, n] = 1
             n_mask = np.array(
                 self.current_mask.matrix[1:, 1:, n],
@@ -1922,10 +1938,16 @@ class Slice(metaclass=utils.Singleton):
         self.q_orientation = np.array((1, 0, 0, 0))
         self.center = [(s * d / 2.0) for (d, s) in zip(self.matrix.shape[::-1], self.spacing)]
 
-        self.__clean_current_mask()
-        if self.current_mask:
-            self.current_mask.matrix[:] = 0
-            self.current_mask.was_edited = False
+        proj = Project()
+        new_shape = self.matrix.shape
+
+        for mask in proj.mask_dict.values():
+            new_mask_shape = (new_shape[0] + 1, new_shape[1] + 1, new_shape[2] + 1)
+            if mask.matrix.shape != new_mask_shape:
+                mask._recreate_mask_matrix(new_mask_shape)
+
+            mask.matrix[:] = 0
+            mask.clear_history()
 
         for o in self.buffer_slices:
             self.buffer_slices[o].discard_buffer()

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1142,12 +1142,7 @@ class Slice(metaclass=utils.Singleton):
         if orientation == "AXIAL":
             if self.current_mask.matrix[n, 0, 0] == 0:
                 mask = self.current_mask.matrix[n, 1:, 1:]
-                if np.any(self.q_orientation[1::]):
-                    image_slice = self.buffer_slices[orientation].image
-                    if image_slice is None:
-                        image_slice = self.get_image_slice(orientation, slice_number)
-                else:
-                    image_slice = target_matrix[slice_number]
+                image_slice = target_matrix[slice_number]
                 mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[n, 0, 0] = 1
             n_mask = np.array(
@@ -1158,12 +1153,7 @@ class Slice(metaclass=utils.Singleton):
         elif orientation == "CORONAL":
             if self.current_mask.matrix[0, n, 0] == 0:
                 mask = self.current_mask.matrix[1:, n, 1:]
-                if np.any(self.q_orientation[1::]):
-                    image_slice = self.buffer_slices[orientation].image
-                    if image_slice is None:
-                        image_slice = self.get_image_slice(orientation, slice_number)
-                else:
-                    image_slice = target_matrix[:, slice_number, :]
+                image_slice = target_matrix[:, slice_number, :]
                 mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[0, n, 0] = 1
             n_mask = np.array(
@@ -1174,12 +1164,7 @@ class Slice(metaclass=utils.Singleton):
         elif orientation == "SAGITAL":
             if self.current_mask.matrix[0, 0, n] == 0:
                 mask = self.current_mask.matrix[1:, 1:, n]
-                if np.any(self.q_orientation[1::]):
-                    image_slice = self.buffer_slices[orientation].image
-                    if image_slice is None:
-                        image_slice = self.get_image_slice(orientation, slice_number)
-                else:
-                    image_slice = target_matrix[:, :, slice_number]
+                image_slice = target_matrix[:, :, slice_number]
                 mask[:] = self.do_threshold_to_a_slice(image_slice, mask)
                 self.current_mask.matrix[0, 0, n] = 1
             n_mask = np.array(
@@ -1935,11 +1920,29 @@ class Slice(metaclass=utils.Singleton):
         os.close(temp_fd)
         os.remove(temp_file)
 
+        # Flush the reoriented image matrix to disk
+        if hasattr(self.matrix, "flush"):
+            self.matrix.flush()
+        if hasattr(self, "matrix_filename"):
+            try:
+                fd = os.open(self.matrix_filename, os.O_RDWR)
+                os.fsync(fd)
+                os.close(fd)
+            except (OSError, AttributeError):
+                pass
+
         self.q_orientation = np.array((1, 0, 0, 0))
         self.center = [(s * d / 2.0) for (d, s) in zip(self.matrix.shape[::-1], self.spacing)]
 
         proj = Project()
         new_shape = self.matrix.shape
+
+        # Update image_versions to point to the reoriented matrix
+        if proj.image_versions:
+            for i, (label, mat) in enumerate(proj.image_versions):
+                if label == "original" or mat is self._matrix:
+                    proj.image_versions[i] = (label, self.matrix)
+                    break
 
         for mask in proj.mask_dict.values():
             new_mask_shape = (new_shape[0] + 1, new_shape[1] + 1, new_shape[2] + 1)
@@ -1947,6 +1950,8 @@ class Slice(metaclass=utils.Singleton):
                 mask._recreate_mask_matrix(new_mask_shape)
 
             mask.matrix[:] = 0
+            mask.matrix.flush()
+            os.fsync(mask.temp_fd)
             mask.clear_history()
 
         for o in self.buffer_slices:

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -2419,6 +2419,8 @@ class ReorientImageInteractorStyle(DefaultInteractorStyle):
         for buffer_ in self.viewer.slice_.buffer_slices.values():
             buffer_.discard_vtk_image()
             buffer_.discard_image()
+            buffer_.discard_vtk_mask()
+            buffer_.discard_mask()
 
 
 class FFillConfig(metaclass=utils.Singleton):


### PR DESCRIPTION
### Fixes #1387 
 
### Overview

This PR fixes an issue where segmentation masks did not align with the image after using the *Reorient Image* feature. Previously, masks continued to appear in their original orientation instead of updating with the transformed image.

### Problem

After applying image reorientation:

* Masks were displayed in the old orientation
* Masks were missing in coronal and sagittal views
* Preview showed stale mask data

This caused incorrect visualization and inconsistent behavior across views.

### Root Causes

1. Mask buffers were not cleared during preview, leading to stale cached data
2. Masks were recalculated using the original image instead of the reoriented one
3. Mask dimensions were not updated after reorientation

### Changes Made

* Cleared mask buffers during preview in `ReorientImageInteractorStyle._discard_buffers()` to ensure recalculation from the updated image
* Updated `apply_reorientation()` to resize mask matrices, reset mask data, and discard buffers
* Modified `get_mask_slice()` to always use the current (reoriented) image matrix
* Added `_recreate_mask_matrix()` in `mask.py` to handle resizing and cleanup when dimensions change

### Result

* Masks correctly follow image reorientation
* Visible across axial, coronal, and sagittal views
* No stale data during preview
* Consistent behavior for both existing and new masks
* No performance impact

### Testing

* Verified mask alignment after reorientation
* Checked all orientations (axial, coronal, sagittal)
* Tested multiple masks and slice navigation
* Confirmed correct behavior for newly created masks

### Files Modified

* `invesalius/data/styles.py`
* `invesalius/data/slice_.py`
* `invesalius/data/mask.py`

