### PR TITLE
Add User-Configurable Keyboard Shortcuts

### DIFF
--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -47,6 +47,7 @@ from invesalius.gui import project_properties
 from invesalius.gui.interactive_shell import InteractiveShellFrame
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
+from invesalius.gui.shortcut_manager import ShortcutManager
 
 try:
     from wx.adv import TaskBarIcon as wx_TaskBarIcon
@@ -122,6 +123,9 @@ class Frame(wx.Frame):
 
         self._show_navigator_message = True
         self.edit_data_notebook_label = False
+
+        # Load shortcut registry before building menus so get_menu_label() works
+        ShortcutManager().load()
 
         # to control check and unckeck of menu view -> interpolated_slices
         main_menu = MenuBar(self)
@@ -222,21 +226,29 @@ class Frame(wx.Frame):
         if focused and isinstance(focused, wx.py.shell.Shell):
             is_shell_focused = True
 
-        # If it is CTRL+S, CTRL+Shift+S, or CTRL+Q, skip this event
-        if modifiers & wx.MOD_CONTROL:
-            unicode = event.GetUnicodeKey()
-            if unicode in (ord("s"), ord("S"), ord("q"), ord("Q")):
-                event.Skip()
-                return
+        # Handle save, save_as, exit and clean_mask dynamically from shortcut registry
+        sm = ShortcutManager()
+        save_key = sm.get_shortcut("save_project")
+        save_as_key = sm.get_shortcut("save_project_as")
+        exit_key = sm.get_shortcut("exit")
+        clean_mask_key = sm.get_shortcut("clean_mask")
 
-        # Handle Ctrl+Shift+A for clearing mask (should work at any time, even outside edit mode)
+        current_key = ""
+        if modifiers & wx.MOD_CONTROL:
+            if modifiers & wx.MOD_SHIFT:
+                current_key = "Ctrl+Shift+" + chr(event.GetUnicodeKey()).upper()
+            else:
+                current_key = "Ctrl+" + chr(event.GetUnicodeKey()).upper()
+
+        if current_key in (save_key, save_as_key, exit_key):
+            event.Skip()
+            return
+
         if (
-            modifiers == (wx.MOD_CONTROL | wx.MOD_SHIFT)
-            and keycode == ord("A")
+            current_key == clean_mask_key
             and not is_search_field
             and not is_shell_focused
         ):
-            # Only clear mask if a mask is available (menu is enabled)
             if hasattr(self, "clean_mask_menu") and self.clean_mask_menu.IsEnabled():
                 self.OnCleanMask()
             event.Skip()
@@ -1441,6 +1453,7 @@ class MenuBar(wx.MenuBar):
         """
         Create all menu and submenus, and add them to self.
         """
+        sm = ShortcutManager()
         # TODO: This definetely needs improvements... ;)
 
         # Import Others Files
@@ -1453,33 +1466,23 @@ class MenuBar(wx.MenuBar):
         # FILE
         file_menu = wx.Menu()
         app = file_menu.Append
-        app(const.ID_DICOM_IMPORT, _("Import DICOM...\tCtrl+I"))
-        # app(const.ID_DICOM_NETWORK, _("Retrieve DICOM from PACS"))
+        app(const.ID_DICOM_IMPORT, sm.get_menu_label("import_dicom", _("Import DICOM...")))
         file_menu.Append(const.ID_IMPORT_OTHERS_FILES, _("Import other files..."), others_file_menu)
-        app(const.ID_PROJECT_OPEN, _("Open project...\tCtrl+O"))
-        app(const.ID_PROJECT_SAVE, _("Save project\tCtrl+S"))
-        app(const.ID_PROJECT_SAVE_AS, _("Save project as...\tCtrl+Shift+S"))
+        app(const.ID_PROJECT_OPEN, sm.get_menu_label("open_project", _("Open project...")))
+        app(const.ID_PROJECT_SAVE, sm.get_menu_label("save_project", _("Save project")))
+        app(const.ID_PROJECT_SAVE_AS, sm.get_menu_label("save_project_as", _("Save project as...")))
         app(const.ID_EXPORT_SLICE, _("Export project"))
         app(const.ID_PROJECT_PROPERTIES, _("Project properties"))
         app(const.ID_PROJECT_CLOSE, _("Close project"))
         file_menu.AppendSeparator()
-        # app(const.ID_PROJECT_INFO, _("Project Information..."))
-        # file_menu.AppendSeparator()
-        # app(const.ID_SAVE_SCREENSHOT, _("Save Screenshot"))
-        # app(const.ID_PRINT_SCREENSHOT, _("Print Screenshot"))
-        # file_menu.AppendSeparator()
-        # app(1, "C:\InvData\sample.inv")
-        # file_menu.AppendSeparator()
-        app(const.ID_EXIT, _("Exit\tCtrl+Q"))
+        app(const.ID_EXIT, sm.get_menu_label("exit", _("Exit")))
 
         file_edit = wx.Menu()
-
-        file_edit.Append(wx.ID_UNDO, _("Undo\tCtrl+Z")).Enable(False)
-        file_edit.Append(wx.ID_REDO, _("Redo\tCtrl+Y")).Enable(False)
-        file_edit.Append(const.ID_GOTO_SLICE, _("Go to slice ...\tCtrl+G"))
+        file_edit.Append(wx.ID_UNDO, sm.get_menu_label("undo", _("Undo"))).Enable(False)
+        file_edit.Append(wx.ID_REDO, sm.get_menu_label("redo", _("Redo"))).Enable(False)
+        file_edit.Append(const.ID_GOTO_SLICE, sm.get_menu_label("goto_slice", _("Go to slice ...")))
         file_edit.Append(const.ID_GOTO_COORD, _("Go to scanner coord ...\t")).Enable(False)
 
-        # app(const.ID_EDIT_LIST, "Show Undo List...")
         #################################################################
 
         # Tool menu
@@ -1488,38 +1491,38 @@ class MenuBar(wx.MenuBar):
         # Mask Menu
         mask_menu = wx.Menu()
 
-        self.new_mask_menu = mask_menu.Append(const.ID_CREATE_MASK, _("New\tCtrl+Shift+M"))
+        self.new_mask_menu = mask_menu.Append(const.ID_CREATE_MASK, sm.get_menu_label("new_mask", _("New")))
         self.new_mask_menu.Enable(False)
 
         self.bool_op_menu = mask_menu.Append(
-            const.ID_BOOLEAN_MASK, _("Boolean operations\tCtrl+Shift+B")
+            const.ID_BOOLEAN_MASK, sm.get_menu_label("boolean_operations", _("Boolean operations"))
         )
         self.bool_op_menu.Enable(False)
 
-        self.clean_mask_menu = mask_menu.Append(const.ID_CLEAN_MASK, _("Clean Mask\tCtrl+Shift+A"))
+        self.clean_mask_menu = mask_menu.Append(const.ID_CLEAN_MASK, sm.get_menu_label("clean_mask", _("Clean Mask")))
         self.clean_mask_menu.Enable(False)
 
         mask_menu.AppendSeparator()
 
         self.fill_hole_mask_menu = mask_menu.Append(
-            const.ID_FLOODFILL_MASK, _("Fill holes manually\tCtrl+Shift+H")
+            const.ID_FLOODFILL_MASK, sm.get_menu_label("fill_holes_manually", _("Fill holes manually"))
         )
         self.fill_hole_mask_menu.Enable(False)
 
         self.fill_hole_auto_menu = mask_menu.Append(
-            const.ID_FILL_HOLE_AUTO, _("Fill holes automatically\tCtrl+Shift+J")
+            const.ID_FILL_HOLE_AUTO, sm.get_menu_label("fill_holes_auto", _("Fill holes automatically"))
         )
         self.fill_hole_mask_menu.Enable(False)
 
         mask_menu.AppendSeparator()
 
         self.remove_mask_part_menu = mask_menu.Append(
-            const.ID_REMOVE_MASK_PART, _("Remove parts\tCtrl+Shift+K")
+            const.ID_REMOVE_MASK_PART, sm.get_menu_label("remove_mask_parts", _("Remove parts"))
         )
         self.remove_mask_part_menu.Enable(False)
 
         self.select_mask_part_menu = mask_menu.Append(
-            const.ID_SELECT_MASK_PART, _("Select parts\tCtrl+Shift+L")
+            const.ID_SELECT_MASK_PART, sm.get_menu_label("select_mask_parts", _("Select parts"))
         )
         self.select_mask_part_menu.Enable(False)
 
@@ -1533,12 +1536,12 @@ class MenuBar(wx.MenuBar):
         mask_preview_menu = wx.Menu()
 
         self.mask_preview = mask_preview_menu.Append(
-            const.ID_MASK_3D_PREVIEW, _("Enable") + "\tCtrl+Shift+P", "", wx.ITEM_CHECK
+            const.ID_MASK_3D_PREVIEW, sm.get_menu_label("mask_3d_preview", _("Enable")), "", wx.ITEM_CHECK
         )
         self.mask_preview.Enable(False)
 
         self.mask_auto_reload = mask_preview_menu.Append(
-            const.ID_MASK_3D_AUTO_RELOAD, _("Auto reload") + "\tCtrl+Shift+D", "", wx.ITEM_CHECK
+            const.ID_MASK_3D_AUTO_RELOAD, sm.get_menu_label("mask_3d_auto_reload", _("Auto reload")), "", wx.ITEM_CHECK
         )
 
         session = ses.Session()
@@ -1548,7 +1551,7 @@ class MenuBar(wx.MenuBar):
         self.mask_auto_reload.Enable(False)
 
         self.mask_preview_reload = mask_preview_menu.Append(
-            const.ID_MASK_3D_RELOAD, _("Reload") + "\tCtrl+Shift+R"
+            const.ID_MASK_3D_RELOAD, sm.get_menu_label("mask_3d_reload", _("Reload"))
         )
         self.mask_preview_reload.Enable(False)
 
@@ -1557,29 +1560,27 @@ class MenuBar(wx.MenuBar):
         # Segmentation Menu
         segmentation_menu = wx.Menu()
         self.threshold_segmentation = segmentation_menu.Append(
-            const.ID_THRESHOLD_SEGMENTATION, _("Threshold\tCtrl+Shift+T")
+            const.ID_THRESHOLD_SEGMENTATION, sm.get_menu_label("threshold_segmentation", _("Threshold"))
         )
         self.manual_segmentation = segmentation_menu.Append(
-            const.ID_MANUAL_SEGMENTATION, _("Manual segmentation\tCtrl+Shift+E")
+            const.ID_MANUAL_SEGMENTATION, sm.get_menu_label("manual_segmentation", _("Manual segmentation"))
         )
         self.watershed_segmentation = segmentation_menu.Append(
-            const.ID_WATERSHED_SEGMENTATION, _("Watershed\tCtrl+Shift+W")
+            const.ID_WATERSHED_SEGMENTATION, sm.get_menu_label("watershed_segmentation", _("Watershed"))
         )
         self.ffill_segmentation = segmentation_menu.Append(
-            const.ID_FLOODFILL_SEGMENTATION, _("Region growing\tCtrl+Shift+G")
+            const.ID_FLOODFILL_SEGMENTATION, sm.get_menu_label("region_growing", _("Region growing"))
         )
         self.ffill_segmentation.Enable(False)
         segmentation_menu.AppendSeparator()
         segmentation_menu.Append(const.ID_SEGMENTATION_BRAIN, _("Brain segmentation (MRI T1)"))
-        segmentation_menu.Append(
-            const.ID_SEGMENTATION_SUBPART, _("Brain subpart segmentation (MRI T1)")
-        )
+        segmentation_menu.Append(const.ID_SEGMENTATION_SUBPART, _("Brain subpart segmentation (MRI T1)"))
         segmentation_menu.Append(const.ID_SEGMENTATION_TRACHEA, _("Trachea segmentation (CT)"))
         segmentation_menu.Append(const.ID_SEGMENTATION_MANDIBLE_CT, _("Mandible segmentation (CT)"))
 
         # Surface Menu
         surface_menu = wx.Menu()
-        self.create_surface = surface_menu.Append(const.ID_CREATE_SURFACE, ("New\tCtrl+Shift+C"))
+        self.create_surface = surface_menu.Append(const.ID_CREATE_SURFACE, sm.get_menu_label("new_surface", _("New")))
         self.create_surface.Enable(False)
 
         self.remove_non_visible = surface_menu.Append(
@@ -1596,20 +1597,15 @@ class MenuBar(wx.MenuBar):
         flip_menu.Append(const.ID_FLIP_Z, _("Top - Bottom")).Enable(False)
 
         swap_axes_menu = wx.Menu()
-        swap_axes_menu.Append(const.ID_SWAP_XY, _("From Right-Left to Anterior-Posterior")).Enable(
-            False
-        )
+        swap_axes_menu.Append(const.ID_SWAP_XY, _("From Right-Left to Anterior-Posterior")).Enable(False)
         swap_axes_menu.Append(const.ID_SWAP_XZ, _("From Right-Left to Top-Bottom")).Enable(False)
-        swap_axes_menu.Append(const.ID_SWAP_YZ, _("From Anterior-Posterior to Top-Bottom")).Enable(
-            False
-        )
+        swap_axes_menu.Append(const.ID_SWAP_YZ, _("From Anterior-Posterior to Top-Bottom")).Enable(False)
 
         image_menu.Append(wx.NewIdRef(), _("Flip"), flip_menu)
         image_menu.Append(wx.NewIdRef(), _("Swap axes"), swap_axes_menu)
 
-        reorient_menu = image_menu.Append(const.ID_REORIENT_IMG, _("Reorient image\tCtrl+Shift+O"))
+        reorient_menu = image_menu.Append(const.ID_REORIENT_IMG, sm.get_menu_label("reorient_image", _("Reorient image")))
         image_menu.Append(const.ID_IMAGE_FILTER, _("Filter"))
-
         image_menu.Append(const.ID_MANUAL_WWWL, _("Set WW&&WL manually"))
 
         planning_menu = wx.Menu()
@@ -1626,52 +1622,21 @@ class MenuBar(wx.MenuBar):
         tools_menu.Append(-1, _("Segmentation"), segmentation_menu)
         tools_menu.Append(-1, _("Surface"), surface_menu)
 
-        # Add separator before debug tools
         tools_menu.AppendSeparator()
-
-        # Add log viewer and error handling test menu items
         tools_menu.Append(ID_SHOW_LOG_VIEWER, _("Show Log Viewer"))
         tools_menu.Append(ID_INTERACTIVE_SHELL, _("Interactive Shell"))
 
         self.tools_menu = tools_menu
 
-        # View
+        #View
         self.view_menu = view_menu = wx.Menu()
         view_menu.Append(const.ID_VIEW_INTERPOLATED, _("Interpolated slices"), "", wx.ITEM_CHECK)
 
         v = self.SliceInterpolationStatus()
         self.view_menu.Check(const.ID_VIEW_INTERPOLATED, v)
-
         self.actived_interpolated_slices = self.view_menu
 
-        # view_tool_menu = wx.Menu()
-        # app = view_tool_menu.Append
-        # app(const.ID_TOOL_PROJECT, "Project Toolbar")
-        # app(const.ID_TOOL_LAYOUT, "Layout Toolbar")
-        # app(const.ID_TOOL_OBJECT, "Object Toolbar")
-        # app(const.ID_TOOL_SLICE, "Slice Toolbar")
-
-        # view_layout_menu = wx.Menu()
-        # app = view_layout_menu.Append
-        # app(const.ID_TASK_BAR, "Task Bar")
-        # app(const.ID_VIEW_FOUR, "Four View")
-
-        # view_menu = wx.Menu()
-        # app = view_menu.Append
-        # appm = view_menu.Append
-        # appm(-1, "Toolbars",view_tool_menu)
-        # appm(-1, "Layout", view_layout_menu)
-        # view_menu.AppendSeparator()
-        # app(const.ID_VIEW_FULL, "Fullscreen\tCtrl+F")
-        # view_menu.AppendSeparator()
-        # app(const.ID_VIEW_TEXT, "2D & 3D Text")
-        # view_menu.AppendSeparator()
-        # app(const.ID_VIEW_3D_BACKGROUND, "3D Background Colour")
-
-        # TOOLS
-        # tools_menu = wx.Menu()
-
-        # OPTIONS
+        # Options
         options_menu = wx.Menu()
         options_menu.Append(const.ID_PREFERENCES, _("Preferences"))
 
@@ -1680,20 +1645,21 @@ class MenuBar(wx.MenuBar):
         nav_menu = wx.Menu()
         nav_menu.Append(
             const.ID_MODE_NAVIGATION,
-            _("Transcranial Magnetic Stimulation Mode\tCtrl+T"),
+            sm.get_menu_label("navigation_mode", _("Transcranial Magnetic Stimulation Mode")),
             "",
             wx.ITEM_CHECK,
         )
-        # Under development
         self.mode_dbs = nav_menu.Append(
-            const.ID_MODE_DBS, _("Deep Brain Stimulation Mode\tCtrl+B"), "", wx.ITEM_CHECK
+            const.ID_MODE_DBS,
+            sm.get_menu_label("dbs_mode", _("Deep Brain Stimulation Mode")),
+            "",
+            wx.ITEM_CHECK,
         )
         self.mode_dbs.Enable(0)
         mode_menu.Append(-1, _("Navigation Mode"), nav_menu)
 
         v = self.NavigationModeStatus()
         self.mode_menu.Check(const.ID_MODE_NAVIGATION, v)
-
         self.actived_navigation_mode = self.mode_menu
 
         plugins_menu = wx.Menu()
@@ -1703,14 +1669,8 @@ class MenuBar(wx.MenuBar):
         # HELP
         help_menu = wx.Menu()
         help_menu.Append(const.ID_START, _("Getting started..."))
-        # help_menu.Append(108, "User Manual...")
         help_menu.AppendSeparator()
         help_menu.Append(const.ID_ABOUT, _("About..."))
-        # help_menu.Append(107, "Check For Updates Now...")
-
-        # if platform.system() == 'Darwin':
-        # wx.App.SetMacAboutMenuItemId(const.ID_ABOUT)
-        # wx.App.SetMacExitMenuItemId(const.ID_EXIT)
 
         # Add all menus to menubar
         self.Append(file_menu, _("File"))
@@ -1718,12 +1678,12 @@ class MenuBar(wx.MenuBar):
         self.Append(view_menu, _("View"))
         self.Append(tools_menu, _("Tools"))
         self.Append(plugins_menu, _("Plugins"))
-        # self.Append(tools_menu, "Tools")
         self.Append(options_menu, _("Options"))
         self.Append(mode_menu, _("Mode"))
         self.Append(help_menu, _("Help"))
 
         plugins_menu.Bind(wx.EVT_MENU, self.OnPluginMenu)
+
 
     def OnPluginMenu(self, evt):
         id = evt.GetId()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -1467,6 +1467,7 @@ class MenuBar(wx.MenuBar):
         file_menu = wx.Menu()
         app = file_menu.Append
         app(const.ID_DICOM_IMPORT, sm.get_menu_label("import_dicom", _("Import DICOM...")))
+        # app(const.ID_DICOM_NETWORK, _("Retrieve DICOM from PACS"))
         file_menu.Append(const.ID_IMPORT_OTHERS_FILES, _("Import other files..."), others_file_menu)
         app(const.ID_PROJECT_OPEN, sm.get_menu_label("open_project", _("Open project...")))
         app(const.ID_PROJECT_SAVE, sm.get_menu_label("save_project", _("Save project")))
@@ -1475,6 +1476,13 @@ class MenuBar(wx.MenuBar):
         app(const.ID_PROJECT_PROPERTIES, _("Project properties"))
         app(const.ID_PROJECT_CLOSE, _("Close project"))
         file_menu.AppendSeparator()
+        # app(const.ID_PROJECT_INFO, _("Project Information..."))
+        # file_menu.AppendSeparator()
+        # app(const.ID_SAVE_SCREENSHOT, _("Save Screenshot"))
+        # app(const.ID_PRINT_SCREENSHOT, _("Print Screenshot"))
+        # file_menu.AppendSeparator()
+        # app(1, "C:\InvData\sample.inv")
+        # file_menu.AppendSeparator()
         app(const.ID_EXIT, sm.get_menu_label("exit", _("Exit")))
 
         file_edit = wx.Menu()
@@ -1483,6 +1491,7 @@ class MenuBar(wx.MenuBar):
         file_edit.Append(const.ID_GOTO_SLICE, sm.get_menu_label("goto_slice", _("Go to slice ...")))
         file_edit.Append(const.ID_GOTO_COORD, _("Go to scanner coord ...\t")).Enable(False)
 
+        # app(const.ID_EDIT_LIST, "Show Undo List...")
         #################################################################
 
         # Tool menu
@@ -1622,19 +1631,49 @@ class MenuBar(wx.MenuBar):
         tools_menu.Append(-1, _("Segmentation"), segmentation_menu)
         tools_menu.Append(-1, _("Surface"), surface_menu)
 
+        # Add separator before debug tools
         tools_menu.AppendSeparator()
+
+        # Add log viewer and error handling test menu items
         tools_menu.Append(ID_SHOW_LOG_VIEWER, _("Show Log Viewer"))
         tools_menu.Append(ID_INTERACTIVE_SHELL, _("Interactive Shell"))
 
         self.tools_menu = tools_menu
 
-        #View
+        # View
         self.view_menu = view_menu = wx.Menu()
         view_menu.Append(const.ID_VIEW_INTERPOLATED, _("Interpolated slices"), "", wx.ITEM_CHECK)
 
         v = self.SliceInterpolationStatus()
         self.view_menu.Check(const.ID_VIEW_INTERPOLATED, v)
         self.actived_interpolated_slices = self.view_menu
+
+        # view_tool_menu = wx.Menu()
+        # app = view_tool_menu.Append
+        # app(const.ID_TOOL_PROJECT, "Project Toolbar")
+        # app(const.ID_TOOL_LAYOUT, "Layout Toolbar")
+        # app(const.ID_TOOL_OBJECT, "Object Toolbar")
+        # app(const.ID_TOOL_SLICE, "Slice Toolbar")
+
+        # view_layout_menu = wx.Menu()
+        # app = view_layout_menu.Append
+        # app(const.ID_TASK_BAR, "Task Bar")
+        # app(const.ID_VIEW_FOUR, "Four View")
+
+        # view_menu = wx.Menu()
+        # app = view_menu.Append
+        # appm = view_menu.Append
+        # appm(-1, "Toolbars",view_tool_menu)
+        # appm(-1, "Layout", view_layout_menu)
+        # view_menu.AppendSeparator()
+        # app(const.ID_VIEW_FULL, "Fullscreen\tCtrl+F")
+        # view_menu.AppendSeparator()
+        # app(const.ID_VIEW_TEXT, "2D & 3D Text")
+        # view_menu.AppendSeparator()
+        # app(const.ID_VIEW_3D_BACKGROUND, "3D Background Colour")
+
+        # TOOLS
+        # tools_menu = wx.Menu()
 
         # Options
         options_menu = wx.Menu()
@@ -1655,6 +1694,8 @@ class MenuBar(wx.MenuBar):
             "",
             wx.ITEM_CHECK,
         )
+
+        # Under development
         self.mode_dbs.Enable(0)
         mode_menu.Append(-1, _("Navigation Mode"), nav_menu)
 
@@ -1669,8 +1710,14 @@ class MenuBar(wx.MenuBar):
         # HELP
         help_menu = wx.Menu()
         help_menu.Append(const.ID_START, _("Getting started..."))
+        # help_menu.Append(108, "User Manual...")
         help_menu.AppendSeparator()
         help_menu.Append(const.ID_ABOUT, _("About..."))
+        # help_menu.Append(107, "Check For Updates Now...")
+
+        # if platform.system() == 'Darwin':
+        # wx.App.SetMacAboutMenuItemId(const.ID_ABOUT)
+        # wx.App.SetMacExitMenuItemId(const.ID_EXIT)
 
         # Add all menus to menubar
         self.Append(file_menu, _("File"))
@@ -1678,12 +1725,12 @@ class MenuBar(wx.MenuBar):
         self.Append(view_menu, _("View"))
         self.Append(tools_menu, _("Tools"))
         self.Append(plugins_menu, _("Plugins"))
+        # self.Append(tools_menu, "Tools")
         self.Append(options_menu, _("Options"))
         self.Append(mode_menu, _("Mode"))
         self.Append(help_menu, _("Help"))
 
         plugins_menu.Bind(wx.EVT_MENU, self.OnPluginMenu)
-
 
     def OnPluginMenu(self, evt):
         id = evt.GetId()

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -45,9 +45,9 @@ from invesalius import inv_paths
 from invesalius.data.slice_ import Slice
 from invesalius.gui import project_properties
 from invesalius.gui.interactive_shell import InteractiveShellFrame
+from invesalius.gui.shortcut_manager import ShortcutManager
 from invesalius.i18n import tr as _
 from invesalius.pubsub import pub as Publisher
-from invesalius.gui.shortcut_manager import ShortcutManager
 
 try:
     from wx.adv import TaskBarIcon as wx_TaskBarIcon
@@ -219,7 +219,7 @@ class Frame(wx.Frame):
         is_shell_focused = False
 
         # Check if the focus is on a text entry field
-        if focused and isinstance(focused, (wx.TextCtrl, wx.ComboBox)):
+        if focused and isinstance(focused, wx.TextCtrl | wx.ComboBox):
             is_search_field = True
 
         # Check if the shell is focused
@@ -244,11 +244,7 @@ class Frame(wx.Frame):
             event.Skip()
             return
 
-        if (
-            current_key == clean_mask_key
-            and not is_search_field
-            and not is_shell_focused
-        ):
+        if current_key == clean_mask_key and not is_search_field and not is_shell_focused:
             if hasattr(self, "clean_mask_menu") and self.clean_mask_menu.IsEnabled():
                 self.OnCleanMask()
             event.Skip()
@@ -1500,7 +1496,9 @@ class MenuBar(wx.MenuBar):
         # Mask Menu
         mask_menu = wx.Menu()
 
-        self.new_mask_menu = mask_menu.Append(const.ID_CREATE_MASK, sm.get_menu_label("new_mask", _("New")))
+        self.new_mask_menu = mask_menu.Append(
+            const.ID_CREATE_MASK, sm.get_menu_label("new_mask", _("New"))
+        )
         self.new_mask_menu.Enable(False)
 
         self.bool_op_menu = mask_menu.Append(
@@ -1508,18 +1506,22 @@ class MenuBar(wx.MenuBar):
         )
         self.bool_op_menu.Enable(False)
 
-        self.clean_mask_menu = mask_menu.Append(const.ID_CLEAN_MASK, sm.get_menu_label("clean_mask", _("Clean Mask")))
+        self.clean_mask_menu = mask_menu.Append(
+            const.ID_CLEAN_MASK, sm.get_menu_label("clean_mask", _("Clean Mask"))
+        )
         self.clean_mask_menu.Enable(False)
 
         mask_menu.AppendSeparator()
 
         self.fill_hole_mask_menu = mask_menu.Append(
-            const.ID_FLOODFILL_MASK, sm.get_menu_label("fill_holes_manually", _("Fill holes manually"))
+            const.ID_FLOODFILL_MASK,
+            sm.get_menu_label("fill_holes_manually", _("Fill holes manually")),
         )
         self.fill_hole_mask_menu.Enable(False)
 
         self.fill_hole_auto_menu = mask_menu.Append(
-            const.ID_FILL_HOLE_AUTO, sm.get_menu_label("fill_holes_auto", _("Fill holes automatically"))
+            const.ID_FILL_HOLE_AUTO,
+            sm.get_menu_label("fill_holes_auto", _("Fill holes automatically")),
         )
         self.fill_hole_mask_menu.Enable(False)
 
@@ -1545,12 +1547,18 @@ class MenuBar(wx.MenuBar):
         mask_preview_menu = wx.Menu()
 
         self.mask_preview = mask_preview_menu.Append(
-            const.ID_MASK_3D_PREVIEW, sm.get_menu_label("mask_3d_preview", _("Enable")), "", wx.ITEM_CHECK
+            const.ID_MASK_3D_PREVIEW,
+            sm.get_menu_label("mask_3d_preview", _("Enable")),
+            "",
+            wx.ITEM_CHECK,
         )
         self.mask_preview.Enable(False)
 
         self.mask_auto_reload = mask_preview_menu.Append(
-            const.ID_MASK_3D_AUTO_RELOAD, sm.get_menu_label("mask_3d_auto_reload", _("Auto reload")), "", wx.ITEM_CHECK
+            const.ID_MASK_3D_AUTO_RELOAD,
+            sm.get_menu_label("mask_3d_auto_reload", _("Auto reload")),
+            "",
+            wx.ITEM_CHECK,
         )
 
         session = ses.Session()
@@ -1569,27 +1577,35 @@ class MenuBar(wx.MenuBar):
         # Segmentation Menu
         segmentation_menu = wx.Menu()
         self.threshold_segmentation = segmentation_menu.Append(
-            const.ID_THRESHOLD_SEGMENTATION, sm.get_menu_label("threshold_segmentation", _("Threshold"))
+            const.ID_THRESHOLD_SEGMENTATION,
+            sm.get_menu_label("threshold_segmentation", _("Threshold")),
         )
         self.manual_segmentation = segmentation_menu.Append(
-            const.ID_MANUAL_SEGMENTATION, sm.get_menu_label("manual_segmentation", _("Manual segmentation"))
+            const.ID_MANUAL_SEGMENTATION,
+            sm.get_menu_label("manual_segmentation", _("Manual segmentation")),
         )
         self.watershed_segmentation = segmentation_menu.Append(
-            const.ID_WATERSHED_SEGMENTATION, sm.get_menu_label("watershed_segmentation", _("Watershed"))
+            const.ID_WATERSHED_SEGMENTATION,
+            sm.get_menu_label("watershed_segmentation", _("Watershed")),
         )
         self.ffill_segmentation = segmentation_menu.Append(
-            const.ID_FLOODFILL_SEGMENTATION, sm.get_menu_label("region_growing", _("Region growing"))
+            const.ID_FLOODFILL_SEGMENTATION,
+            sm.get_menu_label("region_growing", _("Region growing")),
         )
         self.ffill_segmentation.Enable(False)
         segmentation_menu.AppendSeparator()
         segmentation_menu.Append(const.ID_SEGMENTATION_BRAIN, _("Brain segmentation (MRI T1)"))
-        segmentation_menu.Append(const.ID_SEGMENTATION_SUBPART, _("Brain subpart segmentation (MRI T1)"))
+        segmentation_menu.Append(
+            const.ID_SEGMENTATION_SUBPART, _("Brain subpart segmentation (MRI T1)")
+        )
         segmentation_menu.Append(const.ID_SEGMENTATION_TRACHEA, _("Trachea segmentation (CT)"))
         segmentation_menu.Append(const.ID_SEGMENTATION_MANDIBLE_CT, _("Mandible segmentation (CT)"))
 
         # Surface Menu
         surface_menu = wx.Menu()
-        self.create_surface = surface_menu.Append(const.ID_CREATE_SURFACE, sm.get_menu_label("new_surface", _("New")))
+        self.create_surface = surface_menu.Append(
+            const.ID_CREATE_SURFACE, sm.get_menu_label("new_surface", _("New"))
+        )
         self.create_surface.Enable(False)
 
         self.remove_non_visible = surface_menu.Append(
@@ -1606,14 +1622,20 @@ class MenuBar(wx.MenuBar):
         flip_menu.Append(const.ID_FLIP_Z, _("Top - Bottom")).Enable(False)
 
         swap_axes_menu = wx.Menu()
-        swap_axes_menu.Append(const.ID_SWAP_XY, _("From Right-Left to Anterior-Posterior")).Enable(False)
+        swap_axes_menu.Append(const.ID_SWAP_XY, _("From Right-Left to Anterior-Posterior")).Enable(
+            False
+        )
         swap_axes_menu.Append(const.ID_SWAP_XZ, _("From Right-Left to Top-Bottom")).Enable(False)
-        swap_axes_menu.Append(const.ID_SWAP_YZ, _("From Anterior-Posterior to Top-Bottom")).Enable(False)
+        swap_axes_menu.Append(const.ID_SWAP_YZ, _("From Anterior-Posterior to Top-Bottom")).Enable(
+            False
+        )
 
         image_menu.Append(wx.NewIdRef(), _("Flip"), flip_menu)
         image_menu.Append(wx.NewIdRef(), _("Swap axes"), swap_axes_menu)
 
-        reorient_menu = image_menu.Append(const.ID_REORIENT_IMG, sm.get_menu_label("reorient_image", _("Reorient image")))
+        reorient_menu = image_menu.Append(
+            const.ID_REORIENT_IMG, sm.get_menu_label("reorient_image", _("Reorient image"))
+        )
         image_menu.Append(const.ID_IMAGE_FILTER, _("Filter"))
         image_menu.Append(const.ID_MANUAL_WWWL, _("Set WW&&WL manually"))
 

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1484,7 +1484,7 @@ class ObjectTab(wx.Panel):
 
         try:
             if filename:
-                with open(filename, "r") as text_file:
+                with open(filename) as text_file:
                     data = [s.split("\t") for s in text_file.readlines()]
 
                 registration_coordinates = np.array(data[1:]).astype(np.float32)
@@ -1562,7 +1562,7 @@ class ObjectTab(wx.Panel):
 
                 msg = _("Object file successfully loaded")
                 wx.MessageBox(msg, _("InVesalius 3"))
-        except:
+        except Exception:
             wx.MessageBox(_("Object registration file incompatible."), _("InVesalius 3"))
             Publisher.sendMessage("Update status text in GUI", label="")
 
@@ -2181,7 +2181,7 @@ class TrackerTab(wx.Panel):
         try:
             if hasattr(self.robot, "SetPressureSetpoint"):
                 self.robot.SetPressureSetpoint(value)
-        except Exception as e:
+        except Exception:
             pass
 
     def OnSetRecommendedPressure(self, event):
@@ -2201,7 +2201,7 @@ class TrackerTab(wx.Panel):
         try:
             if hasattr(self.robot, "SetPressureSetpoint"):
                 self.robot.SetPressureSetpoint(value)
-        except Exception as e:
+        except Exception:
             pass
 
     def _update_pressure_controls_state(self, slider_enabled: bool):
@@ -2312,13 +2312,12 @@ class LanguageTab(wx.Panel):
 
 
 class ShortcutsTab(wx.Panel):
-
     """
     Preferences tab for viewing and remapping keyboard shortcuts.
     Users can reassign any shortcut, reset individual ones, or
     reset all to factory defaults. Changes take effect on next restart.
     """
-    
+
     def __init__(self, parent):
         wx.Panel.__init__(self, parent)
         from invesalius.gui.shortcut_manager import ShortcutManager
@@ -2327,9 +2326,7 @@ class ShortcutsTab(wx.Panel):
         self._changes_made = False  # track if user changed anything
 
         # List control showing all shortcuts
-        self.list = wx.ListCtrl(
-            self, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN
-        )
+        self.list = wx.ListCtrl(self, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN)
         self.list.InsertColumn(0, _("Category"), width=120)
         self.list.InsertColumn(1, _("Action"), width=200)
         self.list.InsertColumn(2, _("Shortcut"), width=120)
@@ -2354,9 +2351,7 @@ class ShortcutsTab(wx.Panel):
         # Info label at bottom
         info_label = wx.StaticText(
             self,
-            label=_(
-                "Note: Shortcut changes take effect the next time InVesalius starts."
-            ),
+            label=_("Note: Shortcut changes take effect the next time InVesalius starts."),
         )
         info_label.SetForegroundColour(wx.Colour(100, 100, 100))
 
@@ -2372,9 +2367,7 @@ class ShortcutsTab(wx.Panel):
         self.list.DeleteAllItems()
         self._action_ids = []
         for entry in self.sm.all_shortcuts():
-            idx = self.list.InsertItem(
-                self.list.GetItemCount(), entry.get("category", "")
-            )
+            idx = self.list.InsertItem(self.list.GetItemCount(), entry.get("category", ""))
             self.list.SetItem(idx, 1, entry.get("label", ""))
             self.list.SetItem(idx, 2, entry.get("current", ""))
             self._action_ids.append(entry["action_id"])
@@ -2483,7 +2476,7 @@ class KeyCaptureDialog(wx.Dialog):
         if keycode in (wx.WXK_CONTROL, wx.WXK_SHIFT, wx.WXK_ALT):
             return
 
-        if hasattr(wx, 'GetKeyName'):
+        if hasattr(wx, "GetKeyName"):
             key_name = wx.GetKeyName(keycode)
         else:
             key_name = chr(keycode) if 32 <= keycode <= 126 else str(keycode)

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -42,6 +42,7 @@ class Preferences(wx.Dialog):
 
         self.visualization_tab = VisualizationTab(self.book)
         self.language_tab = LanguageTab(self.book)
+        self.shortcuts_tab = ShortcutsTab(self.book)
         if self.have_log_tab == 1:
             self.logging_tab = LoggingTab(self.book)
 
@@ -68,6 +69,7 @@ class Preferences(wx.Dialog):
             self.book.AddPage(self.object_tab, _("TMS Coil"))
 
         self.book.AddPage(self.language_tab, _("Language"))
+        self.book.AddPage(self.shortcuts_tab, _("Shortcuts"))
         if self.have_log_tab == 1:
             self.book.AddPage(self.logging_tab, _("Logging"))
 
@@ -124,6 +126,8 @@ class Preferences(wx.Dialog):
 
         values.update(lang)
         values.update(viewer)
+        shortcuts = self.shortcuts_tab.GetSelection()
+        values.update(shortcuts)
 
         # Add navigation tab preferences (includes marker shapes)
         if hasattr(self, "navigation_tab"):
@@ -2305,3 +2309,188 @@ class LanguageTab(wx.Panel):
         locales = self.lg.GetLocalesKey()
         selection = locales.index(language)
         self.cmb_lang.SetSelection(int(selection))
+
+
+class ShortcutsTab(wx.Panel):
+
+    """
+    Preferences tab for viewing and remapping keyboard shortcuts.
+    Users can reassign any shortcut, reset individual ones, or
+    reset all to factory defaults. Changes take effect on next restart.
+    """
+    
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent)
+        from invesalius.gui.shortcut_manager import ShortcutManager
+
+        self.sm = ShortcutManager()
+        self._changes_made = False  # track if user changed anything
+
+        # List control showing all shortcuts
+        self.list = wx.ListCtrl(
+            self, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN
+        )
+        self.list.InsertColumn(0, _("Category"), width=120)
+        self.list.InsertColumn(1, _("Action"), width=200)
+        self.list.InsertColumn(2, _("Shortcut"), width=120)
+
+        self._populate_list()
+
+        # Buttons
+        btn_edit = wx.Button(self, label=_("Reassign"))
+        btn_reset_one = wx.Button(self, label=_("Reset selected"))
+        btn_reset_all = wx.Button(self, label=_("Reset all to defaults"))
+
+        btn_edit.Bind(wx.EVT_BUTTON, self.OnReassign)
+        btn_reset_one.Bind(wx.EVT_BUTTON, self.OnResetOne)
+        btn_reset_all.Bind(wx.EVT_BUTTON, self.OnResetAll)
+
+        btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        btn_sizer.Add(btn_edit, 0, wx.ALL, 5)
+        btn_sizer.Add(btn_reset_one, 0, wx.ALL, 5)
+        btn_sizer.AddStretchSpacer()
+        btn_sizer.Add(btn_reset_all, 0, wx.ALL, 5)
+
+        # Info label at bottom
+        info_label = wx.StaticText(
+            self,
+            label=_(
+                "Note: Shortcut changes take effect the next time InVesalius starts."
+            ),
+        )
+        info_label.SetForegroundColour(wx.Colour(100, 100, 100))
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 10)
+        main_sizer.Add(info_label, 0, wx.LEFT | wx.BOTTOM, 10)
+        main_sizer.Add(btn_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        self.SetSizerAndFit(main_sizer)
+        self.Layout()
+
+    def _populate_list(self):
+        self.list.DeleteAllItems()
+        self._action_ids = []
+        for entry in self.sm.all_shortcuts():
+            idx = self.list.InsertItem(
+                self.list.GetItemCount(), entry.get("category", "")
+            )
+            self.list.SetItem(idx, 1, entry.get("label", ""))
+            self.list.SetItem(idx, 2, entry.get("current", ""))
+            self._action_ids.append(entry["action_id"])
+
+    def OnReassign(self, evt):
+        idx = self.list.GetFirstSelected()
+        if idx == -1:
+            wx.MessageBox(_("Please select a shortcut to reassign."), _("InVesalius"))
+            return
+        action_id = self._action_ids[idx]
+        label = self.list.GetItemText(idx, 1)
+
+        dlg = KeyCaptureDialog(self, label)
+        if dlg.ShowModal() == wx.ID_OK:
+            new_key = dlg.GetKey()
+            if new_key:
+                try:
+                    self.sm.set_shortcut(action_id, new_key)
+                    self.list.SetItem(idx, 2, new_key)
+                    self._changes_made = True
+                except ValueError as e:
+                    wx.MessageBox(str(e), _("Conflict"))
+        dlg.Destroy()
+
+    def OnResetOne(self, evt):
+        idx = self.list.GetFirstSelected()
+        if idx == -1:
+            wx.MessageBox(_("Please select a shortcut to reset."), _("InVesalius"))
+            return
+        action_id = self._action_ids[idx]
+        self.sm.reset_one(action_id)
+        default = self.sm._shortcuts[action_id]["default"]
+        self.list.SetItem(idx, 2, default)
+        self._changes_made = True
+
+    def OnResetAll(self, evt):
+        if (
+            wx.MessageBox(
+                _("Reset all shortcuts to defaults?"),
+                _("InVesalius"),
+                wx.YES_NO | wx.NO_DEFAULT,
+            )
+            == wx.YES
+        ):
+            self.sm.reset_all()
+            self._populate_list()
+            self._changes_made = True
+
+    def GetSelection(self):
+        self.sm.save()
+        if self._changes_made:
+            wx.MessageBox(
+                _("Shortcut changes will take effect the next time InVesalius starts."),
+                _("Shortcuts"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            self._changes_made = False
+        return {}
+
+    def LoadSelection(self, values):
+        self._populate_list()
+
+
+class KeyCaptureDialog(wx.Dialog):
+    """
+    Dialog that captures a key combination from the user.
+    Press any key combination to set it as the new shortcut.
+    """
+
+    def __init__(self, parent, action_label):
+        wx.Dialog.__init__(self, parent, title=_("Reassign Shortcut"))
+        self._key = ""
+
+        msg = wx.StaticText(self, label=_("Press a key combination for:\n") + action_label)
+        self.key_display = wx.TextCtrl(self, style=wx.TE_READONLY | wx.TE_CENTRE)
+        self.key_display.SetMinSize((200, -1))
+
+        btn_ok = wx.Button(self, wx.ID_OK, _("Assign"))
+        btn_cancel = wx.Button(self, wx.ID_CANCEL, _("Cancel"))
+        btn_sizer = wx.StdDialogButtonSizer()
+        btn_sizer.AddButton(btn_ok)
+        btn_sizer.AddButton(btn_cancel)
+        btn_sizer.Realize()
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(msg, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+        sizer.Add(self.key_display, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        sizer.Add(btn_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        self.SetSizerAndFit(sizer)
+
+        self.key_display.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
+        self.key_display.SetFocus()
+
+    def OnKeyDown(self, evt):
+        keycode = evt.GetKeyCode()
+        modifiers = evt.GetModifiers()
+
+        parts = []
+        if modifiers & wx.MOD_CONTROL:
+            parts.append("Ctrl")
+        if modifiers & wx.MOD_SHIFT:
+            parts.append("Shift")
+        if modifiers & wx.MOD_ALT:
+            parts.append("Alt")
+
+        if keycode in (wx.WXK_CONTROL, wx.WXK_SHIFT, wx.WXK_ALT):
+            return
+
+        if hasattr(wx, 'GetKeyName'):
+            key_name = wx.GetKeyName(keycode)
+        else:
+            key_name = chr(keycode) if 32 <= keycode <= 126 else str(keycode)
+
+        parts.append(key_name.upper() if len(key_name) == 1 else key_name)
+        self._key = "+".join(parts)
+        self.key_display.SetValue(self._key)
+
+    def GetKey(self):
+        return self._key

--- a/invesalius/gui/shortcut_manager.py
+++ b/invesalius/gui/shortcut_manager.py
@@ -15,10 +15,8 @@ Usage
 """
 
 import json
-import os
 import shutil
 from pathlib import Path
-
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -27,16 +25,19 @@ from pathlib import Path
 # The bundled default lives next to this file (invesalius/gui/shortcuts.json).
 _DEFAULT_JSON = Path(__file__).parent / "shortcuts.json"
 
+
 # The user-editable copy lives in the InVesalius config directory so it
 # survives reinstalls.  We import inv_paths lazily to avoid circular imports.
 def _user_json_path() -> Path:
     from invesalius import inv_paths  # noqa: PLC0415
+
     return Path(inv_paths.USER_INV_DIR) / "shortcuts.json"
 
 
 # ---------------------------------------------------------------------------
 # ShortcutManager
 # ---------------------------------------------------------------------------
+
 
 class ShortcutManager:
     """
@@ -51,7 +52,7 @@ class ShortcutManager:
     def __new__(cls):
         if cls._instance is None:
             obj = super().__new__(cls)
-            obj._shortcuts = {}   # action_id -> dict entry from JSON
+            obj._shortcuts = {}  # action_id -> dict entry from JSON
             obj._loaded = False
             cls._instance = obj
         return cls._instance
@@ -71,12 +72,9 @@ class ShortcutManager:
             self._seed_user_file(user_path)
 
         try:
-            with open(user_path, "r", encoding="utf-8") as fh:
+            with open(user_path, encoding="utf-8") as fh:
                 data = json.load(fh)
-            self._shortcuts = {
-                entry["action_id"]: entry
-                for entry in data.get("shortcuts", [])
-            }
+            self._shortcuts = {entry["action_id"]: entry for entry in data.get("shortcuts", [])}
         except Exception as exc:
             print(f"[ShortcutManager] Failed to load {user_path}: {exc}")
             print("[ShortcutManager] Falling back to bundled defaults.")
@@ -131,9 +129,7 @@ class ShortcutManager:
         self._ensure_loaded()
         conflict = self._find_conflict(action_id, key_string)
         if conflict:
-            raise ValueError(
-                f"Key '{key_string}' is already used by '{conflict}'."
-            )
+            raise ValueError(f"Key '{key_string}' is already used by '{conflict}'.")
         if action_id in self._shortcuts:
             self._shortcuts[action_id]["current"] = key_string
 
@@ -184,8 +180,7 @@ class ShortcutManager:
         else:
             # Bundled file missing — write a minimal valid JSON so we don't crash.
             print(
-                "[ShortcutManager] Bundled shortcuts.json not found; "
-                "creating empty user file."
+                "[ShortcutManager] Bundled shortcuts.json not found; " "creating empty user file."
             )
             with open(user_path, "w", encoding="utf-8") as fh:
                 json.dump({"shortcuts": []}, fh, indent=2)
@@ -193,12 +188,9 @@ class ShortcutManager:
     def _load_defaults(self) -> None:
         """Load directly from the bundled default file (fallback)."""
         try:
-            with open(_DEFAULT_JSON, "r", encoding="utf-8") as fh:
+            with open(_DEFAULT_JSON, encoding="utf-8") as fh:
                 data = json.load(fh)
-            self._shortcuts = {
-                entry["action_id"]: entry
-                for entry in data.get("shortcuts", [])
-            }
+            self._shortcuts = {entry["action_id"]: entry for entry in data.get("shortcuts", [])}
         except Exception as exc:
             print(f"[ShortcutManager] Cannot load bundled defaults either: {exc}")
             self._shortcuts = {}

--- a/invesalius/gui/shortcut_manager.py
+++ b/invesalius/gui/shortcut_manager.py
@@ -1,0 +1,219 @@
+"""
+shortcut_manager.py
+-------------------
+Central registry for InVesalius keyboard shortcuts.
+
+Usage
+-----
+    from invesalius.gui.shortcut_manager import ShortcutManager
+    sm = ShortcutManager()          # loads on first call, cached after
+    label = sm.get_menu_label("import_dicom", "Import DICOM")
+    # returns e.g. "Import DICOM\tCtrl+I"
+
+    sm.set_shortcut("import_dicom", "Ctrl+Shift+I")
+    sm.save()
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+# The bundled default lives next to this file (invesalius/gui/shortcuts.json).
+_DEFAULT_JSON = Path(__file__).parent / "shortcuts.json"
+
+# The user-editable copy lives in the InVesalius config directory so it
+# survives reinstalls.  We import inv_paths lazily to avoid circular imports.
+def _user_json_path() -> Path:
+    from invesalius import inv_paths  # noqa: PLC0415
+    return Path(inv_paths.USER_INV_DIR) / "shortcuts.json"
+
+
+# ---------------------------------------------------------------------------
+# ShortcutManager
+# ---------------------------------------------------------------------------
+
+class ShortcutManager:
+    """
+    Singleton-style manager for keyboard shortcuts.
+
+    Call ``ShortcutManager()`` anywhere; the first call loads the JSON,
+    subsequent calls return the same cached instance.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            obj = super().__new__(cls)
+            obj._shortcuts = {}   # action_id -> dict entry from JSON
+            obj._loaded = False
+            cls._instance = obj
+        return cls._instance
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """
+        Load shortcuts from the user config file.
+        If no user file exists yet, copy the bundled default there first.
+        """
+        user_path = _user_json_path()
+
+        if not user_path.exists():
+            self._seed_user_file(user_path)
+
+        try:
+            with open(user_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self._shortcuts = {
+                entry["action_id"]: entry
+                for entry in data.get("shortcuts", [])
+            }
+        except Exception as exc:
+            print(f"[ShortcutManager] Failed to load {user_path}: {exc}")
+            print("[ShortcutManager] Falling back to bundled defaults.")
+            self._load_defaults()
+
+        self._loaded = True
+
+    def save(self) -> None:
+        """Persist the current (possibly edited) shortcuts to the user file."""
+        user_path = _user_json_path()
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "_comment": (
+                "InVesalius keyboard shortcuts registry. "
+                "Edit 'current' to remap. Do not change 'action_id' or 'category'."
+            ),
+            "shortcuts": list(self._shortcuts.values()),
+        }
+        try:
+            with open(user_path, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, ensure_ascii=False)
+        except Exception as exc:
+            print(f"[ShortcutManager] Failed to save shortcuts: {exc}")
+
+    def reset_all(self) -> None:
+        """Reset every shortcut to its factory default and save."""
+        for entry in self._shortcuts.values():
+            entry["current"] = entry["default"]
+        self.save()
+
+    def reset_one(self, action_id: str) -> None:
+        """Reset a single shortcut to its factory default."""
+        if action_id in self._shortcuts:
+            entry = self._shortcuts[action_id]
+            entry["current"] = entry["default"]
+
+    def get_shortcut(self, action_id: str) -> str:
+        """Return the *current* key string for action_id, e.g. 'Ctrl+I'."""
+        self._ensure_loaded()
+        entry = self._shortcuts.get(action_id)
+        if entry is None:
+            return ""
+        return entry.get("current") or entry.get("default", "")
+
+    def set_shortcut(self, action_id: str, key_string: str) -> None:
+        """
+        Update the current binding for action_id.
+        Raises ValueError if key_string conflicts with another action.
+        Does NOT save automatically — call save() when done.
+        """
+        self._ensure_loaded()
+        conflict = self._find_conflict(action_id, key_string)
+        if conflict:
+            raise ValueError(
+                f"Key '{key_string}' is already used by '{conflict}'."
+            )
+        if action_id in self._shortcuts:
+            self._shortcuts[action_id]["current"] = key_string
+
+    def get_menu_label(self, action_id: str, base_label: str) -> str:
+        """
+        Build the full wxPython menu label string.
+
+        Example:
+            get_menu_label("import_dicom", "Import DICOM")
+            -> "Import DICOM\\tCtrl+I"
+
+        If the action has no shortcut, returns base_label unchanged.
+        """
+        key = self.get_shortcut(action_id)
+        if key:
+            return f"{base_label}\t{key}"
+        return base_label
+
+    def all_shortcuts(self) -> list:
+        """Return a list of all shortcut dicts (sorted by category then label)."""
+        self._ensure_loaded()
+        return sorted(
+            self._shortcuts.values(),
+            key=lambda e: (e.get("category", ""), e.get("label", "")),
+        )
+
+    def find_action_by_key(self, key_string: str) -> str | None:
+        """Return the action_id that currently uses key_string, or None."""
+        self._ensure_loaded()
+        for action_id, entry in self._shortcuts.items():
+            if entry.get("current", "").lower() == key_string.lower():
+                return action_id
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    def _seed_user_file(self, user_path: Path) -> None:
+        """Copy the bundled shortcuts.json to the user config directory."""
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+        if _DEFAULT_JSON.exists():
+            shutil.copy2(_DEFAULT_JSON, user_path)
+        else:
+            # Bundled file missing — write a minimal valid JSON so we don't crash.
+            print(
+                "[ShortcutManager] Bundled shortcuts.json not found; "
+                "creating empty user file."
+            )
+            with open(user_path, "w", encoding="utf-8") as fh:
+                json.dump({"shortcuts": []}, fh, indent=2)
+
+    def _load_defaults(self) -> None:
+        """Load directly from the bundled default file (fallback)."""
+        try:
+            with open(_DEFAULT_JSON, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self._shortcuts = {
+                entry["action_id"]: entry
+                for entry in data.get("shortcuts", [])
+            }
+        except Exception as exc:
+            print(f"[ShortcutManager] Cannot load bundled defaults either: {exc}")
+            self._shortcuts = {}
+
+    def _find_conflict(self, action_id: str, key_string: str) -> str | None:
+        """
+        Return the label of the action that already uses key_string,
+        or None if there is no conflict.
+        Ignores the action_id being reassigned (so you can 're-set' to same key).
+        """
+        if not key_string:
+            return None
+        for aid, entry in self._shortcuts.items():
+            if aid == action_id:
+                continue
+            if entry.get("current", "").lower() == key_string.lower():
+                return entry.get("label", aid)
+        return None

--- a/invesalius/gui/shortcut_manager.py
+++ b/invesalius/gui/shortcut_manager.py
@@ -15,8 +15,11 @@ Usage
 """
 
 import json
+import logging
 import shutil
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -76,8 +79,8 @@ class ShortcutManager:
                 data = json.load(fh)
             self._shortcuts = {entry["action_id"]: entry for entry in data.get("shortcuts", [])}
         except Exception as exc:
-            print(f"[ShortcutManager] Failed to load {user_path}: {exc}")
-            print("[ShortcutManager] Falling back to bundled defaults.")
+            logger.error(f"Failed to load {user_path}: {exc}")
+            logger.info("Falling back to bundled defaults.")
             self._load_defaults()
 
         self._loaded = True
@@ -98,7 +101,7 @@ class ShortcutManager:
             with open(user_path, "w", encoding="utf-8") as fh:
                 json.dump(data, fh, indent=2, ensure_ascii=False)
         except Exception as exc:
-            print(f"[ShortcutManager] Failed to save shortcuts: {exc}")
+            logger.error(f"Failed to save shortcuts: {exc}")
 
     def reset_all(self) -> None:
         """Reset every shortcut to its factory default and save."""
@@ -179,9 +182,7 @@ class ShortcutManager:
             shutil.copy2(_DEFAULT_JSON, user_path)
         else:
             # Bundled file missing — write a minimal valid JSON so we don't crash.
-            print(
-                "[ShortcutManager] Bundled shortcuts.json not found; " "creating empty user file."
-            )
+            logger.warning("Bundled shortcuts.json not found; creating empty user file.")
             with open(user_path, "w", encoding="utf-8") as fh:
                 json.dump({"shortcuts": []}, fh, indent=2)
 
@@ -192,7 +193,7 @@ class ShortcutManager:
                 data = json.load(fh)
             self._shortcuts = {entry["action_id"]: entry for entry in data.get("shortcuts", [])}
         except Exception as exc:
-            print(f"[ShortcutManager] Cannot load bundled defaults either: {exc}")
+            logger.critical(f"Cannot load bundled defaults either: {exc}")
             self._shortcuts = {}
 
     def _find_conflict(self, action_id: str, key_string: str) -> str | None:

--- a/invesalius/gui/shortcuts.json
+++ b/invesalius/gui/shortcuts.json
@@ -1,0 +1,187 @@
+{
+  "_comment": "InVesalius keyboard shortcuts registry. Edit 'current' to remap. Do not change 'action_id' or 'category'.",
+  "shortcuts": [
+    {
+      "action_id": "import_dicom",
+      "label": "Import DICOM",
+      "category": "File",
+      "default": "Ctrl+I",
+      "current": "Ctrl+I"
+    },
+    {
+      "action_id": "open_project",
+      "label": "Open project",
+      "category": "File",
+      "default": "Ctrl+O",
+      "current": "Ctrl+O"
+    },
+    {
+      "action_id": "save_project",
+      "label": "Save project",
+      "category": "File",
+      "default": "Ctrl+S",
+      "current": "Ctrl+S"
+    },
+    {
+      "action_id": "save_project_as",
+      "label": "Save project as",
+      "category": "File",
+      "default": "Ctrl+Shift+S",
+      "current": "Ctrl+Shift+S"
+    },
+    {
+      "action_id": "exit",
+      "label": "Exit",
+      "category": "File",
+      "default": "Ctrl+Q",
+      "current": "Ctrl+Q"
+    },
+    {
+      "action_id": "undo",
+      "label": "Undo",
+      "category": "Edit",
+      "default": "Ctrl+Z",
+      "current": "Ctrl+Z"
+    },
+    {
+      "action_id": "redo",
+      "label": "Redo",
+      "category": "Edit",
+      "default": "Ctrl+Y",
+      "current": "Ctrl+Y"
+    },
+    {
+      "action_id": "goto_slice",
+      "label": "Go to slice",
+      "category": "Edit",
+      "default": "Ctrl+G",
+      "current": "Ctrl+G"
+    },
+    {
+      "action_id": "new_mask",
+      "label": "New mask",
+      "category": "Mask",
+      "default": "Ctrl+Shift+M",
+      "current": "Ctrl+Shift+M"
+    },
+    {
+      "action_id": "boolean_operations",
+      "label": "Boolean operations",
+      "category": "Mask",
+      "default": "Ctrl+Shift+B",
+      "current": "Ctrl+Shift+B"
+    },
+    {
+      "action_id": "clean_mask",
+      "label": "Clean mask",
+      "category": "Mask",
+      "default": "Ctrl+Shift+A",
+      "current": "Ctrl+Shift+A"
+    },
+    {
+      "action_id": "fill_holes_manually",
+      "label": "Fill holes manually",
+      "category": "Mask",
+      "default": "Ctrl+Shift+H",
+      "current": "Ctrl+Shift+H"
+    },
+    {
+      "action_id": "fill_holes_auto",
+      "label": "Fill holes automatically",
+      "category": "Mask",
+      "default": "Ctrl+Shift+J",
+      "current": "Ctrl+Shift+J"
+    },
+    {
+      "action_id": "remove_mask_parts",
+      "label": "Remove mask parts",
+      "category": "Mask",
+      "default": "Ctrl+Shift+K",
+      "current": "Ctrl+Shift+K"
+    },
+    {
+      "action_id": "select_mask_parts",
+      "label": "Select mask parts",
+      "category": "Mask",
+      "default": "Ctrl+Shift+L",
+      "current": "Ctrl+Shift+L"
+    },
+    {
+      "action_id": "mask_3d_preview",
+      "label": "Mask 3D preview enable",
+      "category": "Mask",
+      "default": "Ctrl+Shift+P",
+      "current": "Ctrl+Shift+P"
+    },
+    {
+      "action_id": "mask_3d_auto_reload",
+      "label": "Mask 3D auto reload",
+      "category": "Mask",
+      "default": "Ctrl+Shift+D",
+      "current": "Ctrl+Shift+D"
+    },
+    {
+      "action_id": "mask_3d_reload",
+      "label": "Mask 3D reload",
+      "category": "Mask",
+      "default": "Ctrl+Shift+R",
+      "current": "Ctrl+Shift+R"
+    },
+    {
+      "action_id": "threshold_segmentation",
+      "label": "Threshold segmentation",
+      "category": "Segmentation",
+      "default": "Ctrl+Shift+T",
+      "current": "Ctrl+Shift+T"
+    },
+    {
+      "action_id": "manual_segmentation",
+      "label": "Manual segmentation",
+      "category": "Segmentation",
+      "default": "Ctrl+Shift+E",
+      "current": "Ctrl+Shift+E"
+    },
+    {
+      "action_id": "watershed_segmentation",
+      "label": "Watershed segmentation",
+      "category": "Segmentation",
+      "default": "Ctrl+Shift+W",
+      "current": "Ctrl+Shift+W"
+    },
+    {
+      "action_id": "region_growing",
+      "label": "Region growing",
+      "category": "Segmentation",
+      "default": "Ctrl+Shift+G",
+      "current": "Ctrl+Shift+G"
+    },
+    {
+      "action_id": "new_surface",
+      "label": "New surface",
+      "category": "Surface",
+      "default": "Ctrl+Shift+C",
+      "current": "Ctrl+Shift+C"
+    },
+    {
+      "action_id": "reorient_image",
+      "label": "Reorient image",
+      "category": "Image",
+      "default": "Ctrl+Shift+O",
+      "current": "Ctrl+Shift+O"
+    },
+    {
+      "action_id": "navigation_mode",
+      "label": "TMS Navigation mode",
+      "category": "Mode",
+      "default": "Ctrl+T",
+      "current": "Ctrl+T"
+    },
+    {
+      "action_id": "dbs_mode",
+      "label": "Deep Brain Stimulation mode",
+      "category": "Mode",
+      "default": "Ctrl+B",
+      "current": "Ctrl+B"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the ability for users to view and remap keyboard shortcuts in InVesalius.

**Summary of Changes**
- Added shortcuts.json — a central registry that stores all keyboard shortcuts with their default and current values
- Added shortcut_manager.py — a singleton utility that loads, saves, and manages shortcuts. Handles conflict detection and reset to defaults
- Updated frame.py — menu labels now read from the registry instead of being hardcoded strings
- Added a Shortcuts tab in the Preferences dialog where users can see all shortcuts, reassign any key combination, reset individual shortcuts, or reset all to defaults

**Working**
On first launch, the registry is copied to the user's config directory. Any changes a user makes are saved to their personal copy, so other users are unaffected. Shortcut changes take effect on the next restart.

**Testing**
Testing done:
- All existing menu shortcuts work correctly
- Remapped shortcuts persist across restarts
- Conflict detection, reset selected, and reset all to defaults work as expected
- Tested on Windows

<img width="1919" height="1009" alt="image" src="https://github.com/user-attachments/assets/19ba02a8-6f7d-47ed-b1ca-48fb6359d901" />
