### PR TITLE
Add progress dialogs for mask export and import

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -255,16 +255,27 @@ class Controller:
             Publisher.sendMessage("Import Nifti mask", filepath=filepath)
 
     def OnImportMaskNifti(self, filepath: "str | bytes") -> None:
+        progress_dlg = None
         try:
             if isinstance(filepath, bytes):
                 filepath = filepath.decode("utf-8")
 
+            progress_dlg = dialogs.MaskProgressDialog(
+                _("Importing Mask"), _("Preparing to import mask..."), maximum=100
+            )
+
             import invesalius.reader.others_reader as oth
             from invesalius.reader.nifti_utils import check_is_mask, validate_mask_compatibility
+
+            if not progress_dlg.Update(10, _("Reading NIfTI file...")):
+                return
 
             img = oth.ReadOthers(filepath)
             if img is False:
                 raise Exception(_("Failed to read NIfTI file."))
+
+            if not progress_dlg.Update(20, _("Validating mask data...")):
+                return
 
             # Ensure a volume is loaded before importing a mask
             if self.Slice.matrix is None:
@@ -275,12 +286,21 @@ class Controller:
             # Preserve original dtype; avoid forcing float64 conversion
             data = np.asarray(img.dataobj)
 
+            if not progress_dlg.Update(40, _("Checking mask compatibility...")):
+                return
+
             # Validate dimensions match the current project volume
             proj_shape = self.Slice.matrix.shape[::-1]
             validate_mask_compatibility(data.shape, proj_shape)
 
+            if not progress_dlg.Update(50, _("Converting mask data...")):
+                return
+
             # Convert and normalize to binary label map (0/255 uint8)
             mask_data = check_is_mask(data)
+
+            if not progress_dlg.Update(60, _("Transforming mask orientation...")):
+                return
 
             # Match InVesalius internal (axial) coordinate layout (ZYX flipped)
             mask_data = np.ascontiguousarray(np.fliplr(np.swapaxes(mask_data, 0, 2)))
@@ -290,7 +310,13 @@ class Controller:
             thresh = (0, 255)
             colour = const.MASK_COLOUR[len(prj.Project().mask_dict) % len(const.MASK_COLOUR)]
 
+            if not progress_dlg.Update(70, _("Creating new mask...")):
+                return
+
             Publisher.sendMessage("Create new mask", mask_name=name, thresh=thresh, colour=colour)
+
+            if not progress_dlg.Update(80, _("Applying mask data...")):
+                return
 
             mask = self.Slice.current_mask
             if mask:
@@ -303,7 +329,13 @@ class Controller:
                 for buffer_ in self.Slice.buffer_slices.values():
                     buffer_.discard_vtk_mask()
                     buffer_.discard_mask()
-                Publisher.sendMessage("Reload actual slice")
+
+            if not progress_dlg.Update(95, _("Refreshing views...")):
+                return
+
+            Publisher.sendMessage("Reload actual slice")
+
+            progress_dlg.Update(100, _("Mask imported successfully!"))
 
             Publisher.sendMessage(
                 "Update status text in GUI", label=_("Mask imported successfully.")
@@ -311,6 +343,9 @@ class Controller:
 
         except Exception as e:
             dialogs.ErrorMessageBox(None, _("Error importing mask"), str(e)).ShowModal()
+        finally:
+            if progress_dlg is not None:
+                progress_dlg.Close()
 
     def OnShowExportMaskDialog(self, mask_indexes: list) -> None:
         if not mask_indexes:
@@ -344,19 +379,41 @@ class Controller:
         dlg.Destroy()
 
     def OnExportMaskNifti(self, mask_indexes: list, filepath: "str | bytes") -> None:
+        progress_dlg = None
         try:
             import nibabel as nib
 
             project = prj.Project()
-            for index in mask_indexes:
+            total_masks = len(mask_indexes)
+            
+            progress_dlg = dialogs.MaskProgressDialog(
+                _("Exporting Mask"), _("Preparing to export mask(s)..."), maximum=100
+            )
+
+            for i, index in enumerate(mask_indexes):
+                base_progress = int((i / total_masks) * 100)
+                progress_step = int(100 / total_masks)
+                
                 mask = project.GetMask(index)
                 if not mask:
                     continue
+                    
+                msg_prefix = f"[{i + 1}/{total_masks}] " if total_masks > 1 else ""
+
+                if not progress_dlg.Update(base_progress + int(progress_step * 0.1), f"{msg_prefix}{_('Preparing mask data...')} ({mask.name})"):
+                    break
 
                 # Ensure all slices have threshold data (lazy threshold only generates visited slices)
                 self.Slice.do_threshold_to_all_slices(mask)
+                
+                if not progress_dlg.Update(base_progress + int(progress_step * 0.4), f"{msg_prefix}{_('Extracting matrix...')} ({mask.name})"):
+                    break
+                    
                 # Strip 1-pixel padding from InVesalius mask matrix (padding is only at index 0)
                 mask_matrix = mask.matrix[1:, 1:, 1:]
+
+                if not progress_dlg.Update(base_progress + int(progress_step * 0.6), f"{msg_prefix}{_('Converting format...')} ({mask.name})"):
+                    break
 
                 # Axis transform to NIfTI layout and cast to uint8
                 export_data = np.ascontiguousarray(
@@ -365,6 +422,9 @@ class Controller:
 
                 # Label-map enforcement: strict binary encoding (0=background, 255=mask)
                 export_data[export_data > 0] = 255
+
+                if not progress_dlg.Update(base_progress + int(progress_step * 0.8), f"{msg_prefix}{_('Saving file...')} ({mask.name})"):
+                    break
 
                 # Use identity affine to ensure RAS+ encoding; as_closest_canonical will be a no-op on reimport
                 mask_nifti = nib.Nifti1Image(export_data, np.eye(4))
@@ -380,9 +440,15 @@ class Controller:
                     save_path = filepath
 
                 nib.save(mask_nifti, save_path)
+                
+            if not progress_dlg.WasCancelled():
+                progress_dlg.Update(100, _("Mask(s) exported successfully!"))
 
         except Exception as e:
             dialogs.ErrorMessageBox(None, _("Error exporting mask"), str(e)).ShowModal()
+        finally:
+            if progress_dlg is not None:
+                progress_dlg.Close()
 
     def ShowDialogOpenProject(self) -> None:
         # Offer to save current project if necessary

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -2141,7 +2141,7 @@ class CalculateSurfacePropertiesProgressWindow:
         self.dlg = wx.ProgressDialog(title, message, parent=parent, style=style)
         self.dlg.Show()
 
-    def Update(self, msg: Optional[str] = None, value=None) -> None:
+    def Update(self, msg: str | None = None, value=None) -> None:
         if msg is None:
             self.dlg.Pulse()
         else:
@@ -7917,10 +7917,73 @@ class ProgressBarHandler(wx.ProgressDialog):
             super().Pulse(msg)
 
 
+class MaskProgressDialog:
+    """Progress dialog for mask import/export operations with cancellation support."""
+
+    def __init__(
+        self, title: str, message: str, maximum: int = 100, parent: wx.Window | None = None
+    ):
+        if parent is None:
+            parent = wx.GetApp().GetTopWindow()
+
+        self.cancelled = False
+        self.dlg = wx.ProgressDialog(
+            title,
+            message,
+            maximum=maximum,
+            parent=parent,
+            style=wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
+        )
+
+        # Force the dialog to paint before work starts
+        wx.SafeYield()
+
+    def Update(self, value: int, message: str = "") -> bool:
+        """
+        Update progress dialog.
+
+        Args:
+            value: Progress value (0-maximum)
+            message: Status message to display
+
+        Returns:
+            True if should continue, False if cancelled
+        """
+        if self.cancelled:
+            return False
+
+        try:
+            if message:
+                continue_op, skip = self.dlg.Update(value, message)
+            else:
+                continue_op, skip = self.dlg.Update(value)
+
+            if not continue_op:
+                self.cancelled = True
+                return False
+
+            return True
+        except Exception:
+            return False
+
+    def WasCancelled(self) -> bool:
+        """Check if user cancelled the operation."""
+        return self.cancelled
+
+    def Close(self) -> None:
+        """Close and destroy the progress dialog."""
+        try:
+            if self.dlg:
+                self.dlg.Destroy()
+                self.dlg = None
+        except Exception:
+            pass
+
+
 class ProjectLoadProgressDialog:
     """Progress dialog for loading .inv3 project files with cancellation support."""
 
-    def __init__(self, parent: Optional[wx.Window] = None):
+    def __init__(self, parent: wx.Window | None = None):
         if parent is None:
             parent = wx.GetApp().GetTopWindow()
 


### PR DESCRIPTION
## Summary
Adds progress dialog feedback to the mask import and export workflows. Previously, these operations ran silently in the background without providing any visual indication of progress or cancellation support, resulting in an inconsistent user experience.
Closes #1392

https://github.com/user-attachments/assets/8c9fb0ec-d0f0-4aa2-9145-6b3b3fe16482


## Problem

- Mask export from the **Mask** tab did not provide any progress or status feedback.
- Mask import functionality also lacked a progress dialog.
- Neither workflow supported cancellation once started.
- Long-running operations could make the UI appear unresponsive until completion.

## Fix

### Added
- Created a reusable `MaskProgressDialog` class in `gui/dialogs.py`.
  - Wraps `wx.ProgressDialog`
  - Supports cancellation via `wx.PD_CAN_ABORT`
  - Displays elapsed time
  - Auto-hides on completion
  
<img width="431" height="222" alt="image" src="https://github.com/user-attachments/assets/ec82338b-ea64-4b87-868b-0da3a863aa8b" />
<img width="416" height="215" alt="image" src="https://github.com/user-attachments/assets/6430e04c-3268-434b-879b-5f3753a39cb8" />


### Updated `OnImportMaskNifti` (`control.py`)
- Integrated progress dialog support.
- Split the import workflow into trackable stages:
  - Reading
  - Validating
  - Converting
  - Transforming
  - Applying
- Added cancellation checks using `WasCancelled()` throughout the process.

### Updated `OnExportMaskNifti` (`control.py`)
- Added dynamic progress tracking based on the total number of masks being exported.
- Introduced per-mask progress stages:
  - Extracting matrix
  - Converting format
  - Saving
- Added safe cancellation handling during export operations.

## Result

The UI now behaves consistently with other heavy data-processing workflows by:

- Displaying clear, auto-closing progress dialogs during mask imports and exports.
- Showing granular progress updates for current processing stages.
- Preventing UI lockups during lengthy operations.
- Providing functional cancellation support that prevents partial files on disk. Cancellation checks occur *before* the disk I/O operations (`nib.save`), meaning if an export is aborted, the application skips writing the file entirely rather than leaving corrupted or half-written data. When exporting multiple masks, any fully saved masks are preserved, while remaining pending masks are cleanly skipped. For imports, cancellation safely discards temporary data in memory before altering the active volume.


## Testing

### Tested on Windows 

#### Import
- Imported a NIfTI mask successfully.
- Verified the progress dialog appeared and updated correctly.
- Confirmed the dialog closed automatically on success.

#### Export
- Exported single and multiple masks to NIfTI.
- Verified progress scaled dynamically with mask count.
- Confirmed per-stage progress updates displayed correctly.

#### Cancellation
- Clicked **Cancel** during import/export operations.
- Verified operations aborted safely without:
  - UI hangs
  - crashes
  - corrupted application state