### PR TITLE
Implement Workspace Perspectives Save/Load/Reset

### DIFF
--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -153,6 +153,9 @@ class Panel(wx.Panel):
         session = ses.Session()
         if session.GetConfig("mode") != const.MODE_NAVIGATOR:
             Publisher.sendMessage("Hide target button")
+            
+        # Save default perspective for reset
+        self.perspective_all = self.aui_manager.SavePerspective()
 
     def __bind_events_wx(self):
         self.aui_manager.Bind(wx.aui.EVT_AUI_PANE_MAXIMIZE, self.OnMaximize)

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -21,7 +21,6 @@ import sys
 
 import wx
 import wx.aui
-import wx.lib.agw.fourwaysplitter as fws
 import wx.lib.colourselect as csel
 import wx.lib.platebtn as pbtn
 

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -216,7 +216,7 @@ class Frame(wx.Frame):
         is_shell_focused = False
 
         # Check if the focus is on a text entry field
-        if focused and isinstance(focused, (wx.TextCtrl, wx.ComboBox)):
+        if focused and isinstance(focused, wx.TextCtrl | wx.ComboBox):
             is_search_field = True
 
         # Check if the shell is focused

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -62,6 +62,7 @@ VIEW_TOOLS = [ID_LAYOUT, ID_TEXT, ID_RULER] = [wx.NewIdRef() for number in range
 
 # Custom IDs for our new menu items
 [ID_SHOW_LOG_VIEWER, ID_INTERACTIVE_SHELL] = [wx.NewIdRef() for number in range(2)]
+[ID_PERSPECTIVE_SAVE, ID_PERSPECTIVE_LOAD, ID_PERSPECTIVE_RESET] = [wx.NewIdRef() for number in range(3)]
 
 WILDCARD_EXPORT_SLICE = (
     "HDF5 (*.hdf5)|*.hdf5|NIfTI 1 (*.nii)|*.nii|Compressed NIfTI (*.nii.gz)|*.nii.gz"
@@ -854,6 +855,12 @@ class Frame(wx.Frame):
             self.OnShowLogViewer(evt)
         elif id == ID_INTERACTIVE_SHELL:
             self.OnInteractiveShell(evt)
+        elif id == ID_PERSPECTIVE_SAVE:
+            self.OnPerspectiveSave(evt)
+        elif id == ID_PERSPECTIVE_LOAD:
+            self.OnPerspectiveLoad(evt)
+        elif id == ID_PERSPECTIVE_RESET:
+            self.OnPerspectiveReset(evt)
 
         # Handle task panel toggle
         elif id == const.ID_TASK_BAR:
@@ -865,6 +872,67 @@ class Frame(wx.Frame):
 
             # Force focus on main window to ensure UI updates properly
             self.SetFocus()
+
+    def OnPerspectiveSave(self, evt):
+        pers_string = self.aui_manager.SavePerspective()
+        
+        # Also save the internal perspective of the 3D viewers (Data pane)
+        data_pane = self.aui_manager.GetPane("Data")
+        if data_pane.IsOk() and hasattr(data_pane.window, "aui_manager"):
+            viewers_pers = data_pane.window.aui_manager.SavePerspective()
+        else:
+            viewers_pers = ""
+            
+        session = ses.Session()
+        session.SetConfig("perspective", pers_string)
+        session.SetConfig("perspective_viewers", viewers_pers)
+
+    def OnPerspectiveLoad(self, evt):
+        session = ses.Session()
+        pers_string = session.GetConfig("perspective")
+        viewers_pers = session.GetConfig("perspective_viewers")
+        
+        if pers_string:
+            # Save current visibility state
+            visible_panes = {pane.name: pane.IsShown() for pane in self.aui_manager.GetAllPanes()}
+            self.aui_manager.LoadPerspective(pers_string)
+            # Restore visibility state
+            for pane in self.aui_manager.GetAllPanes():
+                if pane.name in visible_panes:
+                    pane.Show(visible_panes[pane.name])
+            self.aui_manager.Update()
+            
+        if viewers_pers:
+            data_pane = self.aui_manager.GetPane("Data")
+            if data_pane.IsOk() and hasattr(data_pane.window, "aui_manager"):
+                v_mgr = data_pane.window.aui_manager
+                v_visible = {pane.name: pane.IsShown() for pane in v_mgr.GetAllPanes()}
+                v_mgr.LoadPerspective(viewers_pers)
+                for pane in v_mgr.GetAllPanes():
+                    if pane.name in v_visible:
+                        pane.Show(v_visible[pane.name])
+                v_mgr.Update()
+
+    def OnPerspectiveReset(self, evt):
+        if hasattr(self, "perspective_all"):
+            # Save current visibility state
+            visible_panes = {pane.name: pane.IsShown() for pane in self.aui_manager.GetAllPanes()}
+            self.aui_manager.LoadPerspective(self.perspective_all)
+            # Restore visibility state
+            for pane in self.aui_manager.GetAllPanes():
+                if pane.name in visible_panes:
+                    pane.Show(visible_panes[pane.name])
+            self.aui_manager.Update()
+            
+        data_pane = self.aui_manager.GetPane("Data")
+        if data_pane.IsOk() and hasattr(data_pane.window, "perspective_all"):
+            v_mgr = data_pane.window.aui_manager
+            v_visible = {pane.name: pane.IsShown() for pane in v_mgr.GetAllPanes()}
+            v_mgr.LoadPerspective(data_pane.window.perspective_all)
+            for pane in v_mgr.GetAllPanes():
+                if pane.name in v_visible:
+                    pane.Show(v_visible[pane.name])
+            v_mgr.Update()
 
     def _HideTask(self):
         """
@@ -1643,6 +1711,15 @@ class MenuBar(wx.MenuBar):
         self.view_menu.Check(const.ID_VIEW_INTERPOLATED, v)
 
         self.actived_interpolated_slices = self.view_menu
+
+        # Perspectives
+        perspectives_menu = wx.Menu()
+        perspectives_menu.Append(ID_PERSPECTIVE_SAVE, _("Save Current Perspective"))
+        perspectives_menu.Append(ID_PERSPECTIVE_LOAD, _("Load Saved Perspective"))
+        perspectives_menu.Append(ID_PERSPECTIVE_RESET, _("Reset to Default"))
+        
+        view_menu.AppendSeparator()
+        view_menu.Append(-1, _("Perspectives"), perspectives_menu)
 
         # view_tool_menu = wx.Menu()
         # app = view_tool_menu.Append


### PR DESCRIPTION
Fixes #1394 
# Fix: Implemented Workspace Perspectives

This PR implements the missing "Workspace Perspectives" feature, allowing users to save, load, and reset their custom UI layouts.

**Changes:**
- Added a `View > Perspectives` menu with Save, Load, and Reset options.
- Wired the save/load logic to persist layout strings in the user's `config.json`.
- Fixed the 3D viewers not saving by ensuring the internal `AuiManager` inside the Data pane is also explicitly saved and loaded alongside the main window.
- Added a visibility check during `LoadPerspective()` so that applying a custom layout doesn't accidentally hide your active DICOM project.
