### PR TITLE
fix: restore sidebar state after cancelling DICOM/Bitmap import

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -95,8 +95,8 @@ class Controller:
         Publisher.subscribe(self.OnOpenDicomGroup, "Open DICOM group")
         Publisher.subscribe(self.OnOpenBitmapFiles, "Open bitmap files")
         Publisher.subscribe(self.OnOpenOtherFiles, "Open other files")
-        Publisher.subscribe(self.Progress, "Update dicom load")
-        Publisher.subscribe(self.Progress, "Update bitmap load")
+        Publisher.subscribe(self.OnUpdateDicomLoad, "Update dicom load")
+        Publisher.subscribe(self.OnUpdateBitmapLoad, "Update bitmap load")
         Publisher.subscribe(self.OnLoadImportPanel, "End dicom load")
         Publisher.subscribe(self.OnLoadImportBitmapPanel, "End bitmap load")
         Publisher.subscribe(self.OnCancelImport, "Cancel DICOM load")
@@ -138,12 +138,19 @@ class Controller:
         proj.spacing = spacing
 
     def OnCancelImport(self) -> None:
-        # self.cancel_import = True
-        Publisher.sendMessage("Hide import panel")
+        # Note: Do NOT send "Hide import panel" here. During a scan-phase cancel,
+        # the Import pane was never shown, so touching the AUI manager while the
+        # progress dialog is still alive causes macOS to grey out the sidebar.
+        # The DICOM thumbnail panel's Cancel button (import_panel.py) sends
+        # "Hide import panel" directly when it actually needs to close.
+        Publisher.sendMessage("End busy cursor")
+        Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
 
     def OnCancelImportBitmap(self) -> None:
         # self.cancel_import = True
         Publisher.sendMessage("Hide import bitmap panel")
+        Publisher.sendMessage("End busy cursor")
+        Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
 
     ###########################
     ###########################
@@ -679,6 +686,7 @@ class Controller:
         reader.SetWindowEvent(self.frame)
         reader.SetDirectoryPath(path)
         Publisher.sendMessage("End busy cursor")
+        Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
 
     def StartImportPanel(self, path: "str | Path") -> None:
         # retrieve DICOM files split into groups
@@ -686,24 +694,36 @@ class Controller:
         reader.SetWindowEvent(self.frame)
         reader.SetDirectoryPath(path)
         Publisher.sendMessage("End busy cursor")
+        Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
 
-    def Progress(self, data: Optional[Sequence[int]]) -> None:
+    def OnUpdateDicomLoad(self, data: Optional[Sequence[int]]) -> None:
+        self.Progress(data, "Cancel DICOM load")
+
+    def OnUpdateBitmapLoad(self, data: Optional[Sequence[int]]) -> None:
+        self.Progress(data, "Cancel bitmap load")
+
+    def Progress(self, data: Optional[Sequence[int]], cancel_msg: str = "Cancel DICOM load") -> None:
         if data:
             message = _("Loading file %d of %d ...") % (data[0], data[1])
             if not (self.progress_dialog):
                 self.progress_dialog = vtk_utils.ProgressDialog(
-                    parent=self.frame, maximum=data[1], abort=True
+                    parent=self.frame, maximum=data[1], abort=True, cancel_msg=cancel_msg
                 )
             else:
-                if not (self.progress_dialog.Update(data[0], message)):
+                update_result = self.progress_dialog.Update(data[0], message)
+                if not update_result:
                     self.progress_dialog.Close()
                     self.progress_dialog = None
-                    Publisher.sendMessage("Begin busy cursor")
+                    Publisher.sendMessage("End busy cursor")
+                    Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
         else:
             # Is None if user canceled the load
             if self.progress_dialog is not None:
                 self.progress_dialog.Close()
                 self.progress_dialog = None
+
+            Publisher.sendMessage("End busy cursor")
+            Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
 
     def OnLoadImportPanel(self, patient_series: Optional[List]) -> None:
         ok = self.LoadImportPanel(patient_series)

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -48,12 +48,18 @@ if TYPE_CHECKING:
 
 class ProgressDialog:
     def __init__(
-        self, parent: Optional[wx.Window], maximum: int, abort: bool = False, msg: str = ""
+        self,
+        parent: Optional[wx.Window],
+        maximum: int,
+        abort: bool = False,
+        msg: str = "",
+        cancel_msg: str = "Cancel DICOM load",
     ):
         self.title = "InVesalius 3"
         self.msg = msg if msg else _("Loading DICOM files")
         self.maximum = maximum
         self.current = 0
+        self.cancel_msg = cancel_msg
         self.style = wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME
         if abort:
             self.style = self.style | wx.PD_CAN_ABORT
@@ -66,7 +72,7 @@ class ProgressDialog:
         self.dlg.SetSize(wx.Size(250, 150))
 
     def Cancel(self, evt: wx.CommandEvent) -> None:
-        Publisher.sendMessage("Cancel DICOM load")
+        Publisher.sendMessage(self.cancel_msg)
 
     def Update(self, value: SupportsInt, message: str) -> Union[Tuple[bool, bool], bool]:
         if int(value) != self.maximum:

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -153,7 +153,6 @@ class Frame(wx.Frame):
         """
         sub = Publisher.subscribe
         sub(self._BeginBusyCursor, "Begin busy cursor")
-        sub(self._ShowContentPanel, "Cancel DICOM load")
         sub(self._EndBusyCursor, "End busy cursor")
         sub(self._HideContentPanel, "Hide content panel")
         sub(self._HideImportPanel, "Hide import panel")
@@ -442,11 +441,12 @@ class Frame(wx.Frame):
 
     def _EndBusyCursor(self):
         """
-        End busy cursor.
-        Note: _BeginBusyCursor should have been called previously.
+        End busy cursor, draining all stacked BeginBusyCursor calls.
+        wx.BeginBusyCursor is reference-counted; each Begin needs a matching End.
         """
         try:
-            wx.EndBusyCursor()
+            while wx.IsBusy():
+                wx.EndBusyCursor()
         except wx.PyAssertionError:
             # no matching wxBeginBusyCursor() for wxEndBusyCursor()
             pass

--- a/invesalius/gui/import_bitmap_panel.py
+++ b/invesalius/gui/import_bitmap_panel.py
@@ -160,7 +160,7 @@ class InnerPanel(wx.Panel):
         parm.ShowModal()
 
     def OnClickCancel(self, evt):
-        Publisher.sendMessage("Cancel DICOM load")
+        Publisher.sendMessage("Cancel bitmap load")
 
 
 class TextPanel(wx.Panel):

--- a/invesalius/gui/import_panel.py
+++ b/invesalius/gui/import_panel.py
@@ -177,6 +177,7 @@ class InnerPanel(wx.Panel):
 
     def OnClickCancel(self, evt):
         Publisher.sendMessage("Cancel DICOM load")
+        Publisher.sendMessage("Hide import panel")
 
     def LoadDicom(self, group):
         if not group:


### PR DESCRIPTION
## Description 

### Fixes: #1400
Clicking Cancel during microtomography or DICOM import did not stop loading, leaving the Load Data sidebar greyed out and unresponsive. This was caused by an incorrect cancel signal in import_bitmap_panel.py and an aui_manager.Update() call in frame.py while the modal progress dialog was still active on macOS.

### Changes

`frame.py `— Removed incorrect `_ShowContentPanel `subscription from "`Cancel DICOM load`" that caused the sidebar grey-out.

`import_bitmap_panel.py` — Fixed Cancel button sending wrong signal (`"Cancel DICOM load"` → `"Cancel bitmap load"`).

`vtk_utils.py` — `ProgressDialog` now accepts a dynamic `cancel_msg` for DICOM vs Bitmap imports.

`control.py` — `OnCancelImport` no longer triggers AUI updates during scan-phase cancel; added UI restore signals to both cancel handlers.

`import_panel.py` — DICOM thumbnail panel Cancel now also sends `"Hide import panel"` to restore the UI correctly.

### Testing

Import TIF/BMP → click Cancel → sidebar stays fully interactive 
Import DICOM → click Cancel → sidebar stays fully interactive 
Cancel from DICOM thumbnail panel → UI returns to Load data screen correctly 