### PR TITLE
fix : Invalidate mask after image flip

### DIFF
--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -366,17 +366,10 @@ class Mask:
         self._open_mask(path, tuple(shape))
 
     def OnFlipVolume(self, axis):
-        submatrix = self.matrix[1:, 1:, 1:]
-        if axis == 0:
-            submatrix[:] = submatrix[::-1]
-            self.matrix[1::, 0, 0] = self.matrix[:0:-1, 0, 0]
-        elif axis == 1:
-            submatrix[:] = submatrix[:, ::-1]
-            self.matrix[0, 1::, 0] = self.matrix[0, :0:-1, 0]
-        elif axis == 2:
-            submatrix[:] = submatrix[:, :, ::-1]
-            self.matrix[0, 0, 1::] = self.matrix[0, 0, :0:-1]
-
+        # Note: slice_.py's OnFlipVolume already zeros matrix[:] and clears
+        # history for all masks before this handler runs.  Here we only need
+        # to update the VTK volume actor if a 3D mask preview is active.
+        # (fix for issue #1402)
         if self.volume:
             self.imagedata = self.as_vtkimagedata()
             self.volume.change_imagedata()
@@ -384,8 +377,10 @@ class Mask:
         self.modified()
 
     def OnSwapVolumeAxes(self, axes):
-        axis0, axis1 = axes
-        self.matrix = self.matrix.swapaxes(axis0, axis1)
+        # Note: slice_.py's OnSwapVolumeAxes already zeros matrix[:] and clears
+        # history for all masks before this handler runs.  Here we only need
+        # to update the VTK volume actor if a 3D mask preview is active.
+        # (fix for issue #1402 — same class of bug as flip)
         if self.volume:
             self.imagedata = self.as_vtkimagedata()
             self.volume.change_imagedata()

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -2089,6 +2089,7 @@ class Slice(metaclass=utils.Singleton):
         import os as _os
 
         _os.fsync(new_fd)
+        _os.close(new_fd)
         del swapped
 
         # Close and remove the old matrix file, replace with new one
@@ -2112,6 +2113,14 @@ class Slice(metaclass=utils.Singleton):
         # Also swap every image version (filtered images) so that mask
         # threshold evaluation always uses the correctly swapped data.
         proj = Project()
+
+        # Update project metadata so save/load uses the new file and shape.
+        # Without this, saving after a swap would archive the old (pre-swap)
+        # matrix file and the wrong shape, causing an error on reopen.
+        proj.matrix_filename = new_filename
+        proj.matrix_shape = new_shape
+        proj.spacing = self.spacing
+        # matrix_dtype stays the same
         for i, (label, mat) in enumerate(proj.image_versions):
             swapped_ver = np.array(mat.swapaxes(axis0, axis1))
             ver_fd, ver_filename = _tempfile.mkstemp()
@@ -2119,6 +2128,7 @@ class Slice(metaclass=utils.Singleton):
             ver_mat[:] = swapped_ver
             ver_mat.flush()
             _os.fsync(ver_fd)
+            _os.close(ver_fd)
             del swapped_ver
             # Clean up the old temp file for this image version
             old_ver_filename = getattr(mat, "filename", None)

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1688,12 +1688,6 @@ class Slice(metaclass=utils.Singleton):
                 )
                 mask.matrix[n, 0, 0] = 1
 
-        # After evaluating all axial slices, the entire volume is fully evaluated.
-        # Mark coronal and sagittal slices as evaluated too, to prevent them from being
-        # incorrectly re-evaluated and corrupted by get_mask_slice when scrolling.
-        mask.matrix[0, 1:, 0] = 1
-        mask.matrix[0, 0, 1:] = 1
-
         mask.matrix.flush()
 
     def do_colour_image(self, imagedata):
@@ -2036,18 +2030,134 @@ class Slice(metaclass=utils.Singleton):
         elif axis == 2:
             self.matrix[:] = self.matrix[:, :, ::-1]
 
+        # Flush the flipped image matrix to disk so it is consistent
+        # with any mask re-evaluation that follows.
+        if hasattr(self.matrix, "flush"):
+            self.matrix.flush()
+
+        # Also flip every image version (filtered images) so that mask
+        # threshold evaluation always uses the correctly flipped data.
+        proj = Project()
+        for i, (label, mat) in enumerate(proj.image_versions):
+            if mat is not self.matrix:
+                if axis == 0:
+                    mat[:] = mat[::-1]
+                elif axis == 1:
+                    mat[:] = mat[:, ::-1]
+                elif axis == 2:
+                    mat[:] = mat[:, :, ::-1]
+                if hasattr(mat, "flush"):
+                    mat.flush()
+
+        # Invalidate every mask so all slices are re-evaluated against the
+        # flipped image on next access.  Without this, do_threshold_to_all_slices
+        # (called by CreateSurfaceFromIndex) pre-marks coronal/sagittal sentinel
+        # flags as evaluated without actually computing them, so get_mask_slice
+        # returns stale data when the user scrolls those views.
+        # (fix for issue #1402, same approach as the #1387 reorientation fix)
+        for mask in proj.mask_dict.values():
+            mask.matrix[:] = 0
+            mask.matrix.flush()
+            if hasattr(mask, "temp_fd"):
+                try:
+                    import os as _os
+
+                    _os.fsync(mask.temp_fd)
+                except OSError:
+                    pass
+            mask.clear_history()
+
         for buffer_ in self.buffer_slices.values():
             buffer_.discard_buffer()
 
     def OnSwapVolumeAxes(self, axes):
         axis0, axis1 = axes
-        self.matrix = self.matrix.swapaxes(axis0, axis1)
+
+        # swapaxes() returns a view — the underlying memmap file is NOT updated.
+        # We must write the swapped data back in-place so that surface workers
+        # (which read the file directly) see the correct data.
+        swapped = np.array(self.matrix.swapaxes(axis0, axis1))  # contiguous copy
+        new_shape = swapped.shape
+
+        # Reopen the memmap with the new shape and write the swapped data
+        import tempfile as _tempfile
+
+        new_fd, new_filename = _tempfile.mkstemp()
+        new_mat = np.memmap(new_filename, dtype=self.matrix.dtype, mode="w+", shape=new_shape)
+        new_mat[:] = swapped
+        new_mat.flush()
+        import os as _os
+
+        _os.fsync(new_fd)
+        del swapped
+
+        # Close and remove the old matrix file, replace with new one
+        old_filename = self._matrix_filename
+        del self._matrix
+        try:
+            _os.remove(old_filename)
+        except OSError:
+            pass
+
+        self._matrix_filename = new_filename
+        self._matrix = new_mat
+
         if (axis0, axis1) == (2, 1):
             self.spacing = self.spacing[1], self.spacing[0], self.spacing[2]
         elif (axis0, axis1) == (2, 0):
             self.spacing = self.spacing[2], self.spacing[1], self.spacing[0]
         elif (axis0, axis1) == (1, 0):
             self.spacing = self.spacing[0], self.spacing[2], self.spacing[1]
+
+        # Also swap every image version (filtered images) so that mask
+        # threshold evaluation always uses the correctly swapped data.
+        proj = Project()
+        for i, (label, mat) in enumerate(proj.image_versions):
+            swapped_ver = np.array(mat.swapaxes(axis0, axis1))
+            ver_fd, ver_filename = _tempfile.mkstemp()
+            ver_mat = np.memmap(ver_filename, dtype=mat.dtype, mode="w+", shape=swapped_ver.shape)
+            ver_mat[:] = swapped_ver
+            ver_mat.flush()
+            _os.fsync(ver_fd)
+            del swapped_ver
+            # Clean up the old temp file for this image version
+            old_ver_filename = getattr(mat, "filename", None)
+            del mat
+            if old_ver_filename and old_ver_filename != old_filename:
+                try:
+                    _os.remove(old_ver_filename)
+                except OSError:
+                    pass
+            proj.image_versions[i] = (label, ver_mat)
+
+        # Update original_orientation so the volume viewer camera is
+        # positioned correctly after the swap.
+        _swap_orientation = {
+            (2, 1): {const.CORONAL: const.SAGITAL, const.SAGITAL: const.CORONAL},
+            (2, 0): {const.AXIAL: const.SAGITAL, const.SAGITAL: const.AXIAL},
+            (1, 0): {const.AXIAL: const.CORONAL, const.CORONAL: const.AXIAL},
+        }
+        mapping = _swap_orientation.get((axis0, axis1), {})
+        proj.original_orientation = mapping.get(
+            proj.original_orientation, proj.original_orientation
+        )
+
+        # Invalidate every mask so all slices are re-evaluated against the
+        # swapped image on next access.  After a swap the image shape changes
+        # so the mask matrix must be recreated with the new shape.
+        for mask in proj.mask_dict.values():
+            new_mask_shape = (new_shape[0] + 1, new_shape[1] + 1, new_shape[2] + 1)
+            if mask.matrix.shape != new_mask_shape:
+                mask._recreate_mask_matrix(new_mask_shape)
+            else:
+                mask.matrix[:] = 0
+                mask.matrix.flush()
+                if hasattr(mask, "temp_fd"):
+                    try:
+                        _os.fsync(mask.temp_fd)
+                    except OSError:
+                        pass
+            mask.clear_history()
 
         for buffer_ in self.buffer_slices.values():
             buffer_.discard_buffer()

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -140,6 +140,7 @@ class Volume:
         Publisher.subscribe(self.ResetRayCasting, "Reset Raycasting")
 
         Publisher.subscribe(self.OnFlipVolume, "Flip volume")
+        Publisher.subscribe(self.OnSwapVolumeAxes, "Swap volume axes")
 
     def ResetRayCasting(self):
         if self.exist:
@@ -269,6 +270,16 @@ class Volume:
         del self.image
         self.image = None
         self.to_reload = True
+
+    def OnSwapVolumeAxes(self, axes):
+        self.loaded_image = False
+        del self.image
+        self.image = None
+        self.to_reload = True
+        if self.exist:
+            self.exist = None
+            self.LoadVolume()
+            Publisher.sendMessage("Render volume viewer")
 
     def __load_preset_config(self):
         self.config = prj.Project().raycasting_preset

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -673,7 +673,13 @@ def Compress(
         if ".." in sanit_name or os.path.isabs(sanit_name):
             continue
 
+
         if not os.path.exists(name):
+            if sanit_name == "matrix.dat" or sanit_name.startswith("matrix"):
+                raise FileNotFoundError(
+                    f"Critical project file missing during save: {name} "
+                    f"(target: {sanit_name}). The project cannot be saved without this file."
+                )
             utils.debug(f"Warning: Skipping missing file during compression: {name}")
             continue
 


### PR DESCRIPTION
# Fix: Mask not updated after image Flip / Swap Axes

Fixes #1402 · Related to #1387

---

## Problem

After applying **Tools → Image → Flip** or **Tools → Image → Swap Axes**, the mask in the 2D slice views was not re-evaluated against the transformed image. Scrolling to a new slice showed the old pre-transform mask overlapping the correct one.

The same issue also occurred with **Swap Axes → Right-Left to Anterior-Posterior** on MRI data, which additionally crashed with an `IndexError` when creating a surface.

---

## Cause

The mask uses per-slice sentinel flags to cache threshold evaluations. After a flip or swap, these flags were never reset, so `get_mask_slice` kept returning stale cached data. Additionally, `do_threshold_to_all_slices` (called during surface creation) was pre-marking coronal and sagittal slices as evaluated without actually computing them, and the image versions used for threshold evaluation were never updated to reflect the transform.

---

## Fix

- **`slice_.py`** — `OnFlipVolume` / `OnSwapVolumeAxes`: zero the mask matrix, flush to disk, apply the same transform to all `image_versions`, resize the mask when the image shape changes (swap axes), and update `original_orientation`
- **`slice_.py`** — `do_threshold_to_all_slices`: removed premature coronal/sagittal flag marking
- **`mask.py`** — `OnFlipVolume` / `OnSwapVolumeAxes`: removed matrix manipulation (delegated to `slice_.py`)
- **`volume.py`** — added `OnSwapVolumeAxes` to reload the raycasting volume
- **`viewer_volume.py`** — added `OnSwapVolumeAxes` to reset the camera view angle

---

## Testing

Tested with:
- CT dataset: [0051.zip](https://github.com/invesalius/invesalius3/releases/download/v3.0/0051.zip) — Flip Top-Bottom
- MRI dataset: [mri3.zip](https://github.com/invesalius/invesalius3/releases/download/v3.0/mri3.zip) — Swap Axes Right-Left to Anterior-Posterior

| Check | Status |
|---|---|
| `pytest` (84 tests) | ✅ Passed |
| `ruff check --select I` | ✅ Passed |
| `ruff format --check` | ✅ Passed |
