### PR TITLE
Refactor : Polydata file loading into shared helper function

### DIFF
--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -70,6 +70,7 @@ import invesalius.data.imagedata_utils as iu
 import invesalius.data.polydata_utils as pu
 import invesalius.data.slice_ as sl
 import invesalius.data.surface_process as surface_process
+import invesalius.data.vtk_utils as vtk_utils
 import invesalius.project as prj
 import invesalius.session as ses
 import invesalius.utils as utl
@@ -612,36 +613,12 @@ class SurfaceManager:
         self.CreateSurfaceFromFile(filename)
 
     def CreateSurfaceFromFile(self, filename):
-        scalar = False
-        if filename.lower().endswith(".stl"):
-            reader = vtkSTLReader()
-        elif filename.lower().endswith(".ply"):
-            reader = vtkPLYReader()
-            scalar = True
-        elif filename.lower().endswith(".obj"):
-            reader = vtkOBJReader()
-        elif filename.lower().endswith(".vtp"):
-            reader = vtkXMLPolyDataReader()
-            scalar = True
-        else:
-            wx.MessageBox(_("File format not reconized by InVesalius"), _("Import surface error"))
+        polydata, scalar = vtk_utils.load_polydata_from_file(filename)
+        if polydata is None:
             return
 
-        if _has_win32api:
-            reader.SetFileName(win32api.GetShortPathName(filename).encode(const.FS_ENCODE))
-        else:
-            reader.SetFileName(filename.encode(const.FS_ENCODE))
-
-        reader.Update()
-        polydata = reader.GetOutput()
-
-        if polydata.GetNumberOfPoints() == 0:
-            wx.MessageBox(
-                _("InVesalius was not able to import this surface"), _("Import surface error")
-            )
-        else:
-            name = os.path.splitext(os.path.split(filename)[-1])[0]
-            self.CreateSurfaceFromPolydata(polydata, name=name, scalar=scalar)
+        name = os.path.splitext(os.path.split(filename)[-1])[0]
+        self.CreateSurfaceFromPolydata(polydata, name=name, scalar=scalar)
 
     def UpdateConvertToInvFlag(self, convert_to_inv=False):
         self.convert_to_inv = convert_to_inv

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -398,41 +398,58 @@ def numpy_to_vtkMatrix4x4(affine: "np.ndarray") -> vtkMatrix4x4:
     return affine_vtk
 
 
-# TODO: Use the SurfaceManager >> CreateSurfaceFromFile inside surface.py method instead of duplicating code
+def load_polydata_from_file(filename: str) -> Tuple[Any, bool]:
+    """
+    Load polydata from a surface file (STL, PLY, OBJ, VTP).
+
+    Args:
+        filename: Path to the surface file
+
+    Returns:
+        Tuple of (polydata, scalar_flag):
+        - polydata: vtkPolyData object or None if loading failed
+        - scalar_flag: True if file format supports scalar data (PLY, VTP)
+    """
+    scalar = False
+
+    if filename.lower().endswith(".stl"):
+        reader = vtkSTLReader()
+    elif filename.lower().endswith(".ply"):
+        reader = vtkPLYReader()
+        scalar = True
+    elif filename.lower().endswith(".obj"):
+        reader = vtkOBJReader()
+    elif filename.lower().endswith(".vtp"):
+        reader = vtkXMLPolyDataReader()
+        scalar = True
+    else:
+        wx.MessageBox(_("File format not reconized by InVesalius"), _("Import surface error"))
+        return None, False
+
+    if _has_win32api:
+        reader.SetFileName(win32api.GetShortPathName(filename).encode(const.FS_ENCODE))
+    else:
+        reader.SetFileName(filename.encode(const.FS_ENCODE))
+
+    reader.Update()
+    polydata = reader.GetOutput()
+
+    if polydata.GetNumberOfPoints() == 0:
+        wx.MessageBox(
+            _("InVesalius was not able to import this surface"), _("Import surface error")
+        )
+        return None, False
+
+    return polydata, scalar
+
+
 def CreateObjectPolyData(filename: str) -> Any:
     """
     Coil for navigation rendered in volume viewer.
     """
     filename = utils.decode(filename, const.FS_ENCODE)
-    if filename:
-        if filename.lower().endswith(".stl"):
-            reader = vtkSTLReader()
-        elif filename.lower().endswith(".ply"):
-            reader = vtkPLYReader()
-        elif filename.lower().endswith(".obj"):
-            reader = vtkOBJReader()
-        elif filename.lower().endswith(".vtp"):
-            reader = vtkXMLPolyDataReader()
-        else:
-            wx.MessageBox(_("File format not reconized by InVesalius"), _("Import surface error"))
-            return
-    else:
+    if not filename:
         filename = os.path.join(inv_paths.OBJ_DIR, "magstim_fig8_coil.stl")
-        reader = vtkSTLReader()
 
-    if _has_win32api:
-        obj_name = win32api.GetShortPathName(filename).encode(const.FS_ENCODE)
-    else:
-        obj_name = filename.encode(const.FS_ENCODE)
-
-    reader.SetFileName(obj_name)
-    reader.Update()
-    obj_polydata = reader.GetOutput()
-
-    if obj_polydata.GetNumberOfPoints() == 0:
-        wx.MessageBox(
-            _("InVesalius was not able to import this surface"), _("Import surface error")
-        )
-        obj_polydata = None
-
-    return obj_polydata
+    polydata, _ = load_polydata_from_file(filename)
+    return polydata


### PR DESCRIPTION
## Summary
This PR refactors duplicate polydata file loading logic by extracting it into a shared helper function.

## Changes
- Added `load_polydata_from_file()` in `vtk_utils.py`
- Refactored `CreateObjectPolyData()` to use the helper
- Refactored `CreateSurfaceFromFile()` to use the helper
- Removed duplicated STL/PLY/OBJ/VTP loading logic
- Resolved existing TODO related to duplicated surface loading code

## Benefits
- Reduces code duplication
- Improves maintainability and consistency
- Centralizes polydata file loading behavior
- Preserves existing functionality and backward compatibility

## Testing
- Syntax validation passed
- Import validation passed
- Verified helper integration in both code paths
- InVesalius starts successfully without errors