### PR TITLE
Fix volume clipping plane interactivity (#1409)

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3664,6 +3664,10 @@ class Viewer(wx.Panel):
 
     def SetWidgetInteractor(self, widget=None):
         widget.SetInteractor(self.interactor._Iren)
+        if hasattr(widget, "SetDefaultRenderer"):
+            widget.SetDefaultRenderer(self.ren)
+        if hasattr(widget, "SetCurrentRenderer"):
+            widget.SetCurrentRenderer(self.ren)
 
     def AppendActor(self, actor):
         self.ren.AddActor(actor)

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -183,7 +183,7 @@ class Viewer(wx.Panel):
         # Render the target guide in a separate renderer, so that it can be
         # rendered on top of the volume.
         self.target_guide_renderer = vtkRenderer()
-
+        self.target_guide_renderer.SetInteractive(0)
         self.interactor.GetRenderWindow().AddRenderer(self.target_guide_renderer)
 
         canvas_renderer = vtkRenderer()
@@ -2975,7 +2975,6 @@ class Viewer(wx.Panel):
         self.SetInteractorStyle(new_state)
 
     def ResetCamClippingRange(self):
-        self.ren.ResetCamera()
         self.ren.ResetCameraClippingRange()
 
     def SendActiveCamera(self):

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -690,6 +690,7 @@ class Volume:
 
         # Enable shading for SSAO compatibility (computes normals for volume raycasting)
         volume.GetProperty().ShadeOn()
+        volume.SetPickable(0)
 
         self.volume = volume
 
@@ -756,7 +757,7 @@ class CutPlane:
         Publisher.subscribe(self.Disable, "Disable Cut Plane")
 
     def Create(self):
-        picker_tolerance = 0.005
+        picker_tolerance = 0.025
         plane_color = (0, 0.8, 0)
 
         self.plane_widget = plane_widget = vtkImagePlaneWidget()
@@ -766,7 +767,7 @@ class CutPlane:
         plane_widget.RestrictPlaneToVolumeOff()
         picker = vtkCellPicker()
         picker.SetTolerance(picker_tolerance)
-        picker.PickFromListOn()
+        picker.PickFromListOff()
         plane_widget.SetPicker(picker)
 
         # plane_widget.SetResliceInterpolateToLinear()
@@ -803,6 +804,7 @@ class CutPlane:
         plane_actor.SetMapper(plane_mapper)
         plane_actor.GetProperty().BackfaceCullingOn()
         plane_actor.GetProperty().SetOpacity(0)
+        plane_actor.SetPickable(0)
         plane_widget.AddObserver("InteractionEvent", self.Update)
         Publisher.sendMessage("AppendActor", actor=self.plane_actor)
         Publisher.sendMessage("Set Widget Interactor", widget=self.plane_widget)
@@ -819,7 +821,9 @@ class CutPlane:
         self.normal = plane_widget.GetNormal()
 
         # Reset camera clipping range to make sure the widget is pickable immediately
+        Publisher.sendMessage("Render volume viewer")
         Publisher.sendMessage("Reset cam clipping range")
+        Publisher.sendMessage("Render volume viewer")
 
     def SetVolumeMapper(self, volume_mapper):
         self.volume_mapper = volume_mapper
@@ -841,6 +845,7 @@ class CutPlane:
         self.plane_widget.On()
         self.plane_actor.VisibilityOn()
         self.volume_mapper.AddClippingPlane(self.plane)
+        Publisher.sendMessage("Render volume viewer")
         Publisher.sendMessage("Reset cam clipping range")
         Publisher.sendMessage("Render volume viewer")
 

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -756,13 +756,16 @@ class CutPlane:
         Publisher.subscribe(self.Disable, "Disable Cut Plane")
 
     def Create(self):
+        picker_tolerance = 0.005
+        plane_color = (0, 0.8, 0)
+
         self.plane_widget = plane_widget = vtkImagePlaneWidget()
         plane_widget.SetInputData(self.img)
         plane_widget.SetPlaneOrientationToXAxes()
 
         plane_widget.RestrictPlaneToVolumeOff()
         picker = vtkCellPicker()
-        picker.SetTolerance(0.005)
+        picker.SetTolerance(picker_tolerance)
         picker.PickFromListOn()
         plane_widget.SetPicker(picker)
 
@@ -774,15 +777,15 @@ class CutPlane:
 
         # Set plane outline color to green
         plane_property = plane_widget.GetPlaneProperty()
-        plane_property.SetColor(0, 0.8, 0)
+        plane_property.SetColor(*plane_color)
 
         # Set selected plane outline color to green
         selected_plane_property = plane_widget.GetSelectedPlaneProperty()
-        selected_plane_property.SetColor(0, 0.8, 0)
+        selected_plane_property.SetColor(*plane_color)
 
         # SetColor margin to green
         margin_property = plane_widget.GetMarginProperty()
-        margin_property.SetColor(0, 0.8, 0)
+        margin_property.SetColor(*plane_color)
         # Disable cross
         cursor_property = plane_widget.GetCursorProperty()
         cursor_property.SetOpacity(0)

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -29,6 +29,7 @@ from vtkmodules.vtkImagingStatistics import vtkImageAccumulate
 from vtkmodules.vtkInteractionWidgets import vtkImagePlaneWidget
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
+    vtkCellPicker,
     vtkColorTransferFunction,
     vtkPolyDataMapper,
     vtkVolume,
@@ -758,16 +759,36 @@ class CutPlane:
         self.plane_widget = plane_widget = vtkImagePlaneWidget()
         plane_widget.SetInputData(self.img)
         plane_widget.SetPlaneOrientationToXAxes()
+
+        plane_widget.RestrictPlaneToVolumeOff()
+        picker = vtkCellPicker()
+        picker.SetTolerance(0.005)
+        picker.PickFromListOn()
+        plane_widget.SetPicker(picker)
+
         # plane_widget.SetResliceInterpolateToLinear()
-        plane_widget.TextureVisibilityOff()
+        plane_widget.TextureVisibilityOn()
+        plane_widget.GetTexturePlaneProperty().SetOpacity(0.02)
         # Set left mouse button to move and rotate plane
         plane_widget.SetLeftButtonAction(1)
+
+        # Set plane outline color to green
+        plane_property = plane_widget.GetPlaneProperty()
+        plane_property.SetColor(0, 0.8, 0)
+
+        # Set selected plane outline color to green
+        selected_plane_property = plane_widget.GetSelectedPlaneProperty()
+        selected_plane_property.SetColor(0, 0.8, 0)
+
         # SetColor margin to green
         margin_property = plane_widget.GetMarginProperty()
         margin_property.SetColor(0, 0.8, 0)
         # Disable cross
         cursor_property = plane_widget.GetCursorProperty()
         cursor_property.SetOpacity(0)
+
+        # Synchronize widget geometry and internal picker bounds immediately
+        plane_widget.UpdatePlacement()
         self.plane_source = plane_source = vtkPlaneSource()
         plane_source.SetOrigin(plane_widget.GetOrigin())
         plane_source.SetPoint1(plane_widget.GetPoint1())
@@ -794,6 +815,9 @@ class CutPlane:
         self.p2 = plane_widget.GetPoint2()
         self.normal = plane_widget.GetNormal()
 
+        # Reset camera clipping range to make sure the widget is pickable immediately
+        Publisher.sendMessage("Reset cam clipping range")
+
     def SetVolumeMapper(self, volume_mapper):
         self.volume_mapper = volume_mapper
         self.volume_mapper.AddClippingPlane(self.plane)
@@ -814,6 +838,7 @@ class CutPlane:
         self.plane_widget.On()
         self.plane_actor.VisibilityOn()
         self.volume_mapper.AddClippingPlane(self.plane)
+        Publisher.sendMessage("Reset cam clipping range")
         Publisher.sendMessage("Render volume viewer")
 
     def Disable(self):


### PR DESCRIPTION
### Description

### Fixes:  #1409 
where the clipping plane in the 3D volume rendering view was completely unresponsive to mouse clicks and drags until the user performed a camera interaction (like zooming). Prior to this fix, attempting to drag the clipping plane would erroneously fall through to `DefaultInteractorStyle`, causing the entire 3D volume to rotate instead of translating the plane.

### Root Cause
1. `vtkImagePlaneWidget` lacked an explicit renderer assignment, causing its internal bounds computation to fail on initialisation.
2. The default `vtkCellPicker` used by the widget was intercepting the `vtkVolume` actor instead of the clipping plane itself because they occupy overlapping space in the rendering frustum.
3. The widget was artificially locked to the bounding box of the volume, obstructing interaction near the edges.

### Changes 
* **Explicit Renderer Assignment:** Modified `SetWidgetInteractor` in `viewer_volume.py` to ensure the widget is explicitly assigned the default/current renderer (`self.ren`).
* **Dedicated Picker Configuration:** Initialised an explicit `vtkCellPicker` in `volume.py` with `PickFromListOn()` to restrict Raycasting strictly to the plane's internal actors (`TextureActor` and `MarginActor`).
* **Interaction Constraints Lifted:** Set `RestrictPlaneToVolumeOff()` to allow uninterrupted mouse dragging.
* **Immediate Synchronisation:** Enforced `plane_widget.UpdatePlacement()` and re-emitted `"Reset cam clipping range"` upon creation so the picker bounds and camera frustum sync immediately, eliminating the need for a manual "zoom" workaround.
* **Visual Styling:** Properly configured the plane interior and outline properties to render the standard green selection color.

