### PR TITLE
Revision efield color bar and updates

### DIFF
--- a/invesalius/data/coregistration.py
+++ b/invesalius/data/coregistration.py
@@ -344,6 +344,7 @@ class CoordinateCorregistrate(threading.Thread):
         target,
         icp,
         e_field_loaded,
+        navigation,
     ):
         threading.Thread.__init__(self, name="CoordCoregObject")
         self.ref_mode_id = ref_mode_id
@@ -356,6 +357,7 @@ class CoordinateCorregistrate(threading.Thread):
         self.object_at_target_queue = queues[2]
         self.efield_queue = queues[3]
         self.e_field_loaded = e_field_loaded
+        self.navigation = navigation
         self.event = event
         self.sle = sle
         self._loop_sleep = max(self.sle, 1.0 / 120.0)
@@ -474,7 +476,9 @@ class CoordinateCorregistrate(threading.Thread):
                 if can_push_tracts and not self.e_field_loaded:
                     self.coord_tracts_queue.put_nowait(m_img_flip)
                 if can_push_efield:
-                    self.efield_queue.put_nowait([m_img, coord])
+                    self.efield_queue.put_nowait(
+                        [m_img, coord, self.navigation.e_field_revision]
+                    )
             except queue.Full:
                 pass
 

--- a/invesalius/data/coregistration.py
+++ b/invesalius/data/coregistration.py
@@ -476,9 +476,7 @@ class CoordinateCorregistrate(threading.Thread):
                 if can_push_tracts and not self.e_field_loaded:
                     self.coord_tracts_queue.put_nowait(m_img_flip)
                 if can_push_efield:
-                    self.efield_queue.put_nowait(
-                        [m_img, coord, self.navigation.e_field_revision]
-                    )
+                    self.efield_queue.put_nowait([m_img, coord, self.navigation.e_field_revision])
             except queue.Full:
                 pass
 

--- a/invesalius/data/e_field.py
+++ b/invesalius/data/e_field.py
@@ -54,13 +54,14 @@ class Visualize_E_field_Thread(threading.Thread):
         self.sle = sle
         self.neuronavigation_api = neuronavigation_api
         self.ID_list = vtkIdList()
-        self.coord_old = []
         if isinstance(debug_efield_enorm, np.ndarray):
             self.enorm_debug = debug_efield_enorm
             self.debug = True
         else:
             self.debug = False
         self.plot_vectors = plot_vectors
+        self.coord_old = None
+        self.revision_old = None
 
     def run(self):
         while not self.event.is_set():
@@ -71,18 +72,28 @@ class Visualize_E_field_Thread(threading.Thread):
                     id_list = []
                     for h in range(self.ID_list.GetNumberOfIds()):
                         id_list.append(self.ID_list.GetId(h))
-                except queue.Full:
-                    self.e_field_IDs_queue.task_done()
+                except queue.Empty:
+                    continue
 
                 if not self.efield_queue.empty():
                     try:
-                        [m_img, coord] = self.efield_queue.get_nowait()
+                        efield_payload = self.efield_queue.get_nowait()
                         self.efield_queue.task_done()
-                    except queue.Full:
-                        self.efield_queue.task_done()
+                    except queue.Empty:
+                        continue
+
+                    if len(efield_payload) == 3:
+                        _m_img, coord, revision = efield_payload
+                    else:
+                        _m_img, coord = efield_payload
+                        revision = None
 
                     if self.ID_list.GetNumberOfIds() != 0:
-                        if np.all(self.coord_old != coord):
+                        if (
+                            self.coord_old is None
+                            or not np.array_equal(self.coord_old, coord)
+                            or self.revision_old != revision
+                        ):
                             [T_rot, cp] = Get_coil_position(coord)
                             if self.debug:
                                 enorm = self.enorm_debug
@@ -106,6 +117,7 @@ class Visualize_E_field_Thread(threading.Thread):
                             except queue.Full:
                                 pass
 
-                            self.coord_old = coord
+                            self.coord_old = np.array(coord)
+                            self.revision_old = revision
 
             time.sleep(self.sle)

--- a/invesalius/data/e_field.py
+++ b/invesalius/data/e_field.py
@@ -98,20 +98,15 @@ class Visualize_E_field_Thread(threading.Thread):
                             if self.debug:
                                 enorm = self.enorm_debug
                             else:
-                                if self.plot_vectors:
-                                    enorm = self.neuronavigation_api.update_efield_vectorROIMax(
-                                        position=cp,
-                                        orientation=coord[3:],
-                                        T_rot=T_rot,
-                                        id_list=id_list,
-                                    )
-                                else:
-                                    enorm = self.neuronavigation_api.update_efield(
-                                        position=cp, orientation=coord[3:], T_rot=T_rot
-                                    )
+                                enorm = self.neuronavigation_api.update_efield_vectorROIMax(
+                                    position=cp,
+                                    orientation=coord[3:],
+                                    T_rot=T_rot,
+                                    id_list=id_list,
+                                )
                             try:
                                 self.e_field_norms_queue.put_nowait(
-                                    [T_rot, cp, coord, enorm, id_list]
+                                    [T_rot, cp, coord, enorm, id_list, revision]
                                 )
 
                             except queue.Full:

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -526,6 +526,7 @@ class SurfaceManager:
         cortex = config_dict["path_meshes"] + config_dict["cortex"]
         bmeshes = config_dict["bmeshes"]
         coil = config_dict["coil"]
+        coil_set = config_dict.get("coil_set", False)
         targeting_file = config_dict["targeting csv file"]
         dIperdt_list = []
         dIperdt = config_dict["dIperdts"]
@@ -590,6 +591,7 @@ class SurfaceManager:
                 cortex_file=cortex_save_file,
                 meshes_file=bmeshes_list,
                 coil=coil,
+                coil_set=coil_set,
                 ci=ci_list,
                 co=co_list,
                 dIperdt_list=dIperdt_list,

--- a/invesalius/data/tractography.py
+++ b/invesalius/data/tractography.py
@@ -43,6 +43,17 @@ from invesalius.pubsub import pub as Publisher
 # np.set_printoptions(suppress=True)
 
 
+def prepare_seed_coordinates(seed_coordinates):
+    seed_coordinates = np.asarray(seed_coordinates, dtype=float)
+    if seed_coordinates.ndim != 2 or seed_coordinates.shape[1] != 3:
+        return None
+    if seed_coordinates.shape[0] == 0:
+        return None
+    if not np.all(np.isfinite(seed_coordinates)):
+        return None
+    return np.ascontiguousarray(seed_coordinates)
+
+
 def compute_directions(trk_n, alpha=255):
     """Compute direction of a single tract in each point and return as an RGBA color
 
@@ -263,7 +274,7 @@ class ComputeTractsThread(threading.Thread):
             img_shift,
         ) = self.inp
         # n_threads = n_tracts_total
-        n_threads = int(n_threads / 4)
+        n_threads = max(1, int(n_threads / 4))
         p_old = np.array([[0.0, 0.0, 0.0]])
         n_tracts = 0
 
@@ -307,7 +318,11 @@ class ComputeTractsThread(threading.Thread):
                 # trekker has internal multiprocessing approach done in C. Here the number of available threads is give,
                 # but in case a large number of tracts is requested, it will compute all in parallel automatically
                 # for a more fluent navigation, better to compute the maximum number the computer handles
-                trekker.seed_coordinates(np.repeat(seed_trk, n_threads, axis=0))
+                seed_coordinates = prepare_seed_coordinates(np.repeat(seed_trk, n_threads, axis=0))
+                if seed_coordinates is None:
+                    self.coord_tracts_queue.task_done()
+                    continue
+                trekker.seed_coordinates(seed_coordinates)
 
                 # run the trekker, this is the slowest line of code, be careful to just use once!
                 trk_list = trekker.run()
@@ -528,7 +543,11 @@ class ComputeTractsACTThread(threading.Thread):
                     # to reduce the overhead for when the coil is moving, we compute only half the number of tracts
                     # that should be computed when the coil is fixed in the same location
                     # required input is Nx3 array
-                    trekker.seed_coordinates(seed_trk_r_world_sampled[::2, :])
+                    seed_coordinates = prepare_seed_coordinates(seed_trk_r_world_sampled[::2, :])
+                    if seed_coordinates is None:
+                        self.coord_tracts_queue.task_done()
+                        continue
+                    trekker.seed_coordinates(seed_coordinates)
                     # run the trekker, this is the slowest line of code, be careful to just use once!
                     trk_list = trekker.run()
 
@@ -551,12 +570,17 @@ class ComputeTractsACTThread(threading.Thread):
                         # of tracts to reduce the overhead
                         bundle = vtkMultiBlockDataSet()
                         # required input is Nx3 array
-                        trekker.seed_coordinates(seed_trk_r_world_sampled[::2, :])
+                        seed_coordinates = prepare_seed_coordinates(seed_trk_r_world_sampled[::2, :])
                         n_tracts, n_branches = 0, 0
                     else:
                         # if the bundle exists compute all tracts requested
                         # required input is Nx3 array
-                        trekker.seed_coordinates(seed_trk_r_world_sampled)
+                        seed_coordinates = prepare_seed_coordinates(seed_trk_r_world_sampled)
+
+                    if seed_coordinates is None:
+                        self.coord_tracts_queue.task_done()
+                        continue
+                    trekker.seed_coordinates(seed_coordinates)
 
                     trk_list = trekker.run()
 

--- a/invesalius/data/tractography.py
+++ b/invesalius/data/tractography.py
@@ -570,7 +570,9 @@ class ComputeTractsACTThread(threading.Thread):
                         # of tracts to reduce the overhead
                         bundle = vtkMultiBlockDataSet()
                         # required input is Nx3 array
-                        seed_coordinates = prepare_seed_coordinates(seed_trk_r_world_sampled[::2, :])
+                        seed_coordinates = prepare_seed_coordinates(
+                            seed_trk_r_world_sampled[::2, :]
+                        )
                         n_tracts, n_branches = 0, 0
                     else:
                         # if the bundle exists compute all tracts requested

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2605,7 +2605,7 @@ class Viewer(wx.Panel):
                 wx.CallAfter(Publisher.sendMessage, "Show distance between Max and CoG Efield")
                 if self.positions_above_threshold is not None:
                     self.DetectClustersEfieldSpread(self.positions_above_threshold)
-            if (self.enableefieldabovethreshold and self.cell_id_indexes_above_threshold is not None):
+            if self.enableefieldabovethreshold and self.cell_id_indexes_above_threshold is not None:
                 self.SegmentEfieldMax(self.cell_id_indexes_above_threshold)
             self.ShowEfieldAtCortexTarget()
             if self.plot_no_connection:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2605,8 +2605,7 @@ class Viewer(wx.Panel):
                 wx.CallAfter(Publisher.sendMessage, "Show distance between Max and CoG Efield")
                 if self.positions_above_threshold is not None:
                     self.DetectClustersEfieldSpread(self.positions_above_threshold)
-            if (
-                self.enableefieldabovethreshold and self.cell_id_indexes_above_threshold is not None):
+            if (self.enableefieldabovethreshold and self.cell_id_indexes_above_threshold is not None):
                 self.SegmentEfieldMax(self.cell_id_indexes_above_threshold)
             self.ShowEfieldAtCortexTarget()
             if self.plot_no_connection:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1804,6 +1804,11 @@ class Viewer(wx.Panel):
         self.position_max_revision = None
         self.center_gravity_position = None
 
+    def RemoveEfieldVectorActor(self):
+        if self.vectorfield_actor is not None:
+            self.ren.RemoveActor(self.vectorfield_actor)
+            self.vectorfield_actor = None
+
     def MaxEfieldActor(self):
         if not self.HasEfieldVectorData():
             self.RemoveEfieldTargetingActors()
@@ -1962,8 +1967,7 @@ class Viewer(wx.Panel):
 
     def EfieldVectors(self):
         vtk_colors = vtkNamedColors()
-        if self.vectorfield_actor is not None:
-            self.ren.RemoveActor(self.vectorfield_actor)
+        self.RemoveEfieldVectorActor()
         points = vtkPoints()
         vectors = vtkDoubleArray()
         vectors.SetNumberOfComponents(3)
@@ -2527,9 +2531,7 @@ class Viewer(wx.Panel):
         # self.diperdt = None
 
         self.RemoveEfieldTargetingActors()
-
-        if self.vectorfield_actor is not None:
-            self.ren.RemoveActor(self.vectorfield_actor)
+        self.RemoveEfieldVectorActor()
 
         if self.efield_scalar_bar is not None:
             self.ren.RemoveActor(self.efield_scalar_bar)
@@ -2596,8 +2598,7 @@ class Viewer(wx.Panel):
                 self.colors_init.InsertTuple(index_id, color)
             self.efield_mesh.GetPointData().SetScalars(self.colors_init)
             wx.CallAfter(Publisher.sendMessage, "Recolor efield actor")
-            if self.vectorfield_actor is not None:
-                self.ren.RemoveActor(self.vectorfield_actor)
+            self.RemoveEfieldVectorActor()
             wx.CallAfter(Publisher.sendMessage, "Show max Efield actor")
             wx.CallAfter(Publisher.sendMessage, "Show CoG Efield actor")
             if self.efield_tools:
@@ -2994,6 +2995,7 @@ class Viewer(wx.Panel):
 
         if self.nav_status:
             self.pTarget = self.CenterOfMass()
+            self.RemoveEfieldVectorActor()
 
         self.camera_show_object = None
         self._update_fps_visibility()

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1,4 +1,4 @@
-90  # --------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
 # Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
 # Homepage:     http://www.softwarepublico.gov.br
@@ -2174,6 +2174,15 @@ class Viewer(wx.Panel):
                     lut.SetTableValue(i, *(np.array(highlight_rgb) / 255.0), 1.0)
         return lut
 
+    def UpdateEfieldScalarBar(self):
+        if self.efield_scalar_bar is None or self.efield_lut is None:
+            return
+
+        self.efield_scalar_bar.SetLookupTable(self.efield_lut)
+        self.efield_scalar_bar.Modified()
+        if not self.ren.HasViewProp(self.efield_scalar_bar):
+            self.ren.AddActor2D(self.efield_scalar_bar)
+
     def GetEfieldMaxMin(self, e_field_norms):
         self.e_field_norms = e_field_norms
         max = np.amax(self.e_field_norms)
@@ -2255,8 +2264,7 @@ class Viewer(wx.Panel):
         self.ren.AddViewProp(self.edge_fill_actor)
         self.ren.AddViewProp(self.edge_actor)
 
-        self.efield_scalar_bar.SetLookupTable(self.efield_lut)
-        self.ren.AddActor2D(self.efield_scalar_bar)
+        self.UpdateEfieldScalarBar()
 
     def RemoveEfieldEdges(self):
         if self.edge_actor is not None:
@@ -2567,6 +2575,7 @@ class Viewer(wx.Panel):
             self.efield_lut = self.CreateLUTTableForEfield(
                 0, self.efield_max, highlight_threshold=self.enableefieldabovethreshold
             )
+            self.UpdateEfieldScalarBar()
             if not self.show_efield_edges or self.tracts_status or self.actor_tracts is not None:
                 self.RemoveEfieldEdges()
             else:

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -142,6 +142,8 @@ class Viewer(wx.Panel):
 
         self.static_markers_efield = []
         self.plot_vector = None
+        self.efield_data_revision = None
+        self.position_max_revision = None
         self.style = None
 
         interactor = wxVTKRenderWindowInteractor(self, -1, size=self.GetSize())
@@ -1799,6 +1801,7 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.ball_GoGEfieldVector)
             self.ball_GoGEfieldVector = None
         self.position_max = None
+        self.position_max_revision = None
         self.center_gravity_position = None
 
     def MaxEfieldActor(self):
@@ -1811,6 +1814,7 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.max_efield_vector)
             self.ren.RemoveActor(self.ball_max_vector)
         self.position_max = self.efield_mesh.GetPoint(self.Idmax)
+        self.position_max_revision = self.efield_data_revision
         orientation = [self.max_efield_array[0], self.max_efield_array[1], self.max_efield_array[2]]
         self.max_efield_vector = self.DrawVectors(
             self.position_max, orientation, vtk_colors.GetColor3d("Red")
@@ -1831,9 +1835,6 @@ class Viewer(wx.Panel):
             self.ren.RemoveActor(self.GoGEfieldVector)
             self.ren.RemoveActor(self.ball_GoGEfieldVector)
         orientation = [self.max_efield_array[0], self.max_efield_array[1], self.max_efield_array[2]]
-        [self.cell_id_indexes_above_threshold, self.positions_above_threshold] = (
-            self.GetIndexesAboveThreshold(self.efield_threshold)
-        )
         if not self.cell_id_indexes_above_threshold:
             return
 
@@ -2185,10 +2186,10 @@ class Viewer(wx.Panel):
 
     def GetEfieldMaxMin(self, e_field_norms):
         self.e_field_norms = e_field_norms
-        max = np.amax(self.e_field_norms)
-        min = np.amin(self.e_field_norms)
-        self.efield_min = min
-        self.efield_max = max
+        efield_max = np.amax(self.e_field_norms)
+        efield_min = np.amin(self.e_field_norms)
+        self.efield_min = efield_min
+        self.efield_max = efield_max
         # self.Idmax = np.array(self.e_field_norms).argmax()
         wx.CallAfter(Publisher.sendMessage, "Update efield vis")
 
@@ -2575,6 +2576,9 @@ class Viewer(wx.Panel):
             self.efield_lut = self.CreateLUTTableForEfield(
                 0, self.efield_max, highlight_threshold=self.enableefieldabovethreshold
             )
+            [self.cell_id_indexes_above_threshold, self.positions_above_threshold] = (
+                self.GetIndexesAboveThreshold(self.efield_threshold)
+            )
             self.UpdateEfieldScalarBar()
             if not self.show_efield_edges or self.tracts_status or self.actor_tracts is not None:
                 self.RemoveEfieldEdges()
@@ -2585,10 +2589,7 @@ class Viewer(wx.Panel):
             for h in range(len(self.Id_list)):
                 dcolor = 3 * [0.0]
                 index_id = self.Id_list[h]
-                if self.plot_vector:
-                    self.efield_lut.GetColor(self.e_field_norms[h], dcolor)
-                else:
-                    self.efield_lut.GetColor(self.e_field_norms[index_id], dcolor)
+                self.efield_lut.GetColor(self.e_field_norms[h], dcolor)
                 color = 3 * [0.0]
                 for j in range(0, 3):
                     color[j] = int(255.0 * dcolor[j])
@@ -2597,23 +2598,22 @@ class Viewer(wx.Panel):
             wx.CallAfter(Publisher.sendMessage, "Recolor efield actor")
             if self.vectorfield_actor is not None:
                 self.ren.RemoveActor(self.vectorfield_actor)
-            if self.plot_vector:
-                wx.CallAfter(Publisher.sendMessage, "Show max Efield actor")
-                wx.CallAfter(Publisher.sendMessage, "Show CoG Efield actor")
-                if self.efield_tools:
-                    wx.CallAfter(Publisher.sendMessage, "Show distance between Max and CoG Efield")
-                    if self.positions_above_threshold is not None:
-                        self.DetectClustersEfieldSpread(self.positions_above_threshold)
-                if (
-                    self.enableefieldabovethreshold
-                    and self.cell_id_indexes_above_threshold is not None
-                ):
-                    self.SegmentEfieldMax(self.cell_id_indexes_above_threshold)
-                self.ShowEfieldAtCortexTarget()
-                if self.plot_no_connection:
-                    wx.CallAfter(Publisher.sendMessage, "Show Efield vectors")
-                    self.plot_vector = False
-                    self.plot_no_connection = False
+            wx.CallAfter(Publisher.sendMessage, "Show max Efield actor")
+            wx.CallAfter(Publisher.sendMessage, "Show CoG Efield actor")
+            if self.efield_tools:
+                wx.CallAfter(Publisher.sendMessage, "Show distance between Max and CoG Efield")
+                if self.positions_above_threshold is not None:
+                    self.DetectClustersEfieldSpread(self.positions_above_threshold)
+            if (
+                self.enableefieldabovethreshold
+                and self.cell_id_indexes_above_threshold is not None
+            ):
+                self.SegmentEfieldMax(self.cell_id_indexes_above_threshold)
+            self.ShowEfieldAtCortexTarget()
+            if self.plot_no_connection:
+                wx.CallAfter(Publisher.sendMessage, "Show Efield vectors")
+                self.plot_vector = False
+                self.plot_no_connection = False
         else:
             wx.CallAfter(Publisher.sendMessage, "Recolor again")
 
@@ -2634,14 +2634,24 @@ class Viewer(wx.Panel):
         except queue.Full:
             pass
 
-    def UpdateTractSeedBasedEfield(self, coord_tracts_queue, fallback_m_img=None):
-        if getattr(self, "position_max", None) is None:
+    def UpdateTractSeedBasedEfield(
+        self, coord_tracts_queue, fallback_m_img=None, current_revision=None
+    ):
+        if (
+            getattr(self, "position_max", None) is None
+            or self.position_max_revision != current_revision
+        ):
             if fallback_m_img is not None:
                 try:
+                    m_img_flip = fallback_m_img.copy()
+                    m_img_flip[1, -1] = -m_img_flip[1, -1]
                     coord_tracts_queue.clear()
-                    coord_tracts_queue.put_nowait(fallback_m_img)
+                    coord_tracts_queue.put_nowait(m_img_flip)
                 except queue.Full:
                     pass
+            return
+
+        if not np.all(np.isfinite(self.position_max)):
             return
 
         orientation = [0, 0, 0]
@@ -2681,105 +2691,121 @@ class Viewer(wx.Panel):
         T_rot = T_rot.tolist()  # to list
         Publisher.sendMessage("Send coil position and rotation", T_rot=T_rot, cp=cp, m_img=m_img)
 
-    def GetEnorm(self, enorm_data, plot_vector):
+    def GetEnorm(self, enorm_data, plot_vector, current_revision=None):
+        result_revision = enorm_data[5] if len(enorm_data) > 5 else current_revision
+        if current_revision is not None and result_revision != current_revision:
+            self.RemoveEfieldTargetingActors()
+            return
+
+        if enorm_data[3] is None:
+            self.RemoveEfieldTargetingActors()
+            return
+
         self.e_field_col1 = []
         self.e_field_col2 = []
         self.e_field_col3 = []
         session = ses.Session()
         self.plot_vector = plot_vector
+        self.efield_data_revision = result_revision
         self.coil_position_Trot = enorm_data[0]
         self.coil_position = enorm_data[1]
         self.efield_coords = enorm_data[2]
         self.Id_list = enorm_data[4]
-        if self.plot_vector:
-            if session.GetConfig("debug_efield"):
-                self.e_field_norms = enorm_data[3][self.Id_list, 0]
-                self.e_field_col1 = enorm_data[3][self.Id_list, 1]
-                self.e_field_col2 = enorm_data[3][self.Id_list, 2]  # LUKATODO: is this a typo?
-                self.e_field_col3 = enorm_data[3][self.Id_list, 3]
-                self.Idmax = np.array(self.Id_list[np.array(self.e_field_norms).argmax()])
-                max = np.array(self.e_field_norms).argmax()
-                self.max_efield_array = [
-                    self.e_field_col1[max],
-                    self.e_field_col2[max],
-                    self.e_field_col3[max],
-                ]
-                self.e_field_norms_to_save = enorm_data[3][:, 0]
-                self.e_field_col1_to_save = enorm_data[3][:, 1]
-                self.e_field_col2_to_save = enorm_data[3][:, 2]
-                self.e_field_col3_to_save = enorm_data[3][:, 3]
-            else:
-                self.e_field_norms_to_save = enorm_data[3].enorm
-                self.e_field_norms = enorm_data[3].enorm
-                self.e_field_norms = [self.e_field_norms[i] for i in self.Id_list]
-                self.e_field_col1 = enorm_data[3].column1
-                self.e_field_col2 = enorm_data[3].column2
-                self.e_field_col3 = enorm_data[3].column3
-                self.e_field_col1_to_save = enorm_data[3].column1
-                self.e_field_col2_to_save = enorm_data[3].column2
-                self.e_field_col3_to_save = enorm_data[3].column3
-                if len(self.e_field_col1) > 1:
-                    K = len(self.e_field_norms_to_save)
-                    col1 = np.asarray(self.e_field_col1, dtype=float)
-                    col2 = np.asarray(self.e_field_col2, dtype=float)
-                    col3 = np.asarray(self.e_field_col3, dtype=float)
-                    N = col1.size // K
-                    if N > 1:
-                        self.e_field_col1 = col1.reshape(N, -1).sum(axis=0)
-                        self.e_field_col2 = col2.reshape(N, -1).sum(axis=0)
-                        self.e_field_col3 = col3.reshape(N, -1).sum(axis=0)
-
-                    self.e_field_col1 = [self.e_field_col1[i] for i in self.Id_list]
-                    self.e_field_col2 = [self.e_field_col2[i] for i in self.Id_list]
-                    self.e_field_col3 = [self.e_field_col3[i] for i in self.Id_list]
-
-                self.max_efield_array = enorm_data[3].mvector
-                self.Idmax = enorm_data[3].maxindex  # self.Id_list[enorm_data[3].maxindex]
-                if self.save_automatically and self.plot_no_connection:
-                    import time
-
-                    import invesalius.gui.dialogs as dlg
-                    import invesalius.project as prj
-
-                    proj = prj.Project()
-                    timestamp = time.localtime(time.time())
-                    stamp_date = (
-                        f"{timestamp.tm_year:0>4d}{timestamp.tm_mon:0>2d}{timestamp.tm_mday:0>2d}"
-                    )
-                    stamp_time = (
-                        f"{timestamp.tm_hour:0>2d}{timestamp.tm_min:0>2d}{timestamp.tm_sec:0>2d}"
-                    )
-                    sep = "-"
-
-                    if self.path_meshes is None:
-                        import os
-
-                        current_folder_path = os.getcwd()
-                    else:
-                        current_folder_path = self.path_meshes
-
-                    parts = [current_folder_path, "/", stamp_date, stamp_time, proj.name, "Efield"]
-                    default_filename = sep.join(parts) + ".csv"
-
-                    filename = dlg.ShowLoadSaveDialog(
-                        message=_("Save markers as..."),
-                        wildcard="(*.csv)|*.csv",
-                        style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-                        default_filename=default_filename,
-                    )
-
-                    if not filename:
-                        return
-
-                    Publisher.sendMessage(
-                        "Save Efield data",
-                        filename=filename,
-                        plot_efield_vectors=self.plot_efield_vectors,
-                        marker_id=self.list_index_efield_vectors,
-                    )
+        if session.GetConfig("debug_efield"):
+            self.e_field_norms = enorm_data[3][self.Id_list, 0]
+            self.e_field_col1 = enorm_data[3][self.Id_list, 1]
+            self.e_field_col2 = enorm_data[3][self.Id_list, 2]  # LUKATODO: is this a typo?
+            self.e_field_col3 = enorm_data[3][self.Id_list, 3]
+            self.Idmax = np.array(self.Id_list[np.array(self.e_field_norms).argmax()])
+            max_idx = np.array(self.e_field_norms).argmax()
+            self.max_efield_array = [
+                self.e_field_col1[max_idx],
+                self.e_field_col2[max_idx],
+                self.e_field_col3[max_idx],
+            ]
+            self.e_field_norms_to_save = enorm_data[3][:, 0]
+            self.e_field_col1_to_save = enorm_data[3][:, 1]
+            self.e_field_col2_to_save = enorm_data[3][:, 2]
+            self.e_field_col3_to_save = enorm_data[3][:, 3]
         else:
-            self.e_field_norms = enorm_data[3]
-            self.Idmax = np.array(self.e_field_norms).argmax()
+            if not hasattr(enorm_data[3], "enorm") or not hasattr(enorm_data[3], "mvector"):
+                self.RemoveEfieldTargetingActors()
+                return
+
+            self.e_field_norms_to_save = enorm_data[3].enorm
+            if len(self.e_field_norms_to_save) == 0:
+                self.RemoveEfieldTargetingActors()
+                return
+            if self.Id_list and max(self.Id_list) >= len(self.e_field_norms_to_save):
+                self.RemoveEfieldTargetingActors()
+                return
+
+            self.e_field_norms = [self.e_field_norms_to_save[i] for i in self.Id_list]
+            self.e_field_col1 = enorm_data[3].column1
+            self.e_field_col2 = enorm_data[3].column2
+            self.e_field_col3 = enorm_data[3].column3
+            self.e_field_col1_to_save = enorm_data[3].column1
+            self.e_field_col2_to_save = enorm_data[3].column2
+            self.e_field_col3_to_save = enorm_data[3].column3
+            if len(self.e_field_col1) > 1:
+                K = len(self.e_field_norms_to_save)
+                col1 = np.asarray(self.e_field_col1, dtype=float)
+                col2 = np.asarray(self.e_field_col2, dtype=float)
+                col3 = np.asarray(self.e_field_col3, dtype=float)
+                N = col1.size // K
+                if N > 1:
+                    self.e_field_col1 = col1.reshape(N, -1).sum(axis=0)
+                    self.e_field_col2 = col2.reshape(N, -1).sum(axis=0)
+                    self.e_field_col3 = col3.reshape(N, -1).sum(axis=0)
+
+                self.e_field_col1 = [self.e_field_col1[i] for i in self.Id_list]
+                self.e_field_col2 = [self.e_field_col2[i] for i in self.Id_list]
+                self.e_field_col3 = [self.e_field_col3[i] for i in self.Id_list]
+
+            self.max_efield_array = enorm_data[3].mvector
+            self.Idmax = enorm_data[3].maxindex
+            if self.save_automatically and self.plot_no_connection:
+                import time
+
+                import invesalius.gui.dialogs as dlg
+                import invesalius.project as prj
+
+                proj = prj.Project()
+                timestamp = time.localtime(time.time())
+                stamp_date = (
+                    f"{timestamp.tm_year:0>4d}{timestamp.tm_mon:0>2d}{timestamp.tm_mday:0>2d}"
+                )
+                stamp_time = (
+                    f"{timestamp.tm_hour:0>2d}{timestamp.tm_min:0>2d}{timestamp.tm_sec:0>2d}"
+                )
+                sep = "-"
+
+                if self.path_meshes is None:
+                    import os
+
+                    current_folder_path = os.getcwd()
+                else:
+                    current_folder_path = self.path_meshes
+
+                parts = [current_folder_path, "/", stamp_date, stamp_time, proj.name, "Efield"]
+                default_filename = sep.join(parts) + ".csv"
+
+                filename = dlg.ShowLoadSaveDialog(
+                    message=_("Save markers as..."),
+                    wildcard="(*.csv)|*.csv",
+                    style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                    default_filename=default_filename,
+                )
+
+                if not filename:
+                    return
+
+                Publisher.sendMessage(
+                    "Save Efield data",
+                    filename=filename,
+                    plot_efield_vectors=self.plot_efield_vectors,
+                    marker_id=self.list_index_efield_vectors,
+                )
         self.GetEfieldMaxMin(self.e_field_norms)
 
     def SaveEfieldData(self, filename, plot_efield_vectors, marker_id):

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -2606,9 +2606,7 @@ class Viewer(wx.Panel):
                 if self.positions_above_threshold is not None:
                     self.DetectClustersEfieldSpread(self.positions_above_threshold)
             if (
-                self.enableefieldabovethreshold
-                and self.cell_id_indexes_above_threshold is not None
-            ):
+                self.enableefieldabovethreshold and self.cell_id_indexes_above_threshold is not None):
                 self.SegmentEfieldMax(self.cell_id_indexes_above_threshold)
             self.ShowEfieldAtCortexTarget()
             if self.plot_no_connection:

--- a/invesalius/gui/task_efield.py
+++ b/invesalius/gui/task_efield.py
@@ -485,6 +485,7 @@ class InnerTaskPanel(wx.Panel):
         self.navigation.neuronavigation_api.efield_coil(
             coil_model_path=coil_model_path, coil_set=coil_set
         )
+        self.navigation.MarkEfieldParametersChanged()
         self.coil = coil_model_path
         self.Send_meshes_coil_paths_to_report()
 
@@ -624,6 +625,7 @@ class InnerTaskPanel(wx.Panel):
         self.navigation.neuronavigation_api.set_dIperdt(
             dIperdt=self.input_coils,
         )
+        self.navigation.MarkEfieldParametersChanged()
         self.Send_dI_per_dt_to_report(self.input_coils, self.ci, self.co)
 
     def OnEnterMtmsCoords(self, evt):
@@ -647,6 +649,7 @@ class InnerTaskPanel(wx.Panel):
         self.navigation.neuronavigation_api.set_dIperdt(
             dIperdt=self.input_coils,
         )
+        self.navigation.MarkEfieldParametersChanged()
         self.Send_dI_per_dt_to_report(self.input_coils, self.ci, self.co)
 
     def OnEfieldsForTargeting(self, evt, ctrl):
@@ -654,6 +657,7 @@ class InnerTaskPanel(wx.Panel):
             self.navigation.neuronavigation_api.set_dIperdt(
                 dIperdt=[1, 1, 1, 1, 1],
             )
+            self.navigation.MarkEfieldParametersChanged()
             self.Send_dI_per_dt_to_report([1, 1, 1, 1, 1], self.ci, self.co)
 
     def GetIds(self, dIs):

--- a/invesalius/gui/task_efield.py
+++ b/invesalius/gui/task_efield.py
@@ -17,6 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
+import os
 import time
 from functools import partial
 
@@ -42,6 +43,8 @@ try:
     has_mTMS = True
 except Exception:
     has_mTMS = False
+
+MTMS_DIDT_COUNT = 5
 
 import wx
 import wx.lib.masked.numctrl
@@ -93,6 +96,7 @@ class InnerTaskPanel(wx.Panel):
         self.meshes_file = None
         self.multilocus_coil = None
         self.coil = None
+        self.coil_set = False
         self.ci = None
         self.co = None
         self.sleep_nav = const.SLEEP_NAVIGATION
@@ -387,11 +391,13 @@ class InnerTaskPanel(wx.Panel):
             self.Init_efield()
 
     def Init_efield(self):
+        coil_set = self.coil_set or self.IsMultilocusCoilset(self.coil)
+        self.coil_set = coil_set
         self.navigation.neuronavigation_api.initialize_efield(
             cortex_model_path=self.cortex_file,
             mesh_models_paths=self.meshes_file,
             coil_model_path=self.coil,
-            coil_set=False,
+            coil_set=coil_set,
             conductivities_inside=self.ci,
             conductivities_outside=self.co,
             dI_per_dt=self.dIperdt_list,
@@ -473,13 +479,31 @@ class InnerTaskPanel(wx.Panel):
     def OnComboCoil(self, evt):
         # coil_name = evt.GetString()
         coil_index = evt.GetSelection()
-        if coil_index == 6:
-            coil_set = True
-        else:
-            coil_set = False
+        coil_set = coil_index == len(self.multilocus_coil) - 1
         self.OnChangeCoil(self.multilocus_coil[coil_index], coil_set)
         # self.e_field_mesh = self.proj.surface_dict[self.surface_index].polydata
         # Publisher.sendMessage('Get Actor', surface_index = self.surface_index)
+
+    def IsMultilocusCoilset(self, coil_model_path):
+        if not coil_model_path or not self.multilocus_coil:
+            return False
+        coil_model_path = os.path.normpath(coil_model_path)
+        coilset_path = os.path.normpath(self.multilocus_coil[-1])
+        return coil_model_path == coilset_path
+
+    def IsMtmsCoilSelected(self):
+        return self.coil_set or self.IsMultilocusCoilset(self.coil)
+
+    def SelectMultilocusCoilset(self):
+        if not self.multilocus_coil:
+            return False
+        self.OnChangeCoil(self.multilocus_coil[-1], True)
+        return True
+
+    def GetUnitdIPerdt(self):
+        if self.IsMtmsCoilSelected():
+            return [1] * MTMS_DIDT_COUNT
+        return [1]
 
     def OnChangeCoil(self, coil_model_path, coil_set):
         self.navigation.neuronavigation_api.efield_coil(
@@ -487,6 +511,7 @@ class InnerTaskPanel(wx.Panel):
         )
         self.navigation.MarkEfieldParametersChanged()
         self.coil = coil_model_path
+        self.coil_set = coil_set
         self.Send_meshes_coil_paths_to_report()
 
     def UpdateNavigationStatus(self, nav_status, vis_status):
@@ -515,13 +540,16 @@ class InnerTaskPanel(wx.Panel):
         self.surface_index = surface_index_cortex
         Publisher.sendMessage("Get Actor", surface_index=self.surface_index)
 
-    def OnGetEfieldPaths(self, path_meshes, cortex_file, meshes_file, coil, ci, co, dIperdt_list):
+    def OnGetEfieldPaths(
+        self, path_meshes, cortex_file, meshes_file, coil, ci, co, dIperdt_list, coil_set=False
+    ):
         self.path_meshes = path_meshes
         self.cortex_file = cortex_file
         self.meshes_file = meshes_file
         self.ci = ci
         self.co = co
         self.coil = coil
+        self.coil_set = coil_set
         self.dIperdt_list = dIperdt_list
 
     def OnGetMultilocusCoils(self, multilocus_coil_list):
@@ -634,7 +662,12 @@ class InnerTaskPanel(wx.Panel):
         Publisher.sendMessage("Send mtms coords", mtms_coord=input_coord)
 
     def SenddI(self, dIs):
-        self.OnChangeCoil(self.multilocus_coil[6], True)
+        if not self.IsMtmsCoilSelected() and not self.SelectMultilocusCoilset():
+            return
+        dIs = list(dIs)
+        if len(dIs) != MTMS_DIDT_COUNT:
+            print(f"Expected {MTMS_DIDT_COUNT} mTMS dI values, got {len(dIs)}")
+            return
         input_dt = 1 / (float(self.input_dt.GetValue()) * 1e-6)
         # dIs[1] = -dIs[1]
         # dIs[2] = -dIs[2]
@@ -654,11 +687,12 @@ class InnerTaskPanel(wx.Panel):
 
     def OnEfieldsForTargeting(self, evt, ctrl):
         if ctrl.GetValue():
+            dIperdt = self.GetUnitdIPerdt()
             self.navigation.neuronavigation_api.set_dIperdt(
-                dIperdt=[1, 1, 1, 1, 1],
+                dIperdt=dIperdt,
             )
             self.navigation.MarkEfieldParametersChanged()
-            self.Send_dI_per_dt_to_report([1, 1, 1, 1, 1], self.ci, self.co)
+            self.Send_dI_per_dt_to_report(dIperdt, self.ci, self.co)
 
     def GetIds(self, dIs):
         self.SenddI(dIs)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3831,8 +3831,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
 
         self.markers.SetPointOfInterest(marker_id)
         Publisher.sendMessage(
-            "Send efield target position on brain",
-            marker_id=marker_id,
+            "Set as Efield target at cortex",
             position=position,
             orientation=orientation,
         )

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -362,6 +362,7 @@ class Navigation(metaclass=Singleton):
         self.e_field_loaded = False
         self.plot_efield_vectors = False
         self.debug_efield_enorm = None
+        self.e_field_revision = 0
 
         # Tractography parameters
         self.trk_inp = None
@@ -672,6 +673,7 @@ class Navigation(metaclass=Singleton):
                     self.target,
                     icp,
                     self.e_field_loaded,
+                    self,
                 )
             )
 
@@ -796,3 +798,6 @@ class Navigation(metaclass=Singleton):
             self.plot_efield_vectors,
         ]
         Publisher.sendMessage("Navigation status", nav_status=False, vis_status=vis_components)
+
+    def MarkEfieldParametersChanged(self):
+        self.e_field_revision += 1

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -218,6 +218,7 @@ class UpdateNavigationScene(threading.Thread):
                                 "Get enorm",
                                 enorm_data=enorm_data,
                                 plot_vector=self.plot_efield_vectors,
+                                current_revision=self.navigation.e_field_revision,
                             )
 
                 if probe_visible:
@@ -264,6 +265,7 @@ class UpdateNavigationScene(threading.Thread):
                             "Update tract seed based efield",
                             coord_tracts_queue=self.navigation.coord_tracts_queue,
                             fallback_m_img=m_imgs[main_coil],
+                            current_revision=self.navigation.e_field_revision,
                         )
                     bundle, affine_vtk, coord_offset, coord_offset_w = (
                         self.tracts_queue.get_nowait()

--- a/invesalius/net/neuronavigation_api.py
+++ b/invesalius/net/neuronavigation_api.py
@@ -282,15 +282,6 @@ class NeuronavigationApi(metaclass=Singleton):
             )
         return None
 
-    def update_efield_vector(self, position, orientation, T_rot):
-        if self.connection is not None:
-            return self.connection.update_efield_vector(
-                position=position,
-                orientation=orientation,
-                T_rot=T_rot,
-            )
-        return None
-
     def update_efield_vectorROI(self, position, orientation, T_rot, id_list):
         if self.connection is not None:
             return self.connection.update_efield_vectorROI(


### PR DESCRIPTION
- Cleaned unused E-field vector service/code.
- Added E-field revision tracking for coil/`dIperdt` changes.
- Updated E-field color bar when parameters change.
- Guarded tractography seeds during E-field updates to avoid stale/invalid max points.
- Fixed threshold/contour behavior and optional E-field edges.
- Removed stale E-field vector actors when navigation starts.