### PR TITLE
Refactor 3D Mask Editor to decouple UI and state management

### DIFF
--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -1,0 +1,221 @@
+import numpy as np
+import numpy.typing as npt
+import wx
+from skimage.draw import polygon2mask
+
+import invesalius.constants as const
+import invesalius.data.slice_ as slc
+import invesalius.session as ses
+from invesalius.data.polygon_select import PolygonSelectCanvas
+from invesalius.pubsub import pub as Publisher
+from invesalius.utils import vtkarray_to_numpy
+from invesalius_rs import mask_cut
+from vtkmodules.vtkRenderingCore import vtkCoordinate
+
+
+class Mask3DEditorState:
+    """State manager for the 3D Mask Editor.
+    
+    This class handles the core logic of managing mask 3D edits, such as storing
+    polygons, determining depth/edit mode, and cutting the 3D volume.
+    It decouples the heavy data operations from the VTK UI loop.
+    """
+
+    def __init__(self, viewer):
+        self.viewer = viewer
+        self.mask_data = None
+        self.m3e_list: list[PolygonSelectCanvas] = []
+        self.edit_mode = const.MASK_3D_EDIT_INCLUDE
+        self.depth_val = 1.0
+        self.has_set_mask_preview = False
+        self.resolution: tuple[int, int] = tuple(viewer.GetSize())
+        
+        self.world_to_screen = None
+        self.world_to_camera_coordinates = None
+        self.clipping_range = None
+        
+        self._bind_events()
+
+    def _bind_events(self):
+        sub = Publisher.subscribe
+        sub(self.ClearPolygons, "M3E clear polygons")
+        sub(self.ReceiveVolumeViewerActiveCamera, "Receive volume viewer active camera")
+        sub(self.ReceiveVolumeViewerSize, "Receive volume viewer size")
+        sub(self.CutMaskFromPolygons, "M3E cut mask from 3D")
+        sub(self.SetEditMode, "M3E set edit mode")
+        sub(self.SetDepthValue, "M3E set depth value")
+        sub(self.OnMaskChanged, "Change mask selected")
+
+    def setup_state(self):
+        """Called when the editor is activated."""
+        for drawn_polygon in self.viewer.canvas.draw_list:
+            if isinstance(drawn_polygon, PolygonSelectCanvas):
+                drawn_polygon.visible = True
+                drawn_polygon.set_interactive(True)
+                self.m3e_list.append(drawn_polygon)
+
+        Publisher.sendMessage("M3E ask for edit mode")
+        Publisher.sendMessage("M3E ask for depth value")
+
+        if not ses.Session().mask_3d_preview:
+            self.has_set_mask_preview = True
+            Publisher.sendMessage("Enable mask 3D preview")
+
+        if slc.Slice().current_mask:
+            self.mask_data = slc.Slice().current_mask.matrix.copy()
+
+        if not self.has_set_mask_preview:
+            Publisher.sendMessage("Render volume viewer")
+
+    def cleanup_state(self):
+        """Called when the editor is deactivated."""
+        self.viewer.canvas.draw_list = [
+            drawn_item
+            for drawn_item in self.viewer.canvas.draw_list
+            if not isinstance(drawn_item, PolygonSelectCanvas)
+        ]
+        self.m3e_list.clear()
+
+        if self.has_set_mask_preview:
+            Publisher.sendMessage("Disable mask 3D preview")
+
+    def SetEditMode(self, mode: int):
+        self.edit_mode = mode
+        Publisher.sendMessage("M3E cut mask from 3D")
+
+    def SetDepthValue(self, value: float):
+        self.depth_val = value
+        Publisher.sendMessage("M3E cut mask from 3D")
+
+    def init_new_polygon(self):
+        self.m3e_list.append(PolygonSelectCanvas())
+        self.viewer.canvas.draw_list.append(self.m3e_list[-1])
+
+    def insert_point(self, mouse_x, mouse_y, world_point):
+        if len(self.m3e_list) == 0 or self.m3e_list[-1].complete:
+            self.init_new_polygon()
+
+        current_masker = self.m3e_list[-1]
+        current_masker.insert_point((mouse_x, mouse_y), world_point)
+        self.viewer.UpdateCanvas()
+
+    def complete_current_polygon(self):
+        if len(self.m3e_list) > 0 and not self.m3e_list[-1].complete:
+            self.m3e_list[-1].complete_polygon()
+            Publisher.sendMessage("M3E cut mask from 3D")
+            self.viewer.UpdateCanvas()
+
+    def ClearPolygons(self):
+        self.viewer.canvas.draw_list = [
+            drawn_item
+            for drawn_item in self.viewer.canvas.draw_list
+            if not isinstance(drawn_item, PolygonSelectCanvas)
+        ]
+        self.m3e_list.clear()
+        self.OnRestoreInitMask()
+        self.viewer.UpdateCanvas()
+
+    def ReceiveVolumeViewerActiveCamera(self, cam):
+        width, height = self.resolution
+        near, far = self.clipping_range = cam.GetClippingRange()
+
+        inv_Y_matrix = np.eye(4)
+        inv_Y_matrix[1, 1] = -1
+
+        M = cam.GetCompositeProjectionTransformMatrix(width / float(height), near, far)
+        M = vtkarray_to_numpy(M)
+        self.world_to_screen = M @ inv_Y_matrix
+
+        MV = cam.GetViewTransformMatrix()
+        MV = vtkarray_to_numpy(MV)
+        self.world_to_camera_coordinates = MV @ inv_Y_matrix
+
+    def ReceiveVolumeViewerSize(self, size: tuple[int, int]):
+        self.resolution = size
+
+    def OnRestoreInitMask(self):
+        if self.mask_data is not None:
+            _mat = self.mask_data[1:, 1:, 1:].copy()
+            self.update_views(_mat)
+
+    def get_filters(self) -> list[npt.NDArray]:
+        w, h = self.resolution
+        renderer = self.viewer.ren
+        coord = vtkCoordinate()
+        filters = []
+        for poly_canvas in self.m3e_list:
+            display_points = []
+            for world_pt in poly_canvas._world_points:
+                coord.SetValue(world_pt)
+                px, py = coord.GetComputedDoubleDisplayValue(renderer)
+                display_points.append((px, py))
+            filters.append(polygon2mask((w, h), display_points))
+        return filters
+
+    def CutMaskFromPolygons(self):
+        completed_polygons = [m3e for m3e in self.m3e_list if m3e.complete]
+        if len(completed_polygons) == 0:
+            return
+
+        if self.mask_data is None:
+            return
+
+        Publisher.sendMessage("Send volume viewer size")
+        Publisher.sendMessage("Send volume viewer active camera")
+
+        w, h = self.resolution
+        if h == 0:
+            return
+
+        filters = self.get_filters()
+        filter = np.logical_or.reduce(filters).T
+
+        if self.edit_mode == const.MASK_3D_EDIT_INCLUDE:
+            np.logical_not(filter, out=filter)
+
+        _mat = self.mask_data[1:, 1:, 1:].copy()
+        out = _mat.copy()
+
+        slice = slc.Slice()
+        sx, sy, sz = slice.spacing
+
+        if self.clipping_range is None or self.world_to_screen is None or self.world_to_camera_coordinates is None:
+            return
+
+        near, far = self.clipping_range
+        depth = near + (far - near) * self.depth_val
+
+        wts = self.world_to_screen
+        wtc = self.world_to_camera_coordinates
+
+        mask_cut(_mat, sx, sy, sz, depth, filter, wts, wtc, out, self.edit_mode)  # type: ignore
+
+        self.update_views(out)
+
+    def OnMaskChanged(self, index: int):
+        cur_mask = slc.Slice().current_mask
+        if cur_mask is not None:
+            self.mask_data = cur_mask.matrix.copy()
+
+    def update_views(self, _mat: npt.NDArray):
+        slice = slc.Slice()
+        _cur_mask = slice.current_mask
+        if _cur_mask is not None:
+            _cur_mask.matrix[:] = 1  # type: ignore
+            _cur_mask.matrix[1:, 1:, 1:] = _mat  # type: ignore
+            _cur_mask.was_edited = True
+
+            if _cur_mask.volume is not None and ses.Session().mask_3d_preview:
+                _cur_mask.imagedata = _cur_mask.as_vtkimagedata()
+                _cur_mask.volume.change_imagedata()
+
+            _cur_mask.modified(all_volume=True)
+
+        for ori in ["AXIAL", "CORONAL", "SAGITAL"]:
+            slice.buffer_slices[ori].discard_buffer()
+
+        if _cur_mask is not None:
+            _cur_mask.save_history(0, "VOLUME", _cur_mask.matrix.copy(), self.mask_data)
+
+        Publisher.sendMessage("Render volume viewer")
+        Publisher.sendMessage("Reload actual slice")

--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy.typing as npt
 import wx
 from skimage.draw import polygon2mask
+from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slc
@@ -10,7 +11,6 @@ from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
 from invesalius_rs import mask_cut
-from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 
 class Mask3DEditorState:
@@ -179,7 +179,11 @@ class Mask3DEditorState:
         slice = slc.Slice()
         sx, sy, sz = slice.spacing
 
-        if self.clipping_range is None or self.world_to_screen is None or self.world_to_camera_coordinates is None:
+        if (
+            self.clipping_range is None
+            or self.world_to_screen is None
+            or self.world_to_camera_coordinates is None
+        ):
             return
 
         near, far = self.clipping_range

--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass, field
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 import wx
@@ -13,6 +16,7 @@ from invesalius.utils import vtkarray_to_numpy
 from invesalius_rs import mask_cut
 
 
+@dataclass
 class Mask3DEditorState:
     """State manager for the 3D Mask Editor.
 
@@ -21,19 +25,20 @@ class Mask3DEditorState:
     It decouples the heavy data operations from the VTK UI loop.
     """
 
-    def __init__(self, viewer):
-        self.viewer = viewer
-        self.mask_data = None
-        self.m3e_list: list[PolygonSelectCanvas] = []
-        self.edit_mode = const.MASK_3D_EDIT_INCLUDE
-        self.depth_val = 1.0
-        self.has_set_mask_preview = False
-        self.resolution: tuple[int, int] = tuple(viewer.GetSize())
+    viewer: Any
+    mask_data: npt.NDArray | None = None
+    m3e_list: list[PolygonSelectCanvas] = field(default_factory=list)
+    edit_mode: int = const.MASK_3D_EDIT_INCLUDE
+    depth_val: float = 1.0
+    has_set_mask_preview: bool = False
 
-        self.world_to_screen = None
-        self.world_to_camera_coordinates = None
-        self.clipping_range = None
+    resolution: tuple[int, int] = field(init=False)
+    world_to_screen: npt.NDArray | None = field(default=None, init=False)
+    world_to_camera_coordinates: npt.NDArray | None = field(default=None, init=False)
+    clipping_range: tuple[float, float] | None = field(default=None, init=False)
 
+    def __post_init__(self):
+        self.resolution = tuple(self.viewer.GetSize())
         self._bind_events()
 
     def _bind_events(self):

--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -15,7 +15,7 @@ from invesalius_rs import mask_cut
 
 class Mask3DEditorState:
     """State manager for the 3D Mask Editor.
-    
+
     This class handles the core logic of managing mask 3D edits, such as storing
     polygons, determining depth/edit mode, and cutting the 3D volume.
     It decouples the heavy data operations from the VTK UI loop.
@@ -29,11 +29,11 @@ class Mask3DEditorState:
         self.depth_val = 1.0
         self.has_set_mask_preview = False
         self.resolution: tuple[int, int] = tuple(viewer.GetSize())
-        
+
         self.world_to_screen = None
         self.world_to_camera_coordinates = None
         self.clipping_range = None
-        
+
         self._bind_events()
 
     def _bind_events(self):

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -35,8 +35,8 @@ import invesalius.constants as const
 import invesalius.data.slice_ as slc
 import invesalius.project as prj
 import invesalius.session as ses
-from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.data.mask3d_editor_state import Mask3DEditorState
+from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
 from invesalius_rs import mask_cut

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -36,6 +36,7 @@ import invesalius.data.slice_ as slc
 import invesalius.project as prj
 import invesalius.session as ses
 from invesalius.data.polygon_select import PolygonSelectCanvas
+from invesalius.data.mask3d_editor_state import Mask3DEditorState
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
 from invesalius_rs import mask_cut
@@ -1081,28 +1082,8 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
     def __init__(self, viewer: "Viewer"):
         super().__init__(viewer)
 
-        # mask_data is captured in SetUp() after the mask preview is enabled,
-        # so that do_threshold_to_all_slices() has already run.
-        self.mask_data = None
-
-        self.m3e_list: list[PolygonSelectCanvas] = []
-
-        self.picker = vtkCellPicker()
-        self.picker.PickFromListOn()
-
-        self.edit_mode = const.MASK_3D_EDIT_INCLUDE
-        self.depth_val = 1.0
-
-        # keep track if we set preview here or not for UX
-        self.has_set_mask_preview = False
-
-        # Initialise resolution from the current viewer widget size so that
-        # CutMaskFromPolygons always has a valid aspect ratio even before the
-        # first "Receive volume viewer size" message arrives (fixes #1086).
-        self.resolution: tuple[int, int] = tuple(viewer.GetSize())
-
+        self.state_manager = Mask3DEditorState(viewer)
         self._bind_events()
-        Publisher.subscribe(self.ClearPolygons, "M3E clear polygons")
 
     def _bind_events(self):
         ## Remove observers and bindings from super
@@ -1121,54 +1102,15 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         self.AddObserver("MouseWheelForwardEvent", self.OnScrollForward)
         self.AddObserver("MouseWheelBackwardEvent", self.OnScrollBackward)
 
-        sub = Publisher.subscribe
-        sub(self.ReceiveVolumeViewerActiveCamera, "Receive volume viewer active camera")
-        sub(self.ReceiveVolumeViewerSize, "Receive volume viewer size")
-        sub(self.CutMaskFromPolygons, "M3E cut mask from 3D")
-        sub(self.SetEditMode, "M3E set edit mode")
-        sub(self.SetDepthValue, "M3E set depth value")
-        sub(self.OnMaskChanged, "Change mask selected")
-
     def SetUp(self):
         """Set up is called just before the style is set in the interactor.
 
         This is called by the volume ``Viewer.SetInteractorStyle`` method.
         """
-        for drawn_polygon in self.viewer.canvas.draw_list:
-            if isinstance(drawn_polygon, PolygonSelectCanvas):
-                drawn_polygon.visible = True
-                drawn_polygon.set_interactive(True)
-                self.m3e_list.append(drawn_polygon)
-
-        # Synchronize edit mode and depth value from the GUI's current state
-        import invesalius.pubsub as pub
-
-        pub.pub.sendMessage("M3E ask for edit mode")
-        pub.pub.sendMessage("M3E ask for depth value")
-
-        if not ses.Session().mask_3d_preview:
-            self.has_set_mask_preview = True
-            Publisher.sendMessage("Enable mask 3D preview")
-
-        # Capture mask_data HERE, after Enable mask 3D preview has called
-        # do_threshold_to_all_slices().  Capturing it in __init__ was too early:
-        # the mask matrix was still all-zeros at that point, so every cut would
-        # restore to an empty mask.  Fixes #1086 (no-surface path).
-        self.mask_data = slc.Slice().current_mask.matrix.copy()
-
+        self.state_manager.setup_state()
         Publisher.sendMessage(
             "Update viewer caption", viewer_name="Volume", caption="Volume - 3D mask editor"
         )
-
-        # If the mask preview was already active before entering this style,
-        # just trigger a re-render (camera was already positioned when preview was enabled).
-        if not self.has_set_mask_preview:
-            Publisher.sendMessage("Render volume viewer")
-
-        # Capture the mask snapshot AFTER enabling the 3D preview, which runs
-        # do_threshold_to_all_slices and modifies the mask. This ensures
-        # ClearPolygons restores the correct post-threshold mask state.
-        self.mask_data = slc.Slice().current_mask.matrix.copy()
 
     def CleanUp(self):
         """Clean up is called when the interactor style is removed or changed.
@@ -1181,92 +1123,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             "LeftButtonDoubleClickEvent", self.OnLeftButtonDoubleClick
         )
 
-        # Issue #1078: When the 3D editor is disabled, polygons shouldn't just be hidden
-        # (which doesn't work properly due to CanvasHandlerBase), they should be fully removed.
-        # However, we cannot call self.ClearPolygons() because it also triggers
-        # self.OnRestoreInitMask() which reverts the cut! Instead, just remove the canvases:
-        self.viewer.canvas.draw_list = [
-            drawn_item
-            for drawn_item in self.viewer.canvas.draw_list
-            if not isinstance(drawn_item, PolygonSelectCanvas)
-        ]
-        self.m3e_list.clear()
-
-        if self.has_set_mask_preview:
-            Publisher.sendMessage("Disable mask 3D preview")
+        self.state_manager.cleanup_state()
 
         Publisher.sendMessage("Update viewer caption", viewer_name="Volume", caption="Volume")
-        self.viewer.UpdateCanvas()
-
-    def _display_to_world_focal_plane(
-        self, display_x: float, display_y: float
-    ) -> tuple[float, float, float]:
-        """Convert display coordinates to world coordinates on the camera focal plane.
-        Projects the given 2D display position onto the plane perpendicular to the
-        camera view direction passing through the focal point. This allows polygon
-        points to be stored in world space, so they remain aligned with the volume
-        when the window is resized, zoomed, or panned.
-
-        Args:
-            display_x: X position in display (pixel) coordinates.
-            display_y: Y position in display (pixel) coordinates.
-
-        Returns:
-            Tuple with (x, y, z) world coordinates on the focal plane.
-        """
-        renderer = self.viewer.ren
-        focal_point = renderer.GetActiveCamera().GetFocalPoint()
-        # Find the depth value of the focal point in display coordinates
-        renderer.SetWorldPoint(*focal_point, 1.0)
-        renderer.WorldToDisplay()
-        focal_depth = renderer.GetDisplayPoint()[2]
-        # Unproject the 2D mouse position at the focal plane depth
-        renderer.SetDisplayPoint(display_x, display_y, focal_depth)
-        renderer.DisplayToWorld()
-        world_point = renderer.GetWorldPoint()
-        w = world_point[3]
-        return (world_point[0] / w, world_point[1] / w, world_point[2] / w)
-
-    def SetEditMode(self, mode: int):
-        """Set edit mode for the style.
-
-        For now, the edit mode can only be include (0) or exclude (1). In include mode, the
-        mask keeps what is inside the polygon, while in exclude mode, it keeps
-        what is outside the polygon.
-
-        Args:
-            mode (int): The edit mode to set. ``0`` to keep inside polygons, ``1`` to keep outside polygon.
-        """
-        self.edit_mode = mode
-        Publisher.sendMessage("M3E cut mask from 3D")
-
-    def SetDepthValue(self, value: float):
-        """Set the depth value for the mask editor (between 0 and 1).
-
-        The depth value is used to determine how deep the mask will be edit in the
-        volume. If ``value = 1.0``, the mask will be edited through the entire volume.
-
-        Args:
-            value (float): The depth value to set, between 0 and 1. ``0.0`` means no
-            depth, ``1.0`` means full depth.
-        """
-        self.depth_val = value
-        Publisher.sendMessage("M3E cut mask from 3D")
-
-    def init_new_polygon(self):
-        """Initialize a new polygon for the mask editor."""
-        self.m3e_list.append(PolygonSelectCanvas())
-        self.viewer.canvas.draw_list.append(self.m3e_list[-1])
-
-    def ClearPolygons(self):
-        """Clear all polygons from the viewer and clear masker list in the style."""
-        self.viewer.canvas.draw_list = [
-            drawn_item
-            for drawn_item in self.viewer.canvas.draw_list
-            if not isinstance(drawn_item, PolygonSelectCanvas)
-        ]
-        self.m3e_list.clear()
-        self.OnRestoreInitMask()
         self.viewer.UpdateCanvas()
 
     def OnLeftButtonPress(self, evt):
@@ -1276,8 +1135,9 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             self.StartRotate()
             return
 
-        # Original polygon insertion logic
-        self.OnInsertPolygonPoint(evt)
+        mouse_x, mouse_y = self.viewer.get_vtk_mouse_position()
+        world_point = self._display_to_world_focal_plane(mouse_x, mouse_y)
+        self.state_manager.insert_point(mouse_x, mouse_y, world_point)
 
     def OnLeftButtonDoubleClick(self, evt):
         if self.viewer.interactor.GetShiftKey():
@@ -1285,16 +1145,13 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
             self.SetCameraFocus(evt)
             return
 
-        # Original polygon completion logic
-        self.OnInsertPolygon(evt)
+        self.state_manager.complete_current_polygon()
 
     def OnMouseMove(self, obj, evt):
         if self.viewer.interactor.GetShiftKey():
-            # If standard camera manipulation was started via shift+left/middle/right click
             if self.left_pressed or self.middle_pressed or self.right_pressed:
                 super().OnMouseMove(obj, evt)
                 return
-
         super().OnMouseMove(obj, evt)
 
     def OnScrollForward(self, obj, evt):
@@ -1309,198 +1166,20 @@ class Mask3DEditorInteractorStyle(DefaultInteractorStyle):
         else:
             self.OnMouseWheelBackward()
 
-    def OnInsertPolygonPoint(self, evt):
-        """Insert a point in the polygon.
-
-        If no polygon is open, it initializes a new one.
-        """
-        mouse_x, mouse_y = self.viewer.get_vtk_mouse_position()
-
-        if len(self.m3e_list) == 0 or self.m3e_list[-1].complete:
-            self.init_new_polygon()
-
-        world_point = self._display_to_world_focal_plane(mouse_x, mouse_y)
-        current_masker = self.m3e_list[-1]
-        current_masker.insert_point((mouse_x, mouse_y), world_point)
-        self.viewer.UpdateCanvas()
-
-    def OnInsertPolygon(self, evt):
-        """Complete the polygon by connecting the last point to the first one."""
-        if len(self.m3e_list) > 0 and not self.m3e_list[-1].complete:
-            self.m3e_list[-1].complete_polygon()
-            Publisher.sendMessage("M3E cut mask from 3D")
-            self.viewer.UpdateCanvas()
-
-    def ReceiveVolumeViewerActiveCamera(self, cam: "vtkCamera"):
-        """Receive the active camera from the volume viewer through pubsub.
-
-        Args:
-            cam (vtkCamera): The active camera from the volume viewer.
-        """
-        width, height = self.resolution
-
-        near, far = self.clipping_range = cam.GetClippingRange()
-
-        # This flip around the Y axis was done to countereffect the flip that vtk performs
-        # in volume.py:780. If we do not flip back, what is being displayed is flipped,
-        # although the actual coordinates are the initial ones, so the cutting gets wrong
-        # after rotations around y or x.
-        inv_Y_matrix = np.eye(4)
-        inv_Y_matrix[1, 1] = -1
-
-        # Composite transform world coordinates to viewport coordinates
-        # This is a concatenation of the view transform (world coordinates to camera
-        # coordinates) and the projection transform (camera coordinates to viewport
-        # coordinates).
-        M = cam.GetCompositeProjectionTransformMatrix(width / float(height), near, far)
-        M = vtkarray_to_numpy(M)
-        self.world_to_screen = M @ inv_Y_matrix
-
-        # Get the model view matrix, which transforms world coordinates to camera
-        # coordinates.
-        MV = cam.GetViewTransformMatrix()
-        MV = vtkarray_to_numpy(MV)
-        self.world_to_camera_coordinates = MV @ inv_Y_matrix
-
-    def ReceiveVolumeViewerSize(self, size: tuple[int, int]):
-        """Receive the size of the volume viewer through pubsub.
-
-        Args:
-            size (tuple[int, int]): The size of the volume viewer in pixels (width,
-            height).
-        """
-        self.resolution = size
-
-    def OnRestoreInitMask(self):
-        """Restore the initial mask data from when the style was setup."""
-        _mat = self.mask_data[1:, 1:, 1:].copy()
-        self.update_views(_mat)
-
-    def get_filters(self) -> list[npt.NDArray]:
-        """Create a boolean mask filter based on the polygon points and viewer size.
-
-        Since polygon points are stored with parallel world coordinates,
-        they are projected back to display coordinates using the current
-        camera before generating the mask.
-        """
-        w, h = self.resolution
+    def _display_to_world_focal_plane(
+        self, display_x: float, display_y: float
+    ) -> tuple[float, float, float]:
+        """Convert display coordinates to world coordinates on the camera focal plane."""
         renderer = self.viewer.ren
-        coord = vtkCoordinate()
-        filters = []
-        for poly_canvas in self.m3e_list:
-            display_points = []
-            for world_pt in poly_canvas._world_points:
-                coord.SetValue(world_pt)
-                px, py = coord.GetComputedDoubleDisplayValue(renderer)
-                display_points.append((px, py))
-            filters.append(polygon2mask((w, h), display_points))
-        return filters
-
-    def CutMaskFromPolygons(self):
-        """Edit mask data based on the polygons drawn in the 3D viewer."""
-        completed_polygons = [m3e for m3e in self.m3e_list if m3e.complete]
-        if len(completed_polygons) == 0:
-            return
-
-        if self.mask_data is None:
-            return
-
-        # All m3e will be updated with correct viewer settings
-        Publisher.sendMessage("Send volume viewer size")
-        Publisher.sendMessage("Send volume viewer active camera")
-
-        # Guard: if the viewer has not reported a valid size yet (e.g. on the
-        # very first Enable after a fresh DICOM import before the widget has
-        # been fully painted), skip the cut to avoid an incorrect projection
-        # matrix that would corrupt the mask.  The polygon stays in place so
-        # the user can re-apply once the viewer is ready.  Fixes #1086.
-        w, h = self.resolution
-        if h == 0:
-            return
-
-        filters = self.get_filters()
-
-        # OR operation in all masks to create a single filter mask
-        filter = np.logical_or.reduce(filters).T
-
-        # If the edit mode is to include, we invert the filter
-        if self.edit_mode == const.MASK_3D_EDIT_INCLUDE:
-            np.logical_not(filter, out=filter)
-
-        _mat = self.mask_data[1:, 1:, 1:].copy()
-        out = _mat.copy()
-
-        slice = slc.Slice()
-        sx, sy, sz = slice.spacing
-
-        try:
-            near, far = self.clipping_range
-        except AttributeError:
-            return
-
-        depth = near + (far - near) * self.depth_val
-
-        try:
-            wts = self.world_to_screen
-            wtc = self.world_to_camera_coordinates
-        except AttributeError:
-            return
-
-        mask_cut(
-            _mat,
-            sx,
-            sy,
-            sz,
-            depth,
-            filter,
-            wts,
-            wtc,
-            out,
-            self.edit_mode,
-        )
-
-        self.update_views(out)
-
-    def OnMaskChanged(self, index: int):
-        """Refresh mask_data when the active mask changes (e.g. after Select Parts).
-
-        Without this, the 3D editor keeps the stale matrix from the old mask,
-        so the first polygon cut after a 'Select Parts' would restore the old
-        mask instead of operating on the new one.  Fixes #1258.
-        """
-        cur_mask = slc.Slice().current_mask
-        if cur_mask is not None:
-            self.mask_data = cur_mask.matrix.copy()
-
-    def update_views(self, _mat: npt.NDArray):
-        """Update the views with the given mask data."""
-        slice = slc.Slice()
-        _cur_mask = slice.current_mask
-        if _cur_mask is not None:
-            _cur_mask.matrix[:] = 1
-            _cur_mask.matrix[1:, 1:, 1:] = _mat
-            _cur_mask.was_edited = True
-
-            # Explicitly rebuild the VTK imagedata from the updated numpy matrix
-            # so that the 3D volume re-renders with the new polygon-cut data.
-            # Calling modified(all_volume=True) only calls imagedata.Modified()
-            # which does NOT transfer the numpy changes into the VTK scalar array.
-            # Fix for #1258: rebuild imagedata so 3D window reflects the cut.
-            if _cur_mask.volume is not None and ses.Session().mask_3d_preview:
-                _cur_mask.imagedata = _cur_mask.as_vtkimagedata()
-                _cur_mask.volume.change_imagedata()
-
-            _cur_mask.modified(all_volume=True)
-
-        # Discard all buffers to reupdate view
-        for ori in ["AXIAL", "CORONAL", "SAGITAL"]:
-            slice.buffer_slices[ori].discard_buffer()
-
-        # Save modification in the history
-        _cur_mask.save_history(0, "VOLUME", _cur_mask.matrix.copy(), self.mask_data)
-
-        Publisher.sendMessage("Render volume viewer")  # Fix #1258: re-render 3D window after cut
-        Publisher.sendMessage("Reload actual slice")
+        focal_point = renderer.GetActiveCamera().GetFocalPoint()
+        renderer.SetWorldPoint(*focal_point, 1.0)
+        renderer.WorldToDisplay()
+        focal_depth = renderer.GetDisplayPoint()[2]
+        renderer.SetDisplayPoint(display_x, display_y, focal_depth)
+        renderer.DisplayToWorld()
+        world_point = renderer.GetWorldPoint()
+        w = world_point[3]
+        return (world_point[0] / w, world_point[1] / w, world_point[2] / w)
 
 
 class AnnotationInteractorStyle(LinearMeasureInteractorStyle):

--- a/tests/test_segmentation_tools.py
+++ b/tests/test_segmentation_tools.py
@@ -206,8 +206,10 @@ def test_do_watershed():
         assert np.any(result > 0), "Watershed should produce segmentation"
 
         # Check that the queue received a completion signal
-        assert not q.empty(), "Queue should contain completion signal"
-        completion_signal = q.get()
+        try:
+            completion_signal = q.get(timeout=2)
+        except Exception:
+            pytest.fail("Queue did not contain a completion signal within timeout")
         assert completion_signal == 1, "Completion signal should be 1"
 
 


### PR DESCRIPTION
# Description
### This PR addresses Phase 1 of my GSoC 2026 project to stabilise and optimise the 3D Mask Editor feature. 

It successfully decouples the core mathematical calculations and data processing from the VTK `Mask3DEditorInteractorStyle`. 

## **Why is this needed?**
Previously, the UI interaction loop in `styles_3d.py` was directly handling heavy Python math (such as `polygon2mask` conversions and matrix slicing) while also trying to track rapid mouse clicks. This bottleneck led to UI freezing and "ghost polygon" bugs where the app would struggle or crash if the user drew polygons too quickly.

## **What was changed:**
- Created a dedicated `Mask3DEditorState` class in `invesalius/data/mask3d_editor_state.py` to handle all heavy polygon manipulation, state tracking, and communication with the Rust `mask_cut` backend.
- Refactored `Mask3DEditorInteractorStyle` in `styles_3d.py` to act purely as a VTK interaction tracker that captures coordinates and safely delegates processing to the state manager.
- This decoupling paves the way for safely swapping the slow Python polygon math with the upcoming multi-threaded Rust implementation in my next phase.

