### PR TITLE
Feature: Create marker grids from coil targets

### DIFF
--- a/invesalius/data/markers/grid_generator.py
+++ b/invesalius/data/markers/grid_generator.py
@@ -24,6 +24,7 @@ import numpy as np
 
 import invesalius.data.coordinates as dco
 import invesalius.data.transformations as tr
+import vtk
 from invesalius.data.markers.marker import Marker, MarkerType
 from invesalius.data.markers.surface_geometry import SurfaceGeometry
 
@@ -86,8 +87,8 @@ class GridGenerator:
                 dx = (r - row_offset) * spacing
                 dy = (c - col_offset) * spacing
 
-                # Label follows the pattern: <ref_label><row>_<col>
-                label = f"{reference_marker.label}{r + 1}_{c + 1}"
+                # Label follows the pattern: <ref_label> <row>_<col>
+                label = f"{reference_marker.label} {r + 1}_{c + 1}"
 
                 new_marker = self._create_grid_point(
                     reference_marker=reference_marker,
@@ -135,8 +136,8 @@ class GridGenerator:
                 dx = radius * np.cos(angle)
                 dy = radius * np.sin(angle)
 
-                # Label follows the pattern: <ref_label><ring>_<point>
-                label = f"{reference_marker.label}{ring_idx}_{point_idx + 1}"
+                # Label follows the pattern: <ref_label> <ring>_<point>
+                label = f"{reference_marker.label} {ring_idx}_{point_idx + 1}"
 
                 new_marker = self._create_grid_point(
                     reference_marker=reference_marker,
@@ -240,28 +241,61 @@ class GridGenerator:
         marker.position = new_position
         marker.orientation = new_orientation
 
-    def _project_to_scalp(self, marker, z_rotation):
+    def _project_to_scalp(self, marker, z_rotation, smooth_radius=15.0):
         """Project a marker onto the smoothed scalp surface and orient it tangentially.
 
-        This replicates the logic from MarkerTransformator.ProjectToScalp, using the
-        smoothed scalp surface from SurfaceGeometry.
+        Instead of just using the normal of the closest point, this method averages
+        the normals of all points within a `smooth_radius` to provide a more stable
+        and robust orientation against local mesh irregularities.
 
         :param marker: The marker to project onto the scalp.
         :param z_rotation: The z_rotation value to apply after projection.
+        :param smooth_radius: Radius in mm to search for points to average normals.
         """
         # The markers have y-coordinate inverted compared to the 3D view.
         marker_position = list(marker.position)
         marker_position[1] = -marker_position[1]
 
-        closest_point, closest_normal = self.surface_geometry.GetClosestPointOnSurface(
-            "scalp", marker_position
-        )
+        surface = self.surface_geometry.GetSmoothedScalpSurface()
+        if not surface:
+            return
+
+        polydata = surface["polydata"]
+        normals = surface["normals"]
+
+        point_locator = vtk.vtkPointLocator()
+        point_locator.SetDataSet(polydata)
+        point_locator.BuildLocator()
+
+        closest_point_id = point_locator.FindClosestPoint(marker_position)
+        closest_point = polydata.GetPoint(closest_point_id)
+
+        # Find points within radius to average normals for a smoother orientation
+        id_list = vtk.vtkIdList()
+        point_locator.FindPointsWithinRadius(smooth_radius, closest_point, id_list)
+
+        normal_data = normals.GetPointData().GetNormals()
+        
+        if id_list.GetNumberOfIds() > 0:
+            avg_normal = np.zeros(3)
+            for i in range(id_list.GetNumberOfIds()):
+                pt_id = id_list.GetId(i)
+                avg_normal += np.array(normal_data.GetTuple(pt_id))
+            
+            avg_normal /= id_list.GetNumberOfIds()
+            norm = np.linalg.norm(avg_normal)
+            if norm > 0:
+                closest_normal = avg_normal / norm
+            else:
+                closest_normal = normal_data.GetTuple(closest_point_id)
+        else:
+            closest_normal = normal_data.GetTuple(closest_point_id)
 
         # The reference direction vector that we want to align the normal to.
         # This was figured out by testing; (0, 0, 1) makes the coil point towards the brain.
         ref_vector = np.array([0, 0, 1])
 
-        # Normal at the closest point.
+        # Average Normal around the closest point.
         normal_vector = np.array(closest_normal)
 
         # Calculate the rotation axis (cross product) and angle (dot product).

--- a/invesalius/data/markers/grid_generator.py
+++ b/invesalius/data/markers/grid_generator.py
@@ -21,13 +21,12 @@ import uuid
 from typing import List
 
 import numpy as np
+import vtk
 
 import invesalius.data.coordinates as dco
 import invesalius.data.transformations as tr
-import vtk
 from invesalius.data.markers.marker import Marker, MarkerType
 from invesalius.data.markers.surface_geometry import SurfaceGeometry
-
 
 # Maximum grid dimension to prevent accidental creation of excessive markers.
 MAX_GRID_DIMENSION = 100
@@ -275,13 +274,13 @@ class GridGenerator:
         point_locator.FindPointsWithinRadius(smooth_radius, closest_point, id_list)
 
         normal_data = normals.GetPointData().GetNormals()
-        
+
         if id_list.GetNumberOfIds() > 0:
             avg_normal = np.zeros(3)
             for i in range(id_list.GetNumberOfIds()):
                 pt_id = id_list.GetId(i)
                 avg_normal += np.array(normal_data.GetTuple(pt_id))
-            
+
             avg_normal /= id_list.GetNumberOfIds()
             norm = np.linalg.norm(avg_normal)
             if norm > 0:

--- a/invesalius/data/markers/grid_generator.py
+++ b/invesalius/data/markers/grid_generator.py
@@ -1,0 +1,306 @@
+# --------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------------
+
+import uuid
+from typing import List
+
+import numpy as np
+
+import invesalius.data.coordinates as dco
+import invesalius.data.transformations as tr
+from invesalius.data.markers.marker import Marker, MarkerType
+from invesalius.data.markers.surface_geometry import SurfaceGeometry
+
+
+# Maximum grid dimension to prevent accidental creation of excessive markers.
+MAX_GRID_DIMENSION = 100
+
+
+class GridGenerator:
+    """Generates a grid of coil targets around a reference target on the scalp surface.
+
+    The grid points are computed in the local coordinate system of the reference marker,
+    projected onto the smoothed scalp surface, and oriented tangentially to the surface
+    while preserving the z_rotation from the original target.
+    """
+
+    def __init__(self, surface_geometry: SurfaceGeometry):
+        self.surface_geometry = surface_geometry
+
+    def generate_rectangular_grid(
+        self,
+        reference_marker: Marker,
+        rows: int,
+        cols: int,
+        spacing: float,
+    ) -> List[Marker]:
+        """Generate a rectangular grid of coil targets centered on the reference marker.
+
+        The grid is laid out in the local coordinate system of the reference marker:
+        - Local X axis (anterior/posterior direction) corresponds to rows.
+        - Local Y axis (lateral direction) corresponds to columns.
+
+        Each grid point is displaced from the reference, projected onto the smoothed
+        scalp surface, and given an orientation tangential to the local surface normal.
+
+        :param reference_marker: The coil target marker serving as the center of the grid.
+        :param rows: Number of rows in the grid.
+        :param cols: Number of columns in the grid.
+        :param spacing: Distance between adjacent grid points in mm.
+        :return: A list of newly created Marker objects (type COIL_TARGET).
+        """
+        if rows > MAX_GRID_DIMENSION or cols > MAX_GRID_DIMENSION:
+            raise ValueError(
+                f"Grid dimensions ({rows}x{cols}) exceed the maximum allowed "
+                f"({MAX_GRID_DIMENSION}x{MAX_GRID_DIMENSION})."
+            )
+
+        markers = []
+
+        # Compute offsets so the grid is centered on the reference marker.
+        row_offset = (rows - 1) / 2.0
+        col_offset = (cols - 1) / 2.0
+
+        for r in range(rows):
+            for c in range(cols):
+                # Skip the center point (the reference marker itself).
+                if r == row_offset and c == col_offset:
+                    continue
+
+                dx = (r - row_offset) * spacing
+                dy = (c - col_offset) * spacing
+
+                # Label follows the pattern: <ref_label><row>_<col>
+                label = f"{reference_marker.label}{r + 1}_{c + 1}"
+
+                new_marker = self._create_grid_point(
+                    reference_marker=reference_marker,
+                    dx=dx,
+                    dy=dy,
+                    label=label,
+                )
+                markers.append(new_marker)
+
+        return markers
+
+    def generate_circular_grid(
+        self,
+        reference_marker: Marker,
+        rings: int,
+        points_per_ring: int,
+        spacing: float,
+    ) -> List[Marker]:
+        """Generate a circular grid of coil targets around the reference marker.
+
+        The grid consists of concentric rings centered on the reference marker.
+        Each ring has a fixed number of points distributed evenly around the circle.
+
+        :param reference_marker: The coil target marker serving as the center of the grid.
+        :param rings: Number of concentric rings.
+        :param points_per_ring: Number of points on each ring.
+        :param spacing: Radial distance between consecutive rings in mm.
+        :return: A list of newly created Marker objects (type COIL_TARGET).
+        """
+        total_points = rings * points_per_ring
+        if total_points > MAX_GRID_DIMENSION * MAX_GRID_DIMENSION:
+            raise ValueError(
+                f"Total grid points ({total_points}) exceed the maximum allowed "
+                f"({MAX_GRID_DIMENSION * MAX_GRID_DIMENSION})."
+            )
+
+        markers = []
+
+        for ring_idx in range(1, rings + 1):
+            radius = ring_idx * spacing
+
+            for point_idx in range(points_per_ring):
+                angle = 2 * np.pi * point_idx / points_per_ring
+
+                dx = radius * np.cos(angle)
+                dy = radius * np.sin(angle)
+
+                # Label follows the pattern: <ref_label><ring>_<point>
+                label = f"{reference_marker.label}{ring_idx}_{point_idx + 1}"
+
+                new_marker = self._create_grid_point(
+                    reference_marker=reference_marker,
+                    dx=dx,
+                    dy=dy,
+                    label=label,
+                )
+                markers.append(new_marker)
+
+        return markers
+
+    def _create_grid_point(
+        self,
+        reference_marker: Marker,
+        dx: float,
+        dy: float,
+        label: str,
+    ) -> Marker:
+        """Create a single grid point by displacing from the reference marker and
+        projecting onto the scalp surface.
+
+        Steps:
+        1. Duplicate the reference marker.
+        2. Move the duplicate in the local coordinate system by (dx, dy, 0).
+        3. Project onto the smoothed scalp surface (find closest point + normal).
+        4. Compute the orientation from the local surface normal.
+        5. Apply the original z_rotation.
+        6. Apply the original z_offset (distance from scalp).
+        7. Set marker type and label.
+
+        :param reference_marker: The original coil target to base the grid point on.
+        :param dx: Displacement along the local X axis (anterior/posterior) in mm.
+        :param dy: Displacement along the local Y axis (lateral) in mm.
+        :param label: Label for the new marker.
+        :return: A new Marker object positioned on the scalp.
+        """
+        new_marker = reference_marker.duplicate()
+
+        # Step 1: Move the marker in its local coordinate system by the grid offset.
+        displacement = [dx, dy, 0, 0, 0, 0]
+        self._move_marker(new_marker, displacement)
+
+        # Step 2: Project the displaced marker onto the smoothed scalp surface.
+        self._project_to_scalp(new_marker, reference_marker.z_rotation)
+
+        # Step 3: Apply the z_offset from the reference marker (distance above scalp).
+        if reference_marker.z_offset != 0:
+            z_offset_displacement = [0, 0, reference_marker.z_offset, 0, 0, 0]
+            self._move_marker(new_marker, z_offset_displacement)
+
+        # Step 4: Set marker properties.
+        new_marker.marker_type = MarkerType.COIL_TARGET
+        new_marker.label = label
+        new_marker.z_rotation = reference_marker.z_rotation
+        new_marker.z_offset = reference_marker.z_offset
+        new_marker.marker_uuid = str(uuid.uuid4())
+        new_marker.is_target = False
+
+        # Reset cortex position since it is no longer valid for the new position.
+        new_marker.cortex_position_orientation = 6 * [None]
+        new_marker.mep_value = None
+
+        return new_marker
+
+    def _move_marker(self, marker, displacement):
+        """Move a marker in its local coordinate system by the given displacement.
+
+        This replicates the logic from MarkerTransformator.MoveMarker, handling the
+        y-coordinate inversion between marker space and 3D view space.
+
+        :param marker: The marker to move.
+        :param displacement: A list of 6 values [dx, dy, dz, dalpha, dbeta, dgamma].
+        """
+        # The markers have y-coordinate inverted compared to the 3D view.
+        position = list(marker.position[:])
+        position[1] = -position[1]
+
+        orientation = marker.orientation[:]
+
+        # Create transformation matrices for the marker and the displacement.
+        m_displacement = dco.coordinates_to_transformation_matrix(
+            position=displacement[:3],
+            orientation=displacement[3:],
+            axes="sxyz",
+        )
+        m_marker = dco.coordinates_to_transformation_matrix(
+            position=position,
+            orientation=orientation,
+            axes="sxyz",
+        )
+        m_marker_new = m_marker @ m_displacement
+
+        new_position, new_orientation = dco.transformation_matrix_to_coordinates(
+            m_marker_new, "sxyz"
+        )
+
+        # Invert back to marker space.
+        new_position = list(new_position)
+        new_position[1] = -new_position[1]
+
+        marker.position = new_position
+        marker.orientation = new_orientation
+
+    def _project_to_scalp(self, marker, z_rotation):
+        """Project a marker onto the smoothed scalp surface and orient it tangentially.
+
+        This replicates the logic from MarkerTransformator.ProjectToScalp, using the
+        smoothed scalp surface from SurfaceGeometry.
+
+        :param marker: The marker to project onto the scalp.
+        :param z_rotation: The z_rotation value to apply after projection.
+        """
+        # The markers have y-coordinate inverted compared to the 3D view.
+        marker_position = list(marker.position)
+        marker_position[1] = -marker_position[1]
+
+        closest_point, closest_normal = self.surface_geometry.GetClosestPointOnSurface(
+            "scalp", marker_position
+        )
+
+        # The reference direction vector that we want to align the normal to.
+        # This was figured out by testing; (0, 0, 1) makes the coil point towards the brain.
+        ref_vector = np.array([0, 0, 1])
+
+        # Normal at the closest point.
+        normal_vector = np.array(closest_normal)
+
+        # Calculate the rotation axis (cross product) and angle (dot product).
+        rotation_axis = np.cross(ref_vector, normal_vector)
+        rotation_axis_norm = np.linalg.norm(rotation_axis)
+
+        # Handle the degenerate case where the normal is parallel to the reference vector.
+        if rotation_axis_norm < 1e-10:
+            euler_angles_deg = [0.0, 0.0, 0.0]
+        else:
+            rotation_angle = np.arccos(
+                np.clip(
+                    np.dot(ref_vector, normal_vector)
+                    / (np.linalg.norm(ref_vector) * np.linalg.norm(normal_vector)),
+                    -1.0,
+                    1.0,
+                )
+            )
+
+            # Normalize the rotation axis.
+            rotation_axis_normalized = rotation_axis / rotation_axis_norm
+
+            # Create a rotation matrix from the axis and angle.
+            rotation_matrix = tr.rotation_matrix(rotation_angle, rotation_axis_normalized)
+
+            # Convert the rotation matrix to Euler angles.
+            euler_angles = tr.euler_from_matrix(rotation_matrix, "sxyz")
+
+            # Convert the Euler angles to degrees.
+            euler_angles_deg = np.degrees(euler_angles)
+
+        # Invert back to marker space.
+        closest_point = list(closest_point)
+        closest_point[1] = -closest_point[1]
+
+        marker.position = closest_point
+        marker.orientation = euler_angles_deg
+
+        # Apply the z_rotation offset (90 degrees base + custom z_rotation).
+        # This accounts for the difference between coil and world coordinate systems.
+        displacement = [0, 0, 0, 0, 0, 90 + z_rotation]
+        self._move_marker(marker, displacement)

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -694,8 +694,9 @@ class Viewer(wx.Panel):
         SetFocalPoint call is required.
         :param position: list of 6 coordinates in vtk world coordinate system wx, wy, wz
         """
-        self.cross.SetFocalPoint(position[:3])
-        if not self.nav_status:
+        if hasattr(self, "cross"):
+            self.cross.SetFocalPoint(position[:3])
+        if not self.nav_status and hasattr(self, "slice_data") and self.slice_data:
             self.UpdateSlicesPosition(position[:3])
 
     def ScrollSlice(self, coord):
@@ -1516,16 +1517,14 @@ class Viewer(wx.Panel):
 
             if 0 <= vx < dx and 0 <= vy < dy and 0 <= vz < dz:
                 voxel_value = matrix[vz, vy, vx]
-                #info = (
+                # info = (
                 #    f"Window: {self.orientation.capitalize()}  |  "
                 #    f"Pos: ({int(px)}, {int(py)})  Slice: {slice_number}  |  "
                 #    f"Value: {voxel_value}"
-                #)
+                # )
 
                 info = _(
-                    "Window: {window}  |  "
-                    "Pos: ({px}, {py})  Slice: {slice}  |  "
-                    "Value: {value}"
+                    "Window: {window}  |  Pos: ({px}, {py})  Slice: {slice}  |  Value: {value}"
                 ).format(
                     window=self.orientation.capitalize(),
                     px=int(px),
@@ -1533,11 +1532,6 @@ class Viewer(wx.Panel):
                     slice=slice_number,
                     value=voxel_value,
                 )
-
-
-
-
-
 
                 Publisher.sendMessage("Update statusbar image info", info=info)
         except Exception:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -8315,9 +8315,7 @@ class GridConfigDialog(wx.Dialog):
         )
         circ_grid.Add(self.spin_rings, 0, wx.EXPAND)
 
-        circ_grid.Add(
-            wx.StaticText(self, -1, _("Points per ring:")), 0, wx.ALIGN_CENTER_VERTICAL
-        )
+        circ_grid.Add(wx.StaticText(self, -1, _("Points per ring:")), 0, wx.ALIGN_CENTER_VERTICAL)
         self.spin_points_per_ring = wx.SpinCtrl(
             self, -1, value=str(self.DEFAULT_POINTS_PER_RING), min=2, max=100, size=(70, -1)
         )
@@ -8407,4 +8405,3 @@ class GridConfigDialog(wx.Dialog):
             "points_per_ring": self.spin_points_per_ring.GetValue(),
             "spacing": self.spin_spacing.GetValue(),
         }
-

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -8250,3 +8250,161 @@ class ImageFilterDialog(wx.Dialog):
             pass
         evt.Skip()
         self.Destroy()
+
+
+class GridConfigDialog(wx.Dialog):
+    """Dialog for configuring the creation of a target grid around a coil target.
+
+    Allows the user to select the grid type (rectangular or circular),
+    configure dimensions and spacing, and preview the grid layout.
+    """
+
+    # Default values for the grid configuration.
+    DEFAULT_SPACING = 5.0
+    DEFAULT_ROWS = 3
+    DEFAULT_COLS = 3
+    DEFAULT_RINGS = 2
+    DEFAULT_POINTS_PER_RING = 6
+
+    def __init__(self, parent):
+        wx.Dialog.__init__(self, parent, -1, _("Target Grid Configuration"))
+        self._build_widgets()
+        self.CenterOnScreen()
+
+    def _build_widgets(self):
+        # --- Grid type selection ---
+        self.rb_rectangular = wx.RadioButton(self, label=_("Rectangular"), style=wx.RB_GROUP)
+        self.rb_circular = wx.RadioButton(self, label=_("Circular"))
+        self.rb_rectangular.SetValue(True)
+
+        type_sizer = wx.StaticBoxSizer(wx.StaticBox(self, -1, _("Grid type")), wx.HORIZONTAL)
+        type_sizer.Add(self.rb_rectangular, 0, wx.ALL, 5)
+        type_sizer.Add(self.rb_circular, 0, wx.ALL, 5)
+
+        # --- Rectangular grid options ---
+        self.sb_rectangular = wx.StaticBox(self, -1, _("Rectangular grid options"))
+        rect_sizer = wx.StaticBoxSizer(self.sb_rectangular, wx.VERTICAL)
+
+        rect_grid = wx.FlexGridSizer(rows=2, cols=2, hgap=10, vgap=5)
+        rect_grid.AddGrowableCol(1, 1)
+
+        rect_grid.Add(wx.StaticText(self, -1, _("Rows:")), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.spin_rows = wx.SpinCtrl(
+            self, -1, value=str(self.DEFAULT_ROWS), min=1, max=100, size=(70, -1)
+        )
+        rect_grid.Add(self.spin_rows, 0, wx.EXPAND)
+
+        rect_grid.Add(wx.StaticText(self, -1, _("Columns:")), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.spin_cols = wx.SpinCtrl(
+            self, -1, value=str(self.DEFAULT_COLS), min=1, max=100, size=(70, -1)
+        )
+        rect_grid.Add(self.spin_cols, 0, wx.EXPAND)
+
+        rect_sizer.Add(rect_grid, 0, wx.EXPAND | wx.ALL, 5)
+
+        # --- Circular grid options ---
+        self.sb_circular = wx.StaticBox(self, -1, _("Circular grid options"))
+        circ_sizer = wx.StaticBoxSizer(self.sb_circular, wx.VERTICAL)
+
+        circ_grid = wx.FlexGridSizer(rows=2, cols=2, hgap=10, vgap=5)
+        circ_grid.AddGrowableCol(1, 1)
+
+        circ_grid.Add(wx.StaticText(self, -1, _("Rings:")), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.spin_rings = wx.SpinCtrl(
+            self, -1, value=str(self.DEFAULT_RINGS), min=1, max=50, size=(70, -1)
+        )
+        circ_grid.Add(self.spin_rings, 0, wx.EXPAND)
+
+        circ_grid.Add(
+            wx.StaticText(self, -1, _("Points per ring:")), 0, wx.ALIGN_CENTER_VERTICAL
+        )
+        self.spin_points_per_ring = wx.SpinCtrl(
+            self, -1, value=str(self.DEFAULT_POINTS_PER_RING), min=2, max=100, size=(70, -1)
+        )
+        circ_grid.Add(self.spin_points_per_ring, 0, wx.EXPAND)
+
+        circ_sizer.Add(circ_grid, 0, wx.EXPAND | wx.ALL, 5)
+
+        # --- Spacing (common to both grid types) ---
+        spacing_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        spacing_sizer.Add(
+            wx.StaticText(self, -1, _("Spacing (mm):")), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5
+        )
+        self.spin_spacing = wx.SpinCtrlDouble(
+            self,
+            -1,
+            value=str(self.DEFAULT_SPACING),
+            min=0.1,
+            max=100.0,
+            inc=0.5,
+            size=(70, -1),
+        )
+        self.spin_spacing.SetDigits(1)
+        spacing_sizer.Add(self.spin_spacing, 0, wx.ALL, 5)
+
+        # --- Buttons ---
+        btn_ok = wx.Button(self, wx.ID_OK)
+        btn_ok.SetDefault()
+        btn_cancel = wx.Button(self, wx.ID_CANCEL)
+
+        btn_sizer = wx.StdDialogButtonSizer()
+        btn_sizer.AddButton(btn_ok)
+        btn_sizer.AddButton(btn_cancel)
+        btn_sizer.Realize()
+
+        # --- Main layout ---
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(type_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        main_sizer.Add(rect_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(circ_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(spacing_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(btn_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
+
+        # --- Bind events ---
+        self.rb_rectangular.Bind(wx.EVT_RADIOBUTTON, self._on_grid_type_changed)
+        self.rb_circular.Bind(wx.EVT_RADIOBUTTON, self._on_grid_type_changed)
+
+        # Initialize visibility: show rectangular, hide circular.
+        self._update_grid_type_visibility()
+
+    def _on_grid_type_changed(self, evt):
+        """Handle grid type radio button change."""
+        self._update_grid_type_visibility()
+        self.Layout()
+        self.Fit()
+
+    def _update_grid_type_visibility(self):
+        """Show/hide grid option panels based on the selected grid type."""
+        is_rectangular = self.rb_rectangular.GetValue()
+
+        # Enable/disable rectangular controls.
+        self.spin_rows.Enable(is_rectangular)
+        self.spin_cols.Enable(is_rectangular)
+
+        # Enable/disable circular controls.
+        self.spin_rings.Enable(not is_rectangular)
+        self.spin_points_per_ring.Enable(not is_rectangular)
+
+    def GetGridConfig(self):
+        """Return the grid configuration as a dictionary.
+
+        :return: A dictionary with keys: 'type', 'rows', 'cols', 'rings',
+                 'points_per_ring', 'spacing'.
+        """
+        if self.rb_rectangular.GetValue():
+            grid_type = "rectangular"
+        else:
+            grid_type = "circular"
+
+        return {
+            "type": grid_type,
+            "rows": self.spin_rows.GetValue(),
+            "cols": self.spin_cols.GetValue(),
+            "rings": self.spin_rings.GetValue(),
+            "points_per_ring": self.spin_points_per_ring.GetValue(),
+            "spacing": self.spin_spacing.GetValue(),
+        }
+

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -592,7 +592,10 @@ class Frame(wx.Frame):
             # Use RichMessageDialog so we can add a 'Store session' checkbox,
             # consistent with the normal (no unsaved changes) exit dialog.
             dialog = wx.RichMessageDialog(
-                None, msg, _("InVesalius 3 - Unsaved Changes"), wx.ICON_WARNING | wx.YES_NO | wx.CANCEL
+                None,
+                msg,
+                _("InVesalius 3 - Unsaved Changes"),
+                wx.ICON_WARNING | wx.YES_NO | wx.CANCEL,
             )
             dialog.SetYesNoLabels(_("Save and Exit"), _("Discard and Exit"))
             dialog.ShowCheckBox(_("Store session"), False)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3187,6 +3187,10 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
 
         # Show 'Set as target'/'Unset target' menu item only if the marker is a coil target.
         if is_coil_target:
+            # 'Create target grid' menu item for coil targets.
+            grid_menu_item = menu_id.Append(unique_menu_id + 19, _("Create target grid"))
+            menu_id.Bind(wx.EVT_MENU, self.OnCreateTargetGrid, grid_menu_item)
+
             mep_menu_item = menu_id.Append(unique_menu_id + 4, _("Change MEP value"))
             menu_id.Bind(wx.EVT_MENU, self.OnMenuChangeMEP, mep_menu_item)
             if is_active_target:
@@ -3200,10 +3204,6 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
             else:
                 target_menu_item = menu_id.Append(unique_menu_id + 7, _("Set as target"))
                 menu_id.Bind(wx.EVT_MENU, self.OnMenuSetTarget, target_menu_item)
-
-            # 'Create target grid' menu item for coil targets.
-            grid_menu_item = menu_id.Append(unique_menu_id + 19, _("Create target grid"))
-            menu_id.Bind(wx.EVT_MENU, self.OnCreateTargetGrid, grid_menu_item)
 
         # Show 'Create coil target' menu item if the marker is a coil pose.
         if is_coil_pose:

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3201,6 +3201,10 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
                 target_menu_item = menu_id.Append(unique_menu_id + 7, _("Set as target"))
                 menu_id.Bind(wx.EVT_MENU, self.OnMenuSetTarget, target_menu_item)
 
+            # 'Create target grid' menu item for coil targets.
+            grid_menu_item = menu_id.Append(unique_menu_id + 19, _("Create target grid"))
+            menu_id.Bind(wx.EVT_MENU, self.OnCreateTargetGrid, grid_menu_item)
+
         # Show 'Create coil target' menu item if the marker is a coil pose.
         if is_coil_pose:
             # 'Create coil target' menu item.
@@ -3516,6 +3520,43 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         marker = self.__get_marker(list_index)
 
         self.markers.CreateCoilTargetFromCoilPose(marker)
+
+    def OnCreateTargetGrid(self, evt):
+        """Open the grid configuration dialog and create a target grid around the
+        currently focused coil target marker."""
+        list_index = self.marker_list_ctrl.GetFocusedItem()
+        if list_index == -1:
+            wx.MessageBox(_("No data selected."), _("InVesalius 3"))
+            return
+
+        marker = self.__get_marker(list_index)
+
+        if marker.marker_type != MarkerType.COIL_TARGET:
+            wx.MessageBox(_("Please select a coil target."), _("InVesalius 3"))
+            return
+
+        proj = prj.Project()
+        if not proj.surface_dict:
+            wx.MessageBox(_("No 3D surface was created."), _("InVesalius 3"))
+            return
+
+        # Show the grid configuration dialog.
+        grid_dlg = dlg.GridConfigDialog(self)
+        if grid_dlg.ShowModal() == wx.ID_OK:
+            config = grid_dlg.GetGridConfig()
+            try:
+                self.markers.CreateGridFromTarget(
+                    reference_marker=marker,
+                    grid_type=config["type"],
+                    rows=config.get("rows", 3),
+                    cols=config.get("cols", 3),
+                    rings=config.get("rings", 2),
+                    points_per_ring=config.get("points_per_ring", 6),
+                    spacing=config["spacing"],
+                )
+            except ValueError as e:
+                wx.MessageBox(str(e), _("InVesalius 3"), wx.OK | wx.ICON_ERROR)
+        grid_dlg.Destroy()
 
     def UpdateMainCoilCombobox(self, done):
         select_main_coil = self.select_main_coil

--- a/invesalius/navigation/markers.py
+++ b/invesalius/navigation/markers.py
@@ -21,6 +21,7 @@ import uuid
 from typing import List, Union
 
 import invesalius.session as ses
+from invesalius.data.markers.grid_generator import GridGenerator
 from invesalius.data.markers.marker import Marker, MarkerType
 from invesalius.data.markers.marker_transformator import MarkerTransformator
 from invesalius.navigation.robot import Robot, RobotObjective
@@ -333,3 +334,46 @@ class MarkersControl(metaclass=Singleton):
         new_marker.marker_type = MarkerType.COIL_TARGET
 
         self.AddMarker(new_marker)
+
+    def CreateGridFromTarget(
+        self,
+        reference_marker: Marker,
+        grid_type: str,
+        rows: int = 3,
+        cols: int = 3,
+        rings: int = 2,
+        points_per_ring: int = 6,
+        spacing: float = 5.0,
+    ) -> List[Marker]:
+        """Create a grid of coil targets around a reference coil target.
+
+        The grid is generated on the smoothed scalp surface, with each target
+        oriented tangentially to the local surface normal and preserving the
+        z_rotation and z_offset from the reference target.
+
+        :param reference_marker: The coil target marker to use as the center of the grid.
+        :param grid_type: Type of grid layout: 'rectangular' or 'circular'.
+        :param rows: Number of rows (rectangular grid only).
+        :param cols: Number of columns (rectangular grid only).
+        :param rings: Number of concentric rings (circular grid only).
+        :param points_per_ring: Number of points per ring (circular grid only).
+        :param spacing: Distance between adjacent grid points in mm.
+        :return: List of newly created Marker objects.
+        """
+        grid_generator = GridGenerator(self.transformator.surface_geometry)
+
+        if grid_type == "rectangular":
+            new_markers = grid_generator.generate_rectangular_grid(
+                reference_marker, rows, cols, spacing
+            )
+        elif grid_type == "circular":
+            new_markers = grid_generator.generate_circular_grid(
+                reference_marker, rings, points_per_ring, spacing
+            )
+        else:
+            raise ValueError(f"Unknown grid type: {grid_type}")
+
+        for marker in new_markers:
+            self.AddMarker(marker)
+
+        return new_markers


### PR DESCRIPTION
This PR introduces a new feature to generate a grid of markers based on a selected TMS coil target. 

**Main changes:**
- Added the `grid_generator` module to handle the grid math and surface projections.
- Created `GridConfigDialog` so users can easily configure grid dimensions and spacing.
- Added a "Create target grid" option in the task navigator context menu.
- Added the `CreateGridFromTarget` method in `MarkersControl` to link the UI with the generator.
- Implemented a radius-based normal averaging to make the grid projection smoother on irregular surfaces.