### PR TITLE
feat: Add 3MF file format import/export support

### DIFF
--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -514,6 +514,7 @@ FILETYPE_VRML = wx.NewIdRef()
 FILETYPE_OBJ = wx.NewIdRef()
 FILETYPE_VTP = wx.NewIdRef()
 FILETYPE_PLY = wx.NewIdRef()
+FILETYPE_3MF = wx.NewIdRef()
 FILETYPE_X3D = wx.NewIdRef()
 
 FILETYPE_IMAGEDATA = wx.NewIdRef()
@@ -524,6 +525,7 @@ FILETYPE_PNG = wx.NewIdRef()
 FILETYPE_PS = wx.NewIdRef()
 FILETYPE_POV = wx.NewIdRef()
 FILETYPE_TIF = wx.NewIdRef()
+
 
 IMAGE_TILING = {
     "1 x 1": (1, 1),

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -672,25 +672,6 @@ class SurfaceManager:
                 idx = 0
                 total_items = build_items.Count()
 
-                if total_items > 20:
-                    progress.Destroy()
-                    msg = _(
-                        "You are about to import {} surfaces. This may take some time. Continue?"
-                    ).format(total_items)
-                    title = _("Confirm Import")
-                    response = wx.MessageBox(msg, title, wx.YES_NO | wx.ICON_QUESTION)
-                    if response != wx.YES:
-                        return
-                    import_msg = _("Import surface")
-                    reading_msg = _("Reading 3MF file...")
-                    progress = wx.ProgressDialog(
-                        import_msg,
-                        reading_msg,
-                        maximum=100,
-                        parent=None,
-                        style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
-                    )
-
                 while build_items.MoveNext():
                     build_item = build_items.GetCurrent()
                     object_resource = build_item.GetObjectResource()
@@ -701,7 +682,11 @@ class SurfaceManager:
                         vertex_count = mesh_object.GetVertexCount()
                         triangle_count = mesh_object.GetTriangleCount()
 
-                        percent_start = 20 + (idx * 60 // max(total_items, 1))
+                        # Calculate progress range for this surface (20% to 80% total range)
+                        progress_range = 60  # Total progress range for all surfaces
+                        surface_progress_chunk = progress_range / max(total_items, 1)
+                        
+                        percent_start = int(20 + (idx * surface_progress_chunk))
                         keep_going, skip = progress.Update(
                             percent_start,
                             _("Loading mesh {}/{}: {} vertices, {} triangles...").format(
@@ -725,7 +710,7 @@ class SurfaceManager:
                                 vertex.Coordinates[2],
                             )
 
-                        percent_mid = percent_start + 20
+                        percent_mid = int(20 + (idx + 0.4) * surface_progress_chunk)
                         keep_going, skip = progress.Update(
                             percent_mid,
                             _("Processing triangles for mesh {}/{}...").format(
@@ -746,7 +731,7 @@ class SurfaceManager:
                             triangle.GetPointIds().SetId(2, triangle_obj.Indices[2])
                             triangles.InsertNextCell(triangle)
 
-                        percent_end = percent_start + 40
+                        percent_end = int(20 + (idx + 0.8) * surface_progress_chunk)
                         keep_going, skip = progress.Update(
                             percent_end, _("Creating surface {}/{}...").format(idx + 1, total_items)
                         )
@@ -1848,16 +1833,6 @@ class SurfaceManager:
                     if not visible_surfaces:
                         progress.Destroy()
                         return
-
-                    if len(visible_surfaces) > 20:
-                        msg = _(
-                            "You are about to export {} surfaces. This may take some time. Continue?"
-                        ).format(len(visible_surfaces))
-                        title = _("Confirm Export")
-                        response = wx.MessageBox(msg, title, wx.YES_NO | wx.ICON_QUESTION)
-                        if response != wx.YES:
-                            progress.Destroy()
-                            return
 
                     # Deduplicate surface names
                     # First pass: normalize empty/None names to Surface_N

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -52,8 +52,15 @@ from vtkmodules.vtkIOGeometry import vtkOBJReader, vtkSTLReader, vtkSTLWriter
 from vtkmodules.vtkIOPLY import vtkPLYReader, vtkPLYWriter
 from vtkmodules.vtkIOXML import vtkXMLPolyDataReader, vtkXMLPolyDataWriter
 from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
+from vtkmodules.util.numpy_support import vtk_to_numpy
 
 from invesalius.pubsub import pub as Publisher
+
+try:
+    import lib3mf
+    _has_lib3mf = True
+except ImportError:
+    _has_lib3mf = False
 
 if sys.platform == "win32":
     try:
@@ -623,6 +630,126 @@ class SurfaceManager:
         elif filename.lower().endswith(".vtp"):
             reader = vtkXMLPolyDataReader()
             scalar = True
+        elif filename.lower().endswith(".3mf"):
+            if not _has_lib3mf:
+                wx.MessageBox(
+                    _("Lib3MF library not available. Cannot import 3MF files."),
+                    _("Import surface error")
+                )
+                return
+            
+            progress = wx.ProgressDialog(
+                _("Importing 3MF file"),
+                _("Reading 3MF file..."),
+                maximum=100,
+                parent=None,
+                style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE
+            )
+            
+            try:
+                keep_going, skip = progress.Update(10, _("Reading 3MF file..."))
+                if not keep_going:
+                    progress.Destroy()
+                    return
+                wx.Yield()
+                
+                wrapper = lib3mf.Wrapper()
+                model = wrapper.CreateModel()
+                reader_3mf = model.QueryReader('3mf')
+                reader_3mf.ReadFromFile(filename)
+                
+                keep_going, skip = progress.Update(20, _("Analyzing 3MF structure..."))
+                if not keep_going:
+                    progress.Destroy()
+                    return
+                wx.Yield()
+                
+                build_items = model.GetBuildItems()
+                base_name = os.path.splitext(os.path.split(filename)[-1])[0]
+                
+                idx = 0
+                total_items = build_items.Count()
+                
+                while build_items.MoveNext():
+                    build_item = build_items.GetCurrent()
+                    object_resource = build_item.GetObjectResource()
+                    
+                    if object_resource.IsMeshObject():
+                        mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
+                        
+                        vertex_count = mesh_object.GetVertexCount()
+                        triangle_count = mesh_object.GetTriangleCount()
+                        
+                        percent_start = 20 + (idx * 60 // max(total_items, 1))
+                        keep_going, skip = progress.Update(
+                            percent_start, 
+                            _("Loading mesh {}/{}: {} vertices, {} triangles...").format(
+                                idx + 1, total_items, vertex_count, triangle_count
+                            )
+                        )
+                        if not keep_going:
+                            progress.Destroy()
+                            return
+                        wx.Yield()
+                        
+                        points = vtkPoints()
+                        points.SetNumberOfPoints(vertex_count)
+                        
+                        for i in range(vertex_count):
+                            vertex = mesh_object.GetVertex(i)
+                            points.SetPoint(i, vertex.Coordinates[0], vertex.Coordinates[1], vertex.Coordinates[2])
+                        
+                        percent_mid = percent_start + 20
+                        keep_going, skip = progress.Update(percent_mid, _("Processing triangles for mesh {}/{}...").format(idx + 1, total_items))
+                        if not keep_going:
+                            progress.Destroy()
+                            return
+                        wx.Yield()
+                        
+                        triangles = vtkCellArray()
+                        for i in range(triangle_count):
+                            triangle_obj = mesh_object.GetTriangle(i)
+                            triangle = vtkTriangle()
+                            triangle.GetPointIds().SetId(0, triangle_obj.Indices[0])
+                            triangle.GetPointIds().SetId(1, triangle_obj.Indices[1])
+                            triangle.GetPointIds().SetId(2, triangle_obj.Indices[2])
+                            triangles.InsertNextCell(triangle)
+                        
+                        percent_end = percent_start + 40
+                        keep_going, skip = progress.Update(percent_end, _("Creating surface {}/{}...").format(idx + 1, total_items))
+                        if not keep_going:
+                            progress.Destroy()
+                            return
+                        wx.Yield()
+                        
+                        polydata = vtkPolyData()
+                        polydata.SetPoints(points)
+                        polydata.SetPolys(triangles)
+                        
+                        try:
+                            surface_name = object_resource.GetName()
+                            if not surface_name:
+                                surface_name = f"{base_name}_{idx + 1}" if total_items > 1 else base_name
+                        except:
+                            surface_name = f"{base_name}_{idx + 1}" if total_items > 1 else base_name
+                        
+                        if polydata.GetNumberOfPoints() > 0:
+                            self.CreateSurfaceFromPolydata(polydata, name=surface_name, scalar=False)
+                        
+                        idx += 1
+                
+                progress.Update(100, _("Import complete."))
+                wx.Yield()
+                progress.Destroy()
+                return
+                
+            except Exception as e:
+                progress.Destroy()
+                wx.MessageBox(
+                    _("Failed to import 3MF file: {}").format(str(e)),
+                    _("Import surface error")
+                )
+                return
         else:
             wx.MessageBox(_("File format not reconized by InVesalius"), _("Import surface error"))
             return
@@ -1421,6 +1548,7 @@ class SurfaceManager:
             const.FILETYPE_VTP: ".vtp",
             const.FILETYPE_PLY: ".ply",
             const.FILETYPE_STL_ASCII: ".stl",
+            const.FILETYPE_3MF: ".3mf",
         }
         if filetype in ftype_prefix:
             temp_fd, temp_file = tempfile.mkstemp(suffix=ftype_prefix[filetype])
@@ -1622,6 +1750,110 @@ class SurfaceManager:
             #   writer = vtkVRMLExporter()
             # elif filetype == const.FILETYPE_OBJ:
             #   writer = vtkOBJExporter()
+
+            elif filetype == const.FILETYPE_3MF:
+                if not _has_lib3mf:
+                    progress.Destroy()
+                    wx.MessageBox(
+                        "Lib3MF library not available. Cannot export 3MF files.",
+                        "Export error"
+                    )
+                    return
+                
+                try:
+                    from ctypes import c_float, c_uint32
+                    
+                    wrapper = lib3mf.Wrapper()
+                    model = wrapper.CreateModel()
+                    model.SetUnit(lib3mf.ModelUnit.MilliMeter)
+                    
+                    keep_going, skip = progress.Update(20, "Preparing 3MF export...")
+                    if not keep_going:
+                        progress.Destroy()
+                        return
+                    wx.Yield()
+                    
+                    visible_surfaces = []
+                    for index in proj.surface_dict:
+                        surface = proj.surface_dict[index]
+                        if surface.is_shown:
+                            visible_surfaces.append((surface.polydata, surface.name, surface.colour, 1 - surface.transparency))
+                    
+                    if not visible_surfaces:
+                        progress.Destroy()
+                        return
+                    
+                    num_surfaces = len(visible_surfaces)
+                    for surf_idx, (surf_polydata, surf_name, surf_colour, surf_opacity) in enumerate(visible_surfaces):
+                        percent_start = 20 + (surf_idx * 60 // num_surfaces)
+                        keep_going, skip = progress.Update(percent_start, f"Processing surface {surf_idx + 1}/{num_surfaces}...")
+                        if not keep_going:
+                            progress.Destroy()
+                            return
+                        wx.Yield()
+                        
+                        if convert_to_world:
+                            surf_polydata = self.ConvertPolydataToInv(surf_polydata, inverse=True)
+                        
+                        points_vtk = surf_polydata.GetPoints()
+                        n_points = points_vtk.GetNumberOfPoints()
+                        
+                        points_array = vtk_to_numpy(points_vtk.GetData())
+                        
+                        mesh_object = model.AddMeshObject()
+                        mesh_object.SetName(surf_name if surf_name else f"Surface_{surf_idx + 1}")
+                        
+                        for i in range(n_points):
+                            pos = lib3mf.Position()
+                            pos.Coordinates = (c_float * 3)(float(points_array[i, 0]), float(points_array[i, 1]), float(points_array[i, 2]))
+                            mesh_object.AddVertex(pos)
+                        
+                        polys = surf_polydata.GetPolys()
+                        polys.InitTraversal()
+                        id_list = vtkIdList()
+                        
+                        while polys.GetNextCell(id_list):
+                            if id_list.GetNumberOfIds() == 3:
+                                tri = lib3mf.Triangle()
+                                tri.Indices = (c_uint32 * 3)(id_list.GetId(0), id_list.GetId(1), id_list.GetId(2))
+                                mesh_object.AddTriangle(tri)
+                        
+                        color_group = model.AddColorGroup()
+                        color = lib3mf.Color()
+                        color.Red = int(surf_colour[0] * 255)
+                        color.Green = int(surf_colour[1] * 255)
+                        color.Blue = int(surf_colour[2] * 255)
+                        color.Alpha = int(surf_opacity * 255)
+                        color_id = color_group.AddColor(color)
+                        
+                        mesh_object.SetObjectLevelProperty(
+                            color_group.GetResourceID(),
+                            color_id
+                        )
+                        
+                        model.AddBuildItem(mesh_object, wrapper.GetIdentityTransform())
+                    
+                    keep_going, skip = progress.Update(85, "Writing 3MF file...")
+                    if not keep_going:
+                        progress.Destroy()
+                        return
+                    wx.Yield()
+                    
+                    writer_3mf = model.QueryWriter('3mf')
+                    writer_3mf.WriteToFile(filename)
+                    
+                    progress.Update(100, "Export complete.")
+                    self.export_successful = True
+                    wx.Yield()
+                    return
+                    
+                except Exception as e:
+                    progress.Destroy()
+                    wx.MessageBox(
+                        f"Failed to export 3MF file: {str(e)}",
+                        "Export error"
+                    )
+                    return
 
             else:
                 progress.Destroy()

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -750,9 +750,31 @@ class SurfaceManager:
                                 f"{base_name}_{idx + 1}" if total_items > 1 else base_name
                             )
 
+                        surface_colour = None
+                        surface_transparency = None
+                        try:
+                            property_result = mesh_object.GetObjectLevelProperty()
+                            if property_result and len(property_result) == 3 and property_result[2]:
+                                resource_id, property_id, has_property = property_result
+                                color_group = model.GetColorGroupByID(resource_id)
+                                color = color_group.GetColor(property_id)
+
+                                surface_colour = (
+                                    color.Red / 255.0,
+                                    color.Green / 255.0,
+                                    color.Blue / 255.0,
+                                )
+                                surface_transparency = 1.0 - (color.Alpha / 255.0)
+                        except Exception:
+                            pass
+
                         if polydata.GetNumberOfPoints() > 0:
                             self.CreateSurfaceFromPolydata(
-                                polydata, name=surface_name, scalar=False
+                                polydata,
+                                name=surface_name,
+                                colour=surface_colour,
+                                transparency=surface_transparency,
+                                scalar=False,
                             )
 
                         idx += 1

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -674,18 +674,18 @@ class SurfaceManager:
 
                 if total_items > 20:
                     progress.Destroy()
-                    response = wx.MessageBox(
-                        _(
-                            "You are about to import {} surfaces. This may take some time. Continue?"
-                        ).format(total_items),
-                        _("Confirm Import"),
-                        wx.YES_NO | wx.ICON_QUESTION,
-                    )
+                    msg = _(
+                        "You are about to import {} surfaces. This may take some time. Continue?"
+                    ).format(total_items)
+                    title = _("Confirm Import")
+                    response = wx.MessageBox(msg, title, wx.YES_NO | wx.ICON_QUESTION)
                     if response != wx.YES:
                         return
+                    import_msg = _("Import surface")
+                    reading_msg = _("Reading 3MF file...")
                     progress = wx.ProgressDialog(
-                        _("Import surface"),
-                        _("Reading 3MF file..."),
+                        import_msg,
+                        reading_msg,
                         maximum=100,
                         parent=None,
                         style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
@@ -1850,13 +1850,11 @@ class SurfaceManager:
                         return
 
                     if len(visible_surfaces) > 20:
-                        response = wx.MessageBox(
-                            _(
-                                "You are about to export {} surfaces. This may take some time. Continue?"
-                            ).format(len(visible_surfaces)),
-                            _("Confirm Export"),
-                            wx.YES_NO | wx.ICON_QUESTION,
-                        )
+                        msg = _(
+                            "You are about to export {} surfaces. This may take some time. Continue?"
+                        ).format(len(visible_surfaces))
+                        title = _("Confirm Export")
+                        response = wx.MessageBox(msg, title, wx.YES_NO | wx.ICON_QUESTION)
                         if response != wx.YES:
                             progress.Destroy()
                             return

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import time
 import traceback
+from collections import Counter
 
 import numpy as np
 import wx
@@ -670,6 +671,25 @@ class SurfaceManager:
 
                 idx = 0
                 total_items = build_items.Count()
+
+                if total_items > 20:
+                    progress.Destroy()
+                    response = wx.MessageBox(
+                        _(
+                            "You are about to import {} surfaces. This may take some time. Continue?"
+                        ).format(total_items),
+                        _("Confirm Import"),
+                        wx.YES_NO | wx.ICON_QUESTION,
+                    )
+                    if response != wx.YES:
+                        return
+                    progress = wx.ProgressDialog(
+                        _("Import surface"),
+                        _("Reading 3MF file..."),
+                        maximum=100,
+                        parent=None,
+                        style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
+                    )
 
                 while build_items.MoveNext():
                     build_item = build_items.GetCurrent()
@@ -1829,6 +1849,35 @@ class SurfaceManager:
                         progress.Destroy()
                         return
 
+                    if len(visible_surfaces) > 20:
+                        response = wx.MessageBox(
+                            _(
+                                "You are about to export {} surfaces. This may take some time. Continue?"
+                            ).format(len(visible_surfaces)),
+                            _("Confirm Export"),
+                            wx.YES_NO | wx.ICON_QUESTION,
+                        )
+                        if response != wx.YES:
+                            progress.Destroy()
+                            return
+
+                    # Deduplicate surface names
+                    # First pass: normalize empty/None names to Surface_N
+                    for i, (polydata, name, colour, opacity) in enumerate(visible_surfaces):
+                        if not name:
+                            visible_surfaces[i] = (polydata, f"Surface_{i + 1}", colour, opacity)
+
+                    # Second pass: add suffixes to duplicates
+                    names = [item[1] for item in visible_surfaces]
+                    name_counts = Counter(names)
+                    duplicates = {name: 0 for name, count in name_counts.items() if count > 1}
+
+                    for i, (polydata, name, colour, opacity) in enumerate(visible_surfaces):
+                        if name in duplicates:
+                            duplicates[name] += 1
+                            new_name = f"{name}_{duplicates[name]:02d}"
+                            visible_surfaces[i] = (polydata, new_name, colour, opacity)
+
                     num_surfaces = len(visible_surfaces)
                     for surf_idx, (
                         surf_polydata,
@@ -1871,11 +1920,11 @@ class SurfaceManager:
 
                         while polys.GetNextCell(id_list):
                             if id_list.GetNumberOfIds() == 3:
-                                tri = lib3mf.Triangle()
-                                tri.Indices = (c_uint32 * 3)(
-                                    id_list.GetId(0), id_list.GetId(1), id_list.GetId(2)
-                                )
-                                mesh_object.AddTriangle(tri)
+                                v0, v1, v2 = id_list.GetId(0), id_list.GetId(1), id_list.GetId(2)
+                                if v0 != v1 and v1 != v2 and v0 != v2:
+                                    tri = lib3mf.Triangle()
+                                    tri.Indices = (c_uint32 * 3)(v0, v1, v2)
+                                    mesh_object.AddTriangle(tri)
 
                         color_group = model.AddColorGroup()
                         color = lib3mf.Color()

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -32,6 +32,7 @@ import traceback
 import numpy as np
 import wx
 import wx.lib.agw.genericmessagedialog as GMD
+from vtkmodules.util.numpy_support import vtk_to_numpy
 from vtkmodules.vtkCommonCore import (
     vtkIdList,
     vtkPoints,
@@ -52,12 +53,12 @@ from vtkmodules.vtkIOGeometry import vtkOBJReader, vtkSTLReader, vtkSTLWriter
 from vtkmodules.vtkIOPLY import vtkPLYReader, vtkPLYWriter
 from vtkmodules.vtkIOXML import vtkXMLPolyDataReader, vtkXMLPolyDataWriter
 from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
-from vtkmodules.util.numpy_support import vtk_to_numpy
 
 from invesalius.pubsub import pub as Publisher
 
 try:
     import lib3mf
+
     _has_lib3mf = True
 except ImportError:
     _has_lib3mf = False
@@ -634,78 +635,88 @@ class SurfaceManager:
             if not _has_lib3mf:
                 wx.MessageBox(
                     _("Lib3MF library not available. Cannot import 3MF files."),
-                    _("Import surface error")
+                    _("Import surface error"),
                 )
                 return
-            
+
             progress = wx.ProgressDialog(
                 _("Importing 3MF file"),
                 _("Reading 3MF file..."),
                 maximum=100,
                 parent=None,
-                style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE
+                style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
             )
-            
+
             try:
                 keep_going, skip = progress.Update(10, _("Reading 3MF file..."))
                 if not keep_going:
                     progress.Destroy()
                     return
                 wx.Yield()
-                
+
                 wrapper = lib3mf.Wrapper()
                 model = wrapper.CreateModel()
-                reader_3mf = model.QueryReader('3mf')
+                reader_3mf = model.QueryReader("3mf")
                 reader_3mf.ReadFromFile(filename)
-                
+
                 keep_going, skip = progress.Update(20, _("Analyzing 3MF structure..."))
                 if not keep_going:
                     progress.Destroy()
                     return
                 wx.Yield()
-                
+
                 build_items = model.GetBuildItems()
                 base_name = os.path.splitext(os.path.split(filename)[-1])[0]
-                
+
                 idx = 0
                 total_items = build_items.Count()
-                
+
                 while build_items.MoveNext():
                     build_item = build_items.GetCurrent()
                     object_resource = build_item.GetObjectResource()
-                    
+
                     if object_resource.IsMeshObject():
                         mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
-                        
+
                         vertex_count = mesh_object.GetVertexCount()
                         triangle_count = mesh_object.GetTriangleCount()
-                        
+
                         percent_start = 20 + (idx * 60 // max(total_items, 1))
                         keep_going, skip = progress.Update(
-                            percent_start, 
+                            percent_start,
                             _("Loading mesh {}/{}: {} vertices, {} triangles...").format(
                                 idx + 1, total_items, vertex_count, triangle_count
-                            )
+                            ),
                         )
                         if not keep_going:
                             progress.Destroy()
                             return
                         wx.Yield()
-                        
+
                         points = vtkPoints()
                         points.SetNumberOfPoints(vertex_count)
-                        
+
                         for i in range(vertex_count):
                             vertex = mesh_object.GetVertex(i)
-                            points.SetPoint(i, vertex.Coordinates[0], vertex.Coordinates[1], vertex.Coordinates[2])
-                        
+                            points.SetPoint(
+                                i,
+                                vertex.Coordinates[0],
+                                vertex.Coordinates[1],
+                                vertex.Coordinates[2],
+                            )
+
                         percent_mid = percent_start + 20
-                        keep_going, skip = progress.Update(percent_mid, _("Processing triangles for mesh {}/{}...").format(idx + 1, total_items))
+                        keep_going, skip = progress.Update(
+                            percent_mid,
+                            _("Processing triangles for mesh {}/{}...").format(
+                                idx + 1, total_items
+                            ),
+                        )
                         if not keep_going:
                             progress.Destroy()
                             return
                         wx.Yield()
-                        
+
                         triangles = vtkCellArray()
                         for i in range(triangle_count):
                             triangle_obj = mesh_object.GetTriangle(i)
@@ -714,40 +725,47 @@ class SurfaceManager:
                             triangle.GetPointIds().SetId(1, triangle_obj.Indices[1])
                             triangle.GetPointIds().SetId(2, triangle_obj.Indices[2])
                             triangles.InsertNextCell(triangle)
-                        
+
                         percent_end = percent_start + 40
-                        keep_going, skip = progress.Update(percent_end, _("Creating surface {}/{}...").format(idx + 1, total_items))
+                        keep_going, skip = progress.Update(
+                            percent_end, _("Creating surface {}/{}...").format(idx + 1, total_items)
+                        )
                         if not keep_going:
                             progress.Destroy()
                             return
                         wx.Yield()
-                        
+
                         polydata = vtkPolyData()
                         polydata.SetPoints(points)
                         polydata.SetPolys(triangles)
-                        
+
                         try:
                             surface_name = object_resource.GetName()
                             if not surface_name:
-                                surface_name = f"{base_name}_{idx + 1}" if total_items > 1 else base_name
+                                surface_name = (
+                                    f"{base_name}_{idx + 1}" if total_items > 1 else base_name
+                                )
                         except:
-                            surface_name = f"{base_name}_{idx + 1}" if total_items > 1 else base_name
-                        
+                            surface_name = (
+                                f"{base_name}_{idx + 1}" if total_items > 1 else base_name
+                            )
+
                         if polydata.GetNumberOfPoints() > 0:
-                            self.CreateSurfaceFromPolydata(polydata, name=surface_name, scalar=False)
-                        
+                            self.CreateSurfaceFromPolydata(
+                                polydata, name=surface_name, scalar=False
+                            )
+
                         idx += 1
-                
+
                 progress.Update(100, _("Import complete."))
                 wx.Yield()
                 progress.Destroy()
                 return
-                
+
             except Exception as e:
                 progress.Destroy()
                 wx.MessageBox(
-                    _("Failed to import 3MF file: {}").format(str(e)),
-                    _("Import surface error")
+                    _("Failed to import 3MF file: {}").format(str(e)), _("Import surface error")
                 )
                 return
         else:
@@ -1755,69 +1773,88 @@ class SurfaceManager:
                 if not _has_lib3mf:
                     progress.Destroy()
                     wx.MessageBox(
-                        "Lib3MF library not available. Cannot export 3MF files.",
-                        "Export error"
+                        "Lib3MF library not available. Cannot export 3MF files.", "Export error"
                     )
                     return
-                
+
                 try:
                     from ctypes import c_float, c_uint32
-                    
+
                     wrapper = lib3mf.Wrapper()
                     model = wrapper.CreateModel()
                     model.SetUnit(lib3mf.ModelUnit.MilliMeter)
-                    
+
                     keep_going, skip = progress.Update(20, "Preparing 3MF export...")
                     if not keep_going:
                         progress.Destroy()
                         return
                     wx.Yield()
-                    
+
                     visible_surfaces = []
                     for index in proj.surface_dict:
                         surface = proj.surface_dict[index]
                         if surface.is_shown:
-                            visible_surfaces.append((surface.polydata, surface.name, surface.colour, 1 - surface.transparency))
-                    
+                            visible_surfaces.append(
+                                (
+                                    surface.polydata,
+                                    surface.name,
+                                    surface.colour,
+                                    1 - surface.transparency,
+                                )
+                            )
+
                     if not visible_surfaces:
                         progress.Destroy()
                         return
-                    
+
                     num_surfaces = len(visible_surfaces)
-                    for surf_idx, (surf_polydata, surf_name, surf_colour, surf_opacity) in enumerate(visible_surfaces):
+                    for surf_idx, (
+                        surf_polydata,
+                        surf_name,
+                        surf_colour,
+                        surf_opacity,
+                    ) in enumerate(visible_surfaces):
                         percent_start = 20 + (surf_idx * 60 // num_surfaces)
-                        keep_going, skip = progress.Update(percent_start, f"Processing surface {surf_idx + 1}/{num_surfaces}...")
+                        keep_going, skip = progress.Update(
+                            percent_start, f"Processing surface {surf_idx + 1}/{num_surfaces}..."
+                        )
                         if not keep_going:
                             progress.Destroy()
                             return
                         wx.Yield()
-                        
+
                         if convert_to_world:
                             surf_polydata = self.ConvertPolydataToInv(surf_polydata, inverse=True)
-                        
+
                         points_vtk = surf_polydata.GetPoints()
                         n_points = points_vtk.GetNumberOfPoints()
-                        
+
                         points_array = vtk_to_numpy(points_vtk.GetData())
-                        
+
                         mesh_object = model.AddMeshObject()
                         mesh_object.SetName(surf_name if surf_name else f"Surface_{surf_idx + 1}")
-                        
+
                         for i in range(n_points):
                             pos = lib3mf.Position()
-                            pos.Coordinates = (c_float * 3)(float(points_array[i, 0]), float(points_array[i, 1]), float(points_array[i, 2]))
+                            pos.Coordinates = (c_float * 3)(
+                                float(points_array[i, 0]),
+                                float(points_array[i, 1]),
+                                float(points_array[i, 2]),
+                            )
                             mesh_object.AddVertex(pos)
-                        
+
                         polys = surf_polydata.GetPolys()
                         polys.InitTraversal()
                         id_list = vtkIdList()
-                        
+
                         while polys.GetNextCell(id_list):
                             if id_list.GetNumberOfIds() == 3:
                                 tri = lib3mf.Triangle()
-                                tri.Indices = (c_uint32 * 3)(id_list.GetId(0), id_list.GetId(1), id_list.GetId(2))
+                                tri.Indices = (c_uint32 * 3)(
+                                    id_list.GetId(0), id_list.GetId(1), id_list.GetId(2)
+                                )
                                 mesh_object.AddTriangle(tri)
-                        
+
                         color_group = model.AddColorGroup()
                         color = lib3mf.Color()
                         color.Red = int(surf_colour[0] * 255)
@@ -1825,34 +1862,28 @@ class SurfaceManager:
                         color.Blue = int(surf_colour[2] * 255)
                         color.Alpha = int(surf_opacity * 255)
                         color_id = color_group.AddColor(color)
-                        
-                        mesh_object.SetObjectLevelProperty(
-                            color_group.GetResourceID(),
-                            color_id
-                        )
-                        
+
+                        mesh_object.SetObjectLevelProperty(color_group.GetResourceID(), color_id)
+
                         model.AddBuildItem(mesh_object, wrapper.GetIdentityTransform())
-                    
+
                     keep_going, skip = progress.Update(85, "Writing 3MF file...")
                     if not keep_going:
                         progress.Destroy()
                         return
                     wx.Yield()
-                    
-                    writer_3mf = model.QueryWriter('3mf')
+
+                    writer_3mf = model.QueryWriter("3mf")
                     writer_3mf.WriteToFile(filename)
-                    
+
                     progress.Update(100, "Export complete.")
                     self.export_successful = True
                     wx.Yield()
                     return
-                    
+
                 except Exception as e:
                     progress.Destroy()
-                    wx.MessageBox(
-                        f"Failed to export 3MF file: {str(e)}",
-                        "Export error"
-                    )
+                    wx.MessageBox(f"Failed to export 3MF file: {str(e)}", "Export error")
                     return
 
             else:

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -685,7 +685,7 @@ class SurfaceManager:
                         # Calculate progress range for this surface (20% to 80% total range)
                         progress_range = 60  # Total progress range for all surfaces
                         surface_progress_chunk = progress_range / max(total_items, 1)
-                        
+
                         percent_start = int(20 + (idx * surface_progress_chunk))
                         keep_going, skip = progress.Update(
                             percent_start,

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -3178,6 +3178,7 @@ class Viewer(wx.Panel):
             const.FILETYPE_VTP,
             const.FILETYPE_PLY,
             const.FILETYPE_STL_ASCII,
+            const.FILETYPE_3MF,
         ):
             if _has_win32api:
                 utils.touch(filename)

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -1507,14 +1507,6 @@ class SurfaceButtonControlPanel(wx.Panel):
     def OnOpenMesh(self):
         filename = dlg.ShowImportMeshFilesDialog()
         if filename:
-            # Guard clause for 3MF format (not yet implemented)
-            if filename.lower().endswith(".3mf"):
-                wx.MessageBox(
-                    _(".3MF import is coming soon. This feature is under active development."),
-                    _("Feature Coming Soon"),
-                    wx.OK | wx.ICON_INFORMATION,
-                )
-                return
             Publisher.sendMessage("Import surface file", filename=filename)
 
     def OnExportSurface(self):

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -296,6 +296,7 @@ WILDCARD_MESH_FILES = (
     "Standard Polygon File Format (*.ply)|*.ply|"
     "Alias Wavefront Object (*.obj)|*.obj|"
     "VTK Polydata File Format (*.vtp)|*.vtp|"
+    "3D Manufacturing Format (*.3mf)|*.3mf|"
     "All files (*.*)|*.*"
 )
 WILDCARD_JSON_FILES = "JSON File format (*.json|*.json|All files (*.*)|*.*"

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -54,6 +54,7 @@ WILDCARD_SAVE_3D = (
     "VRML (*.vrml)|*.vrml|"
     "VTK PolyData (*.vtp)|*.vtp|"
     "Wavefront (*.obj)|*.obj|"
+    "3MF (*.3mf)|*.3mf|"
     "X3D (*.x3d)|*.x3d"
 )
 
@@ -66,7 +67,8 @@ INDEX_TO_TYPE_3D = {
     5: const.FILETYPE_VRML,
     6: const.FILETYPE_VTP,
     7: const.FILETYPE_OBJ,
-    8: const.FILETYPE_X3D,
+    8: const.FILETYPE_3MF,
+    9: const.FILETYPE_X3D,
 }
 INDEX_TO_EXTENSION = {
     0: "iv",
@@ -77,7 +79,8 @@ INDEX_TO_EXTENSION = {
     5: "vrml",
     6: "vtp",
     7: "obj",
-    8: "x3d",
+    8: "3mf",
+    9: "x3d",
 }
 
 WILDCARD_SAVE_2D = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = [
 dependencies = [
     "h5py==3.11.0",
     "imageio==2.34.2",
+    "lib3mf==2.3.2",
     "matplotlib==3.9.0",
     "nibabel==5.2.1",
     "numpy==1.26.4",
@@ -189,6 +190,7 @@ module = [
     'sigar.*',
     'numpy.*',
     'invesalius_rs.*',
+    'lib3mf.*',
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ nibabel==5.2.1
 scikit-image==0.24.0
 python-gdcm==3.0.24.1
 vtk==9.3.0
+lib3mf==2.3.2
 
 # Machine Learning
 torch>=2.3.1

--- a/tests/test_3mf.py
+++ b/tests/test_3mf.py
@@ -331,3 +331,26 @@ def test_vertex_coordinates_preserved(tmp_path: Path):
         ]
     
     assert np.allclose(original_points, imported_points, atol=1e-5)
+
+
+def test_large_surface_count_progress_calculation():
+    """Test that progress calculations stay within 0-100 for many surfaces."""
+    # Test the progress calculation logic for 25 surfaces
+    total_items = 25
+    progress_range = 60
+    surface_progress_chunk = progress_range / max(total_items, 1)
+    
+    for idx in range(total_items):
+        percent_start = int(20 + (idx * surface_progress_chunk))
+        percent_mid = int(20 + (idx + 0.4) * surface_progress_chunk)
+        percent_end = int(20 + (idx + 0.8) * surface_progress_chunk)
+        
+        # All values must be <= 80 (since 80-100 reserved for final processing)
+        assert 20 <= percent_start <= 80, f"Surface {idx}: start={percent_start} out of range"
+        assert 20 <= percent_mid <= 80, f"Surface {idx}: mid={percent_mid} out of range"
+        assert 20 <= percent_end <= 80, f"Surface {idx}: end={percent_end} out of range"
+    
+    # Verify last surface reaches close to 80%
+    last_idx = total_items - 1
+    last_end = int(20 + (last_idx + 0.8) * surface_progress_chunk)
+    assert 78 <= last_end <= 80, f"Last surface end={last_end} should be near 80%"

--- a/tests/test_3mf.py
+++ b/tests/test_3mf.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for 3MF import/export functionality.
+Tests lib3mf integration directly without full GUI dependencies.
+"""
+
+import os
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from ctypes import c_float, c_uint32
+from vtkmodules.util import numpy_support
+from vtkmodules.vtkCommonCore import vtkPoints, vtkIdList
+from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData, vtkTriangle
+
+# Check if lib3mf is available
+try:
+    import lib3mf
+    HAS_LIB3MF = True
+except ImportError:
+    HAS_LIB3MF = False
+
+pytestmark = pytest.mark.skipif(not HAS_LIB3MF, reason="lib3mf not available")
+
+
+def make_simple_triangle() -> vtkPolyData:
+    """Create a simple polydata with a single triangle."""
+    points = vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 0.0)
+    points.InsertNextPoint(1.0, 0.0, 0.0)
+    points.InsertNextPoint(0.0, 1.0, 0.0)
+
+    triangle = vtkTriangle()
+    triangle.GetPointIds().SetId(0, 0)
+    triangle.GetPointIds().SetId(1, 1)
+    triangle.GetPointIds().SetId(2, 2)
+
+    triangles = vtkCellArray()
+    triangles.InsertNextCell(triangle)
+
+    polydata = vtkPolyData()
+    polydata.SetPoints(points)
+    polydata.SetPolys(triangles)
+
+    return polydata
+
+
+def export_polydata_to_3mf(polydata: vtkPolyData, filename: str, name: str = "Test",
+                          color: tuple = (1.0, 0.0, 0.0), alpha: int = 255):
+    """Helper to export a vtkPolyData to 3MF using lib3mf."""
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    model.SetUnit(lib3mf.ModelUnit.MilliMeter)
+    
+    mesh_object = model.AddMeshObject()
+    mesh_object.SetName(name)
+    
+    # Add vertices
+    points_vtk = polydata.GetPoints()
+    for i in range(points_vtk.GetNumberOfPoints()):
+        pos = lib3mf.Position()
+        pt = points_vtk.GetPoint(i)
+        pos.Coordinates = (c_float * 3)(float(pt[0]), float(pt[1]), float(pt[2]))
+        mesh_object.AddVertex(pos)
+    
+    # Add triangles
+    polys = polydata.GetPolys()
+    polys.InitTraversal()
+    id_list = vtkIdList()
+    while polys.GetNextCell(id_list):
+        if id_list.GetNumberOfIds() == 3:
+            tri = lib3mf.Triangle()
+            tri.Indices = (c_uint32 * 3)(
+                id_list.GetId(0), id_list.GetId(1), id_list.GetId(2)
+            )
+            mesh_object.AddTriangle(tri)
+    
+    # Add color
+    color_group = model.AddColorGroup()
+    color_obj = lib3mf.Color()
+    color_obj.Red = int(color[0] * 255)
+    color_obj.Green = int(color[1] * 255)
+    color_obj.Blue = int(color[2] * 255)
+    color_obj.Alpha = alpha
+    color_id = color_group.AddColor(color_obj)
+    mesh_object.SetObjectLevelProperty(color_group.GetResourceID(), color_id)
+    
+    model.AddBuildItem(mesh_object, wrapper.GetIdentityTransform())
+    writer = model.QueryWriter("3mf")
+    writer.WriteToFile(filename)
+
+
+def test_export_creates_valid_file(tmp_path: Path):
+    """Test that exporting creates a valid non-empty 3MF file."""
+    filename = tmp_path / "test.3mf"
+    polydata = make_simple_triangle()
+    
+    export_polydata_to_3mf(polydata, str(filename))
+    
+    assert os.path.exists(filename), "3MF file was not created"
+    assert os.path.getsize(filename) > 0, "3MF file is empty"
+    assert zipfile.is_zipfile(filename), "3MF file is not a valid zip archive"
+
+
+def test_geometry_roundtrip(tmp_path: Path):
+    """Test that vertex and triangle counts are preserved."""
+    filename = tmp_path / "roundtrip.3mf"
+    polydata = make_simple_triangle()
+    
+    original_vertices = polydata.GetNumberOfPoints()
+    original_triangles = polydata.GetNumberOfCells()
+    
+    export_polydata_to_3mf(polydata, str(filename))
+    
+    # Import back
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    reader = model.QueryReader("3mf")
+    reader.ReadFromFile(str(filename))
+    
+    build_items = model.GetBuildItems()
+    assert build_items.Count() > 0
+    
+    build_items.MoveNext()
+    build_item = build_items.GetCurrent()
+    object_resource = build_item.GetObjectResource()
+    mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
+    
+    assert mesh_object.GetVertexCount() == original_vertices
+    assert mesh_object.GetTriangleCount() == original_triangles
+
+
+def test_color_roundtrip(tmp_path: Path):
+    """Test that RGBA color values are preserved."""
+    filename = tmp_path / "color_test.3mf"
+    polydata = make_simple_triangle()
+    original_color = (1.0, 0.5, 0.25)
+    
+    export_polydata_to_3mf(polydata, str(filename), color=original_color)
+    
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    reader = model.QueryReader("3mf")
+    reader.ReadFromFile(str(filename))
+    
+    build_items = model.GetBuildItems()
+    build_items.MoveNext()
+    build_item = build_items.GetCurrent()
+    object_resource = build_item.GetObjectResource()
+    mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
+    
+    property_result = mesh_object.GetObjectLevelProperty()
+    assert property_result and len(property_result) == 3 and property_result[2]
+    
+    resource_id, property_id, has_property = property_result
+    color_group = model.GetColorGroupByID(resource_id)
+    color = color_group.GetColor(property_id)
+    
+    imported_color = (color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0)
+    assert np.allclose(imported_color, original_color, atol=1.0 / 255.0)
+
+
+def test_alpha_roundtrip(tmp_path: Path):
+    """Test that transparency (alpha) is preserved."""
+    filename = tmp_path / "alpha_test.3mf"
+    polydata = make_simple_triangle()
+    original_alpha = 128  # 50% transparent
+    
+    export_polydata_to_3mf(polydata, str(filename), alpha=original_alpha)
+    
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    reader = model.QueryReader("3mf")
+    reader.ReadFromFile(str(filename))
+    
+    build_items = model.GetBuildItems()
+    build_items.MoveNext()
+    build_item = build_items.GetCurrent()
+    object_resource = build_item.GetObjectResource()
+    mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
+    
+    property_result = mesh_object.GetObjectLevelProperty()
+    resource_id, property_id, has_property = property_result
+    color_group = model.GetColorGroupByID(resource_id)
+    color = color_group.GetColor(property_id)
+    
+    assert color.Alpha == original_alpha
+
+
+def test_multi_surface_export(tmp_path: Path):
+    """Test exporting multiple surfaces creates correct number of mesh objects."""
+    filename = tmp_path / "multi.3mf"
+    
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    model.SetUnit(lib3mf.ModelUnit.MilliMeter)
+    
+    # Create 3 meshes
+    for i in range(3):
+        polydata = make_simple_triangle()
+        mesh_object = model.AddMeshObject()
+        mesh_object.SetName(f"Surface_{i}")
+        
+        points_vtk = polydata.GetPoints()
+        for j in range(points_vtk.GetNumberOfPoints()):
+            pos = lib3mf.Position()
+            pt = points_vtk.GetPoint(j)
+            pos.Coordinates = (c_float * 3)(float(pt[0]), float(pt[1]), float(pt[2]))
+            mesh_object.AddVertex(pos)
+        
+        polys = polydata.GetPolys()
+        polys.InitTraversal()
+        id_list = vtkIdList()
+        while polys.GetNextCell(id_list):
+            if id_list.GetNumberOfIds() == 3:
+                tri = lib3mf.Triangle()
+                tri.Indices = (c_uint32 * 3)(
+                    id_list.GetId(0), id_list.GetId(1), id_list.GetId(2)
+                )
+                mesh_object.AddTriangle(tri)
+        
+        model.AddBuildItem(mesh_object, wrapper.GetIdentityTransform())
+    
+    writer = model.QueryWriter("3mf")
+    writer.WriteToFile(str(filename))
+    
+    # Verify
+    wrapper2 = lib3mf.Wrapper()
+    model2 = wrapper2.CreateModel()
+    reader = model2.QueryReader("3mf")
+    reader.ReadFromFile(str(filename))
+    
+    assert model2.GetBuildItems().Count() == 3
+
+
+def test_duplicate_name_handling():
+    """Test that the deduplication logic works correctly."""
+    from collections import Counter
+    
+    # Simulate visible_surfaces list
+    visible_surfaces = [
+        (None, "Bone", (1, 0, 0), 1.0),
+        (None, "Bone", (0, 1, 0), 1.0),
+        (None, "Skin", (0, 0, 1), 1.0),
+    ]
+    
+    # Apply deduplication logic from surface.py
+    for i, (polydata, name, colour, opacity) in enumerate(visible_surfaces):
+        if not name:
+            visible_surfaces[i] = (polydata, f"Surface_{i + 1}", colour, opacity)
+    
+    names = [item[1] for item in visible_surfaces]
+    name_counts = Counter(names)
+    duplicates = {name: 0 for name, count in name_counts.items() if count > 1}
+    
+    for i, (polydata, name, colour, opacity) in enumerate(visible_surfaces):
+        if name in duplicates:
+            duplicates[name] += 1
+            new_name = f"{name}_{duplicates[name]:02d}"
+            visible_surfaces[i] = (polydata, new_name, colour, opacity)
+    
+    names_after = [item[1] for item in visible_surfaces]
+    assert "Bone_01" in names_after
+    assert "Bone_02" in names_after
+    assert "Skin" in names_after
+    assert len(names_after) == len(set(names_after))
+
+
+def test_degenerate_triangle_filtering():
+    """Test that degenerate triangles are filtered correctly."""
+    test_cases = [
+        ((0, 1, 2), True),   # Valid
+        ((0, 0, 2), False),  # v0==v1
+        ((0, 1, 1), False),  # v1==v2
+        ((2, 1, 2), False),  # v0==v2
+        ((3, 3, 3), False),  # All same
+    ]
+    
+    for (v0, v1, v2), expected_valid in test_cases:
+        is_valid = (v0 != v1 and v1 != v2 and v0 != v2)
+        assert is_valid == expected_valid, f"Failed for ({v0}, {v1}, {v2})"
+
+
+def test_malformed_file_import(tmp_path: Path):
+    """Test that importing an invalid 3MF raises an exception."""
+    invalid_file = tmp_path / "invalid.3mf"
+    with zipfile.ZipFile(invalid_file, "w") as zf:
+        zf.writestr("invalid.xml", "<invalid/>")
+    
+    try:
+        wrapper = lib3mf.Wrapper()
+        model = wrapper.CreateModel()
+        reader = model.QueryReader("3mf")
+        reader.ReadFromFile(str(invalid_file))
+    except Exception:
+        assert True  # Expected
+        return
+    
+    # If no exception, that's okay - lib3mf might handle gracefully
+
+
+def test_vertex_coordinates_preserved(tmp_path: Path):
+    """Test that vertex coordinates are accurately preserved."""
+    filename = tmp_path / "coords_test.3mf"
+    polydata = make_simple_triangle()
+    original_points = numpy_support.vtk_to_numpy(polydata.GetPoints().GetData())
+    
+    export_polydata_to_3mf(polydata, str(filename))
+    
+    wrapper = lib3mf.Wrapper()
+    model = wrapper.CreateModel()
+    reader = model.QueryReader("3mf")
+    reader.ReadFromFile(str(filename))
+    
+    build_items = model.GetBuildItems()
+    build_items.MoveNext()
+    build_item = build_items.GetCurrent()
+    object_resource = build_item.GetObjectResource()
+    mesh_object = model.GetMeshObjectByID(object_resource.GetResourceID())
+    
+    vertex_count = mesh_object.GetVertexCount()
+    imported_points = np.zeros((vertex_count, 3))
+    
+    for i in range(vertex_count):
+        vertex = mesh_object.GetVertex(i)
+        imported_points[i] = [
+            vertex.Coordinates[0],
+            vertex.Coordinates[1],
+            vertex.Coordinates[2],
+        ]
+    
+    assert np.allclose(original_points, imported_points, atol=1e-5)


### PR DESCRIPTION
# Add 3MF File Format Import/Export Support (GSoC 2026)

## Summary

This PR adds support for importing and exporting **3MF (3D Manufacturing Format)** files in InVesalius.

3MF is a modern file format widely used by 3D printing software such as OrcaSlicer, Bambu Studio, PrusaSlicer, and Cura. Unlike STL, it supports multiple meshes, object metadata, and color information, making it a better fit for medical models generated in InVesalius.

This implementation integrates 3MF into the existing surface import/export workflow while maintaining full backward compatibility with current functionality.

---

## Motivation

Currently, reconstructed anatomical models exported from InVesalius are commonly saved as STL files. While STL is widely supported, it has several limitations:

- Surface colors are lost during export.
- Multiple surfaces cannot be preserved as separate named objects.
- Metadata such as surface names is not retained.
- Modern slicer workflows increasingly rely on 3MF as the preferred exchange format.

Adding 3MF support enables a more complete workflow from medical image reconstruction to 3D printing while preserving information that would otherwise be lost.

---

## Features

### Export

- Export surfaces to `.3mf`
- Export multiple visible surfaces into a single 3MF file
- Preserve surface names
- Preserve RGBA color information
- Support world-coordinate exports
- Progress dialog with cancellation support
- Millimeter unit specification for 3D printing compatibility

### Import

- Import `.3mf` files containing one or more meshes
- Restore object names from 3MF metadata
- Progress feedback during loading
- Graceful handling when `lib3mf` is unavailable
- Coordinate behavior consistent with existing STL import/export workflow

---

## Implementation Overview

### Export Flow

```text
task_exporter.py
    ↓
surface.py :: OnExportSurface()
    ↓
surface.py :: _export_surface()
    ↓
lib3mf
```

### Import Flow

```text
data_notebook.py
    ↓
surface.py :: CreateSurfaceFromFile()
    ↓
lib3mf
    ↓
CreateSurfaceFromPolydata()
```

### Design Decisions

- Coordinates are written and read directly from VTK data without additional transformations, matching existing STL behavior.
- A dedicated export path is used for 3MF generation, avoiding interference with existing VTK writers.
- Iterator-based mesh traversal follows the lib3mf API design.
- Long-running operations provide progress feedback and cancellation support.
- The feature is implemented as an optional dependency and does not affect existing workflows when unavailable.

---

## Files Modified

| File | Description |
|--------|------------|
| `constants.py` | Added 3MF file type constant |
| `surface.py` | Implemented 3MF import/export functionality |
| `viewer_volume.py` | Added 3MF handling updates |
| `dialogs.py` | Added 3MF file filters |
| `data_notebook.py` | Enabled 3MF import workflow |
| `task_exporter.py` | Added 3MF export option |
| `requirements.txt` | Added lib3mf dependency |
| `docs/3mf-support.md` | Added documentation |

---

## Testing

### Export Validation

-  Single-surface export
-  Surface name preservation
-  Color preservation
-  Dimension verification
-  Progress dialog functionality
-  Export cancellation handling

### Import Validation

- Single-mesh import
- Metadata-based name restoration
- Fallback naming behavior
- Progress dialog functionality
- Missing dependency error handling

### Round-Trip Validation

- Export → Import geometry consistency
- Export → Import dimension consistency
- Exported files verified in OrcaSlicer
- Color information preserved correctly

### Validation Results

Exported 3MF files were successfully opened and verified in OrcaSlicer:

- Correct dimensions preserved
- Correct orientation preserved
- Triangle counts preserved
- Multiple surfaces retained as separate objects
- Surface colors preserved correctly

---


## Backward Compatibility

This change is fully backward compatible.

No existing functionality has been removed or modified, and users who do not require 3MF support can continue using InVesalius as before.

---

