### PR TITLE
feat: Centralised Undo/Redo System via Command Pattern

### DIFF
--- a/invesalius/data/commands.py
+++ b/invesalius/data/commands.py
@@ -1,3 +1,21 @@
+# --------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------------
 import abc
 from invesalius.pubsub import pub as Publisher
 

--- a/invesalius/data/commands.py
+++ b/invesalius/data/commands.py
@@ -1,0 +1,132 @@
+import abc
+from invesalius.pubsub import pub as Publisher
+
+class Command(abc.ABC):
+    @abc.abstractmethod
+    def execute(self):
+        pass
+
+    @abc.abstractmethod
+    def undo(self):
+        pass
+
+    @abc.abstractmethod
+    def get_name(self) -> str:
+        pass
+
+
+class AddMaskCommand(Command):
+    def __init__(self, mask):
+        self.mask = mask
+        self.index = None
+
+    def execute(self):
+        from invesalius.project import Project
+        proj = Project()
+        if self.index is None:
+            self.index = proj.AddMask(self.mask)
+        else:
+            proj.InsertMask(self.index, self.mask)
+        
+        # Need to update UI about the newly added mask
+        Publisher.sendMessage('Add mask', mask=self.mask)
+
+    def undo(self):
+        from invesalius.project import Project
+        proj = Project()
+        # RemoveMask must not cleanup the VTK/memory properties so we can redo
+        proj.RemoveMask(self.index, cleanup=False)
+        Publisher.sendMessage('Remove mask', index=self.index)
+
+    def get_name(self) -> str:
+        return "Add Mask"
+
+
+class RemoveMaskCommand(Command):
+    def __init__(self, index, mask):
+        self.index = index
+        self.mask = mask
+
+    def execute(self):
+        from invesalius.project import Project
+        proj = Project()
+        proj.RemoveMask(self.index, cleanup=False)
+        Publisher.sendMessage('Remove mask', index=self.index)
+
+    def undo(self):
+        from invesalius.project import Project
+        proj = Project()
+        proj.InsertMask(self.index, self.mask)
+        Publisher.sendMessage('Add mask', mask=self.mask)
+
+    def get_name(self) -> str:
+        return "Remove Mask"
+
+
+class DuplicateMaskCommand(Command):
+    def __init__(self, original_index, new_mask):
+        self.original_index = original_index
+        self.new_mask = new_mask
+        self.new_index = None
+
+    def execute(self):
+        from invesalius.project import Project
+        proj = Project()
+        if self.new_index is None:
+            self.new_index = proj.AddMask(self.new_mask)
+        else:
+            proj.InsertMask(self.new_index, self.new_mask)
+        Publisher.sendMessage('Add mask', mask=self.new_mask)
+
+    def undo(self):
+        from invesalius.project import Project
+        proj = Project()
+        proj.RemoveMask(self.new_index, cleanup=False)
+        Publisher.sendMessage('Remove mask', index=self.new_index)
+
+    def get_name(self) -> str:
+        return "Duplicate Mask"
+
+
+class MaskEditCommand(Command):
+    def __init__(self, mask, index, orientation, array, p_array, clean=False):
+        self.mask = mask
+        # Push the node to the mask's internal edition history
+        self.mask.history.new_node(index, orientation, array, p_array, clean)
+        self.actual_slices = None
+        self._is_first_execute = True
+
+    def execute(self):
+        if self._is_first_execute:
+            # First time, the edit is already applied in UI/Slice before this command is created.
+            self._is_first_execute = False
+            return
+            
+        # For redo, we actually need to apply it.
+        if self.actual_slices is not None:
+            self.mask.redo_history(self.actual_slices)
+            self._discard_buffers_and_reload()
+
+    def undo(self):
+        import invesalius.data.slice_ as slc
+        s = slc.Slice()
+        buffer_slices = s.buffer_slices
+        self.actual_slices = {
+            "AXIAL": buffer_slices["AXIAL"].index,
+            "CORONAL": buffer_slices["CORONAL"].index,
+            "SAGITAL": buffer_slices["SAGITAL"].index,
+            "VOLUME": 0,
+        }
+        self.mask.undo_history(self.actual_slices)
+        self._discard_buffers_and_reload()
+
+    def _discard_buffers_and_reload(self):
+        import invesalius.data.slice_ as slc
+        s = slc.Slice()
+        for o in s.buffer_slices:
+            s.buffer_slices[o].discard_mask()
+            s.buffer_slices[o].discard_vtk_mask()
+        Publisher.sendMessage("Reload actual slice")
+
+    def get_name(self) -> str:
+        return "Mask Edit"

--- a/invesalius/data/history_manager.py
+++ b/invesalius/data/history_manager.py
@@ -1,3 +1,21 @@
+# --------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------------
 import wx
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import Singleton

--- a/invesalius/data/history_manager.py
+++ b/invesalius/data/history_manager.py
@@ -1,0 +1,86 @@
+import wx
+from invesalius.pubsub import pub as Publisher
+from invesalius.utils import Singleton
+
+class HistoryManager(metaclass=Singleton):
+    def __init__(self, max_history_size=50):
+        self._undo_stack = []
+        self._redo_stack = []
+        self._max_history_size = max_history_size
+        self._bind_events()
+
+    def _bind_events(self):
+        Publisher.subscribe(self.undo, "Undo edition")
+        Publisher.subscribe(self.redo, "Redo edition")
+        Publisher.subscribe(self.clear, "Close project data")
+
+    def execute_command(self, command):
+        """
+        Executes a command and adds it to the undo stack.
+        Clears the redo stack.
+        """
+        try:
+            command.execute()
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return False
+
+        self._undo_stack.append(command)
+        if len(self._undo_stack) > self._max_history_size:
+            self._undo_stack.pop(0)
+
+        self._redo_stack.clear()
+        self._update_ui()
+        return True
+
+    def undo(self):
+        if not self._undo_stack:
+            return
+
+        command = self._undo_stack.pop()
+        try:
+            command.undo()
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            # If undo fails, we might be in an inconsistent state
+            self._undo_stack.clear()
+            self._redo_stack.clear()
+            self._update_ui()
+            return
+
+        self._redo_stack.append(command)
+        self._update_ui()
+
+    def redo(self):
+        if not self._redo_stack:
+            return
+
+        command = self._redo_stack.pop()
+        try:
+            command.execute()
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            self._undo_stack.clear()
+            self._redo_stack.clear()
+            self._update_ui()
+            return
+
+        self._undo_stack.append(command)
+        self._update_ui()
+
+    def clear(self):
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+        self._update_ui()
+
+    def _update_ui(self):
+        undo_label = f"Undo {self._undo_stack[-1].get_name()}" if self._undo_stack else "Undo"
+        redo_label = f"Redo {self._redo_stack[-1].get_name()}" if self._redo_stack else "Redo"
+        
+        Publisher.sendMessage("Update undo label", label=undo_label)
+        Publisher.sendMessage("Update redo label", label=redo_label)
+        Publisher.sendMessage("Enable undo", value=bool(self._undo_stack))
+        Publisher.sendMessage("Enable redo", value=bool(self._redo_stack))

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -265,7 +265,10 @@ class Mask:
             Publisher.sendMessage("Render volume viewer")
 
     def save_history(self, index, orientation, array, p_array, clean=False):
-        self.history.new_node(index, orientation, array, p_array, clean)
+        from invesalius.data.commands import MaskEditCommand
+        from invesalius.data.history_manager import HistoryManager
+        cmd = MaskEditCommand(self, index, orientation, array, p_array, clean)
+        HistoryManager().execute_command(cmd)
 
     def undo_history(self, actual_slices):
         self.history.undo(self.matrix, actual_slices)

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -360,6 +360,9 @@ class Slice(metaclass=utils.Singleton):
 
     def OnRemoveMasks(self, mask_indexes):
         proj = Project()
+        from invesalius.data.commands import RemoveMaskCommand
+        from invesalius.data.history_manager import HistoryManager
+        
         for item in mask_indexes:
             # if the deleted mask is the current mask, cleans the current mask
             # and discard from buffer all datas related to mask.
@@ -372,11 +375,16 @@ class Slice(metaclass=utils.Singleton):
 
                 Publisher.sendMessage("Show mask", index=item, value=False)
                 Publisher.sendMessage("Reload actual slice")
-            proj.RemoveMask(item)
+            
+            cmd = RemoveMaskCommand(item, proj.mask_dict[item])
+            HistoryManager().execute_command(cmd)
 
     def OnDuplicateMasks(self, mask_indexes):
         proj = Project()
         mask_dict = proj.mask_dict
+        from invesalius.data.commands import DuplicateMaskCommand
+        from invesalius.data.history_manager import HistoryManager
+
         for index in mask_indexes:
             original_mask = mask_dict[index]
             # compute copy name
@@ -384,8 +392,12 @@ class Slice(metaclass=utils.Singleton):
             names_list = [mask_dict[i].name for i in mask_dict.keys()]
             new_name = utils.next_copy_name(name, names_list)
 
-            copy_mask = original_mask.copy(new_name)
-            self._add_mask_into_proj(copy_mask)
+            # copy dictionary
+            new_mask = original_mask.copy()
+            new_mask.name = new_name
+            
+            cmd = DuplicateMaskCommand(index, new_mask)
+            HistoryManager().execute_command(cmd)
 
     def OnEnableStyle(self, style):
         if style in const.SLICE_STYLES:
@@ -1564,12 +1576,12 @@ class Slice(metaclass=utils.Singleton):
             mask: A mask object.
             show: indicate if the mask will be shown.
         """
-        proj = Project()
-        index = proj.AddMask(mask)
-        mask.index = index
-
-        ## update gui related to mask
-        Publisher.sendMessage("Add mask", mask=mask)
+    def _add_mask_into_proj(self, mask, show=True):
+        from invesalius.data.commands import AddMaskCommand
+        from invesalius.data.history_manager import HistoryManager
+        
+        cmd = AddMaskCommand(mask)
+        HistoryManager().execute_command(cmd)
 
         if show:
             Publisher.sendMessage("Change mask selected", index=mask.index)

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -1427,6 +1427,8 @@ class MenuBar(wx.MenuBar):
         sub(self.OnEnableState, "Enable state project")
         sub(self.OnEnableUndo, "Enable undo")
         sub(self.OnEnableRedo, "Enable redo")
+        sub(self.OnUpdateUndoLabel, "Update undo label")
+        sub(self.OnUpdateRedoLabel, "Update redo label")
         sub(self.OnEnableGotoCoord, "Enable Go-to-Coord")
         sub(self.OnEnableNavigation, "Navigation status")
 
@@ -1815,6 +1817,16 @@ class MenuBar(wx.MenuBar):
             self.FindItemById(wx.ID_REDO).Enable(True)
         else:
             self.FindItemById(wx.ID_REDO).Enable(False)
+
+    def OnUpdateUndoLabel(self, label):
+        item = self.FindItemById(wx.ID_UNDO)
+        if item:
+            item.SetItemLabel(f"{label}\tCtrl+Z")
+
+    def OnUpdateRedoLabel(self, label):
+        item = self.FindItemById(wx.ID_REDO)
+        if item:
+            item.SetItemLabel(f"{label}\tCtrl+Y")
 
     def OnEnableGotoCoord(self, status=True):
         """

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -130,13 +130,14 @@ class Project(metaclass=Singleton):
         mask.index = index
         return index
 
-    def RemoveMask(self, index: int) -> None:
+    def RemoveMask(self, index: int, cleanup: bool = True) -> None:
         new_dict = TwoWaysDictionary()
         # Iterate safely over a snapshot of items
         for i, mask in self.mask_dict.items():
             if i == index:
                 # Clean up the removed mask
-                mask.cleanup()
+                if cleanup:
+                    mask.cleanup()
                 continue
             # Compute the new index and update mask
             new_i = i if i < index else i - 1
@@ -145,6 +146,19 @@ class Project(metaclass=Singleton):
             if hasattr(mask, "index"):
                 mask.index = new_i
         # Replace the dictionary with the rebuilt one
+        self.mask_dict = new_dict
+
+    def InsertMask(self, index: int, mask: "Mask") -> None:
+        new_dict = TwoWaysDictionary()
+        # Shift masks at or after the index by +1
+        for i, m in self.mask_dict.items():
+            new_i = i if i < index else i + 1
+            new_dict[new_i] = m
+            if hasattr(m, "index"):
+                m.index = new_i
+        # Insert the mask at the correct index
+        mask.index = index
+        new_dict[index] = mask
         self.mask_dict = new_dict
 
     def GetMask(self, index):


### PR DESCRIPTION
This PR implements a robust Centralised Undo/Redo System for InVesalius 3, resolving the "Dual-Stack Problem" encountered in previous attempts (such as PR #1058) and addressing Issue #1062.

By utilizing the standard Command Pattern and unifying the history stack, this PR ensures that all operations (mask creation, duplication, deletion, and importantly, pixel-level voxel editing) are executed and reversed in strictly chronological order.

Changes Included
HistoryManager (Singleton): Tracks all project state modifications in a unified stack, guaranteeing safe memory handling (max 50 operations) and emitting PubSub events to update GUI menu labels dynamically (e.g., "Undo Add Mask", "Undo Mask Edit").
Commands Architecture: Created AddMaskCommand, RemoveMaskCommand, DuplicateMaskCommand, and MaskEditCommand.
Project Re-indexing: Modified Project.RemoveMask with a non-destructive cleanup=False parameter, allowing deleted masks to stay in memory to be seamlessly recovered upon Undo. Introduced Project.InsertMask to restore deleted masks to their exact previous dictionary indices.
Pixel-Level Stack Unification: Instead of isolating mask brushing/painting into an independent EditionHistory stack that desynchronizes with the global state, pixel edits are now wrapped in a MaskEditCommand and dispatched to the global HistoryManager.
This prevents the race-condition bug from previous PRs where pressing Ctrl+Z could accidentally delete an entire mask instead of undoing the latest brush stroke!

Issue Resolved
Closes #1062
