### PR TITLE
Fix incorrect parameter documentation in viewer_slice and mep_visualizer

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -923,12 +923,12 @@ class Viewer(wx.Panel):
     def get_slice_pixel_coord_by_world_pos(self, wx, wy, wz):
         """
         Given the (wx, wy, wz) world position returns the pixel coordinate
-        of the slice at (that mx, my) position.
+        of the slice at that position.
 
         Parameters:
-            mx (int): x position.
-            my (int): y position
-            picker: the picker used to get calculate the pixel coordinate.
+            wx (float): x position in world coordinates.
+            wy (float): y position in world coordinates.
+            wz (float): z position in world coordinates.
 
         Returns:
             voxel_coordinate (x, y): voxel coordinate inside the matrix. Can

--- a/invesalius/data/visualization/mep_visualizer.py
+++ b/invesalius/data/visualization/mep_visualizer.py
@@ -336,11 +336,8 @@ class MEPVisualizer:
 
     def UpdateMEPPoints(self):
         """
-        Updates or creates the point data with MEP values from a list of markers.
-
-        Args:
-            markers (List[Marker]): The list of marker objects to add/update points for.
-            clear_old (bool, default=False): If True, clears all existing points before updating.
+        Updates or creates the point data with MEP values from the active
+        marker list.
         """
         if not self._config_params["mep_enabled"]:
             return
@@ -387,11 +384,14 @@ class MEPVisualizer:
 
     def UpdateMEPPointsFromBrainTargets(self, marker_target, brain_target_list):
         """
-        Updates or creates the point data with MEP values from a list of markers.
+        Updates or creates the point data with MEP values from a list of brain
+        targets.
 
         Args:
-            markers (List[Marker]): The list of marker objects to add/update points for.
-            clear_old (bool, default=False): If True, clears all existing points before updating.
+            marker_target (Marker): The coil marker whose orientation is used
+                to position the MEP points.
+            brain_target_list (List[Marker]): The list of brain target markers
+                to add or update points for.
         """
         if not self._config_params["mep_enabled"]:
             return


### PR DESCRIPTION
### Description

Three docstrings documented parameters that do not match their function signatures:

- `get_slice_pixel_coord_by_world_pos` (`invesalius/data/viewer_slice.py`) documented `mx`/`my`/`picker` (apparently copied from `get_coord_inside_volume`), but the method takes `wx`/`wy`/`wz` world coordinates.
- `UpdateMEPPoints` (`invesalius/data/visualization/mep_visualizer.py`) takes no arguments (it derives the markers internally via `_FilterMarkers`), but documented `markers`/`clear_old`.
- `UpdateMEPPointsFromBrainTargets` documented `markers`/`clear_old` instead of its actual `marker_target`/`brain_target_list` parameters.

This corrects the documented parameter names and descriptions to match each signature. Documentation-only change.
