### PR TITLE
feat: Hook up Python UI to Rust Ray-Casting algorithm for 3D Polygon …

### DIFF
--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -4,16 +4,15 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import wx
-
 from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slc
 import invesalius.session as ses
+import invesalius_rs
 from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
-import invesalius_rs
 from invesalius_rs import mask_cut
 
 
@@ -155,12 +154,16 @@ class Mask3DEditorState:
                 coord.SetValue(world_pt)
                 px, py = coord.GetComputedDoubleDisplayValue(renderer)
                 display_points.append((px, py))
-            
+
             # Use the high-performance Rust Ray-Casting engine instead of skimage!
-            poly_array = np.array(display_points, dtype=np.float64) if display_points else np.zeros((0, 2), dtype=np.float64)
+            poly_array = (
+                np.array(display_points, dtype=np.float64)
+                if display_points
+                else np.zeros((0, 2), dtype=np.float64)
+            )
             mask = invesalius_rs.polygon2mask_rs((w, h), poly_array)
             filters.append(mask)
-            
+
         return filters
 
     def CutMaskFromPolygons(self):

--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -4,7 +4,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import wx
-from skimage.draw import polygon2mask
+
 from vtkmodules.vtkRenderingCore import vtkCoordinate
 
 import invesalius.constants as const
@@ -13,6 +13,7 @@ import invesalius.session as ses
 from invesalius.data.polygon_select import PolygonSelectCanvas
 from invesalius.pubsub import pub as Publisher
 from invesalius.utils import vtkarray_to_numpy
+import invesalius_rs
 from invesalius_rs import mask_cut
 
 
@@ -154,7 +155,12 @@ class Mask3DEditorState:
                 coord.SetValue(world_pt)
                 px, py = coord.GetComputedDoubleDisplayValue(renderer)
                 display_points.append((px, py))
-            filters.append(polygon2mask((w, h), display_points))
+            
+            # Use the high-performance Rust Ray-Casting engine instead of skimage!
+            poly_array = np.array(display_points, dtype=np.float64) if display_points else np.zeros((0, 2), dtype=np.float64)
+            mask = invesalius_rs.polygon2mask_rs((w, h), poly_array)
+            filters.append(mask)
+            
         return filters
 
     def CutMaskFromPolygons(self):

--- a/invesalius_rs/src/polygon_mask.rs
+++ b/invesalius_rs/src/polygon_mask.rs
@@ -1,7 +1,79 @@
 use ndarray::Array2;
+use rayon::prelude::*;
 
-pub fn polygon2mask_internal(shape: (usize, usize), _points: &[[f64; 2]]) -> Array2<bool> {
-    // Returns an empty mask (all false).
-    // The actual high-performance ray-casting math will be implemented here.
-    Array2::from_elem(shape, false)
+pub fn polygon2mask_internal(shape: (usize, usize), points: &[[f64; 2]]) -> Array2<bool> {
+    let (w, h) = shape;
+    
+    // Handle empty polygons or zero-size images safely
+    if points.is_empty() || w == 0 || h == 0 {
+        return Array2::from_elem(shape, false);
+    }
+    
+    // Optimization 1: Calculate Bounding Box
+    let mut min_px = f64::MAX;
+    let mut max_px = f64::MIN;
+    let mut min_py = f64::MAX;
+    let mut max_py = f64::MIN;
+    
+    for p in points {
+        if p[0] < min_px { min_px = p[0]; }
+        if p[0] > max_px { max_px = p[0]; }
+        if p[1] < min_py { min_py = p[1]; }
+        if p[1] > max_py { max_py = p[1]; }
+    }
+    
+    // Safely clamp the bounding box to the screen dimensions (handles zooming off-screen)
+    let min_x_idx = (min_px.floor() as isize - 1).max(0) as usize;
+    let max_x_idx = (max_px.ceil() as isize + 1).max(0) as usize;
+    let min_x_idx = min_x_idx.min(w);
+    let max_x_idx = max_x_idx.min(w);
+    
+    let min_y_idx = (min_py.floor() as isize - 1).max(0) as usize;
+    let max_y_idx = (max_py.ceil() as isize + 1).max(0) as usize;
+    let min_y_idx = min_y_idx.min(h);
+    let max_y_idx = max_y_idx.min(h);
+
+    // Initialize flat vector for the mask
+    let mut mask_vec = vec![false; w * h];
+    
+    // Optimization 2: Rayon Multithreading
+    // We iterate over the rows in parallel (each chunk is one row of length h)
+    mask_vec.par_chunks_exact_mut(h).enumerate().for_each(|(r, row)| {
+        // Only process rows inside the X bounding box
+        if r >= min_x_idx && r <= max_x_idx {
+            let px = r as f64;
+            let n = points.len();
+            
+            for (c, val) in row.iter_mut().enumerate() {
+                // Only process columns inside the Y bounding box
+                if c >= min_y_idx && c <= max_y_idx {
+                    let py = c as f64;
+                    let mut inside = false;
+                    let mut j = n - 1;
+                    
+                    // Ray-Casting Algorithm
+                    for i in 0..n {
+                        let xi = points[i][0];
+                        let yi = points[i][1];
+                        let xj = points[j][0];
+                        let yj = points[j][1];
+                        
+                        // Check if the horizontal ray from (px, py) to the right intersects edge i-j
+                        // (yi > py) != (yj > py) guarantees we don't divide by zero when yi == yj
+                        let intersect = ((yi > py) != (yj > py))
+                            && (px < (xj - xi) * (py - yi) / (yj - yi) + xi);
+                            
+                        if intersect {
+                            inside = !inside;
+                        }
+                        j = i;
+                    }
+                    *val = inside;
+                }
+            }
+        }
+    });
+    
+    // Convert back to 2D Array
+    Array2::from_shape_vec((w, h), mask_vec).unwrap()
 }


### PR DESCRIPTION
### Description
This PR replaces the slow Python `skimage.draw.polygon2mask` logic inside the 3D Mask Editor with a high-performance, custom multi-threaded Rust backend (Phase 3 of my GSoC project).

It builds directly upon the PyO3 infrastructure introduced in my previous PR, entirely removing the `skimage` dependency for this tool and drastically reducing UI freezing during mask cuts.
### Changes
- **Custom Ray-Casting Algorithm:** Built a mathematical point-in-polygon ray-casting engine in `invesalius_rs/src/polygon_mask.rs` that exactly replicates the original Python output.
- **Multi-threading:** Leveraged `rayon`'s `par_chunks_exact_mut` to split the massive 2D boolean array generation across all available CPU cores.
- **Bounding Box Optimizations:** Implemented a pre-pass bounding box check to ignore pixels far outside the polygon, safely clamping coordinates to the viewport bounds to prevent crashes on high-DPI (Retina) displays.
- **Python Integration:** Replaced the legacy `skimage` call in `invesalius/data/mask3d_editor_state.py` with our new `invesalius_rs.polygon2mask_rs` bridge function.

### Testing
- Validated via `cargo check` & `cargo test` for memory safety and logic correctness.
- Manually tested in the InVesalius GUI: successfully cuts masks exactly identical to the old Python code but in a fraction of the time, dramatically reducing UI freezing.