### PR TITLE
feat: Add All option for batch surface generation from multiple masks

### DIFF
--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -228,6 +228,7 @@ class Slice(metaclass=utils.Singleton):
     def __bind_events(self) -> None:
         # General slice control
         Publisher.subscribe(self.CreateSurfaceFromIndex, "Create surface from index")
+        Publisher.subscribe(self.CreateSurfacesForAllMasks, "Create surfaces for all masks")
         # Mask control
         Publisher.subscribe(self.__add_mask_thresh, "Create new mask")
         Publisher.subscribe(self.__select_current_mask, "Change mask selected")
@@ -291,7 +292,6 @@ class Slice(metaclass=utils.Singleton):
         Publisher.subscribe(self.UpdateSlice3D, "Update slice 3D")
 
         Publisher.subscribe(self.on_select_all_masks_changed, "Select all masks changed")
-        Publisher.subscribe(self.create_surfaces_for_all_masks, "Create surfaces for all masks")
         Publisher.subscribe(self.update_selected_masks, "Update selected masks list")
 
         Publisher.subscribe(self.OnFlipVolume, "Flip volume")
@@ -1347,42 +1347,84 @@ class Slice(metaclass=utils.Singleton):
             surface_parameters=surface_parameters,
         )
 
-    def on_select_all_masks_changed(self, select_all_active):
-        Publisher.sendMessage("Update create surface button", select_all_active=select_all_active)
-
-    def create_surfaces_for_all_masks(self, surface_template):
+    def CreateSurfacesForAllMasks(self, surface_parameters):
+        """
+        Create surfaces for all existing masks.
+        This is called when "All" is selected in the Mask of Reference field.
+        """
         proj = Project()
-        created_surfaces = []
-        mask_dict = proj.mask_dict
+        created_count = 0
+        failed_masks = []
 
-        for mask_index in self.selected_mask_indices:
-            if mask_index not in mask_dict:
-                continue
-            mask = mask_dict[mask_index]
+        # Get all masks sorted by index
+        mask_indices = sorted(proj.mask_dict.keys())
+
+        if not mask_indices:
+            import wx
+
+            wx.MessageBox(
+                _("No masks available to create surfaces."),
+                _("Create surfaces warning"),
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        for mask_index in mask_indices:
+            mask = proj.mask_dict[mask_index]
+
+            # Skip masks with no voxels selected
             if mask.matrix.max() < 127:
-                print(f"Skipping mask '{mask.name}' (index {mask_index}) - no voxels available")
+                print(f"Skipping mask '{mask.name}' (index {mask_index}) - no voxels selected")
+                failed_masks.append(mask.name)
                 continue
 
-            surface_parameters = surface_template.copy()
-            surface_parameters["options"] = surface_template["options"].copy()
+            # Create a copy of surface parameters for this mask
+            mask_surface_params = {
+                "method": surface_parameters["method"].copy(),
+                "options": surface_parameters["options"].copy(),
+            }
 
-            surface_parameters["options"]["index"] = mask_index
-            surface_parameters["options"]["name"] = f"{mask.name}"
-            surface_parameters["options"]["overwrite"] = False  # always create new surfaces
+            # Update the parameters for this specific mask
+            mask_surface_params["options"]["index"] = mask_index
+            mask_surface_params["options"]["name"] = mask.name
+            mask_surface_params["options"]["overwrite"] = False
 
             print(f"Creating surface for mask '{mask.name}' (index {mask_index})")
 
             try:
                 self.do_threshold_to_all_slices(mask)
                 Publisher.sendMessage(
-                    "Create surface", slice_=self, mask=mask, surface_parameters=surface_parameters
+                    "Create surface",
+                    slice_=self,
+                    mask=mask,
+                    surface_parameters=mask_surface_params,
                 )
-                created_surfaces.append(mask_index)
+                created_count += 1
             except Exception as e:
                 print(f"Failed to create surface for mask '{mask.name}': {str(e)}")
+                failed_masks.append(mask.name)
 
-        print(f"Successfully created surfaces for {len(created_surfaces)} masks")
-        Publisher.sendMessage("Surfaces creation completed", created_count=len(created_surfaces))
+        # Show summary message
+        import wx
+
+        if created_count > 0:
+            msg = _("Successfully created {} surface(s).").format(created_count)
+            if failed_masks:
+                msg += _("\n\nSkipped {} mask(s) with no voxels: {}").format(
+                    len(failed_masks), ", ".join(failed_masks)
+                )
+            wx.MessageBox(msg, _("Surface creation complete"), wx.OK | wx.ICON_INFORMATION)
+        else:
+            wx.MessageBox(
+                _("No surfaces were created. All masks are empty."),
+                _("Create surfaces warning"),
+                wx.OK | wx.ICON_WARNING,
+            )
+
+        print(f"Batch surface creation complete: {created_count} surfaces created")
+
+    def on_select_all_masks_changed(self, select_all_active):
+        Publisher.sendMessage("Update create surface button", select_all_active=select_all_active)
 
     def GetOutput(self):
         return self.blend_filter.GetOutput()

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1352,6 +1352,8 @@ class Slice(metaclass=utils.Singleton):
         Create surfaces for all existing masks.
         This is called when "All" is selected in the Mask of Reference field.
         """
+        import wx
+
         proj = Project()
         created_count = 0
         failed_masks = []
@@ -1360,8 +1362,6 @@ class Slice(metaclass=utils.Singleton):
         mask_indices = sorted(proj.mask_dict.keys())
 
         if not mask_indices:
-            import wx
-
             wx.MessageBox(
                 _("No masks available to create surfaces."),
                 _("Create surfaces warning"),
@@ -1369,54 +1369,90 @@ class Slice(metaclass=utils.Singleton):
             )
             return
 
+        # Filter out empty masks before starting
+        valid_masks = []
         for mask_index in mask_indices:
             mask = proj.mask_dict[mask_index]
-
-            # Skip masks with no voxels selected
-            if mask.matrix.max() < 127:
+            if mask.matrix.max() >= 127:
+                valid_masks.append((mask_index, mask))
+            else:
                 print(f"Skipping mask '{mask.name}' (index {mask_index}) - no voxels selected")
                 failed_masks.append(mask.name)
-                continue
 
-            # Create a copy of surface parameters for this mask
-            mask_surface_params = {
-                "method": surface_parameters["method"].copy(),
-                "options": surface_parameters["options"].copy(),
-            }
+        if not valid_masks:
+            wx.MessageBox(
+                _("No surfaces were created. All masks are empty."),
+                _("Create surfaces warning"),
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
 
-            # Update the parameters for this specific mask
-            mask_surface_params["options"]["index"] = mask_index
-            mask_surface_params["options"]["name"] = ""
-            mask_surface_params["options"]["overwrite"] = False
+        total_masks = len(valid_masks)
 
-            print(f"Creating surface for mask '{mask.name}' (index {mask_index})")
+        # Create unified progress dialog
+        progress_dialog = wx.ProgressDialog(
+            _("Creating surfaces"),
+            _("Creating surface 1/{}").format(total_masks),
+            maximum=total_masks,
+            parent=wx.GetApp().GetTopWindow(),
+            style=wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_AUTO_HIDE | wx.PD_ELAPSED_TIME,
+        )
 
-            try:
-                self.do_threshold_to_all_slices(mask)
-                Publisher.sendMessage(
-                    "Create surface",
-                    slice_=self,
-                    mask=mask,
-                    surface_parameters=mask_surface_params,
+        try:
+            for idx, (mask_index, mask) in enumerate(valid_masks, start=1):
+                # Check if user cancelled before starting next surface
+                if progress_dialog.WasCancelled():
+                    print(
+                        f"Batch surface creation cancelled by user after {created_count} surfaces"
+                    )
+                    break
+
+                # Update progress dialog BEFORE creating surface
+                progress_dialog.Update(
+                    idx - 1, _("Creating surface {}/{}: {}").format(idx, total_masks, mask.name)
                 )
-                created_count += 1
-            except Exception as e:
-                print(f"Failed to create surface for mask '{mask.name}': {str(e)}")
-                failed_masks.append(mask.name)
+
+                # Create a copy of surface parameters for this mask
+                mask_surface_params = {
+                    "method": surface_parameters["method"].copy(),
+                    "options": surface_parameters["options"].copy(),
+                }
+
+                # Update the parameters for this specific mask
+                mask_surface_params["options"]["index"] = mask_index
+                mask_surface_params["options"]["name"] = mask.name
+                mask_surface_params["options"]["overwrite"] = False
+                mask_surface_params["options"]["batch_mode"] = True
+
+                print(f"Creating surface for mask '{mask.name}' (index {mask_index})")
+
+                try:
+                    self.do_threshold_to_all_slices(mask)
+                    Publisher.sendMessage(
+                        "Create surface",
+                        slice_=self,
+                        mask=mask,
+                        surface_parameters=mask_surface_params,
+                    )
+                    created_count += 1
+                except Exception as e:
+                    print(f"Failed to create surface for mask '{mask.name}': {str(e)}")
+                    failed_masks.append(mask.name)
+
+        finally:
+            progress_dialog.Destroy()
 
         # Show summary message
-        import wx
-
         if created_count > 0:
             msg = _("Successfully created {} surface(s).").format(created_count)
             if failed_masks:
-                msg += _("\n\nSkipped {} mask(s) with no voxels: {}").format(
+                msg += _("\n\nSkipped {} mask(s): {}").format(
                     len(failed_masks), ", ".join(failed_masks)
                 )
             wx.MessageBox(msg, _("Surface creation complete"), wx.OK | wx.ICON_INFORMATION)
         else:
             wx.MessageBox(
-                _("No surfaces were created. All masks are empty."),
+                _("No surfaces were created."),
                 _("Create surfaces warning"),
                 wx.OK | wx.ICON_WARNING,
             )

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -1386,7 +1386,7 @@ class Slice(metaclass=utils.Singleton):
 
             # Update the parameters for this specific mask
             mask_surface_params["options"]["index"] = mask_index
-            mask_surface_params["options"]["name"] = mask.name
+            mask_surface_params["options"]["name"] = ""
             mask_surface_params["options"]["overwrite"] = False
 
             print(f"Creating surface for mask '{mask.name}' (index {mask_index})")

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -1123,7 +1123,8 @@ class SurfaceManager:
         Publisher.sendMessage("Update surface info in GUI", surface=surface)
         Publisher.sendMessage("End busy cursor")
 
-        dialog.running = False
+        if dialog:
+            dialog.running = False
 
     def on_publish_surface(self):
         Publisher.sendMessage("Stop navigation")
@@ -1246,9 +1247,14 @@ class SurfaceManager:
             pass
 
     def _on_callback_error(self, e, dialog=None):
-        dialog.running = False
-        msg = utl.log_traceback(e)
-        dialog.error = msg
+        if dialog:
+            dialog.running = False
+            msg = utl.log_traceback(e)
+            dialog.error = msg
+        else:
+            # Batch mode: just log the error
+            msg = utl.log_traceback(e)
+            print(f"Surface creation error: {msg}")
 
     def AddNewActor(self, slice_, mask, surface_parameters):
         """
@@ -1311,6 +1317,10 @@ class SurfaceManager:
             overwrite = surface_parameters["options"]["overwrite"]
         except KeyError:
             overwrite = False
+
+        # Check if we're in batch mode (suppress individual progress dialogs)
+        batch_mode = surface_parameters["options"].get("batch_mode", False)
+
         mask.matrix.flush()
 
         if quality in const.SURFACE_QUALITY.keys():
@@ -1450,7 +1460,12 @@ class SurfaceManager:
 
         # With GUI
         else:
-            sp = dialogs.SurfaceProgressWindow()
+            # In batch mode, skip individual progress dialogs
+            if not batch_mode:
+                sp = dialogs.SurfaceProgressWindow()
+            else:
+                sp = None
+
             for i in range(n_pieces):
                 init = i * piece_size
                 end = init + piece_size + o_piece
@@ -1481,17 +1496,20 @@ class SurfaceManager:
                         fill_border_holes,
                     ),
                     callback=lambda x: filenames.append(x),
-                    error_callback=functools.partial(self._on_callback_error, dialog=sp),
+                    error_callback=functools.partial(self._on_callback_error, dialog=sp)
+                    if sp
+                    else None,
                 )
 
             while len(filenames) != n_pieces:
-                if sp.WasCancelled() or not sp.running:
+                if sp and (sp.WasCancelled() or not sp.running):
                     break
                 time.sleep(0.25)
-                sp.Update(_("Creating 3D surface..."))
-                wx.Yield()
+                if sp:
+                    sp.Update(_("Creating 3D surface..."))
+                    wx.Yield()
 
-            if not sp.WasCancelled() or sp.running:
+            if not sp or (not sp.WasCancelled() or sp.running):
                 f = pool.apply_async(
                     surface_process.join_process_surface,
                     args=(
@@ -1513,27 +1531,37 @@ class SurfaceManager:
                         category=category,
                         dialog=sp,
                     ),
-                    error_callback=functools.partial(self._on_callback_error, dialog=sp),
+                    error_callback=functools.partial(self._on_callback_error, dialog=sp)
+                    if sp
+                    else lambda e: print(f"Surface creation error: {e}"),
                 )
 
-                while sp.running:
-                    if sp.WasCancelled():
-                        break
-                    time.sleep(0.25)
-                    try:
-                        msg = msg_queue.get_nowait()
-                        sp.Update(msg)
-                    except Exception:
-                        sp.Update(None)
-                    wx.Yield()
+                if sp:
+                    while sp.running:
+                        if sp.WasCancelled():
+                            break
+                        time.sleep(0.25)
+                        try:
+                            msg = msg_queue.get_nowait()
+                            sp.Update(msg)
+                        except Exception:
+                            sp.Update(None)
+                        wx.Yield()
+                else:
+                    # In batch mode, just wait for completion without GUI updates
+                    while not f.ready():
+                        time.sleep(0.25)
 
             t_end = time.time()
             print(f"Elapsed time - {t_end - t_init}")
-            sp.Close()
-            if sp.error:
-                dlg = GMD.GenericMessageDialog(None, sp.error, "Exception!", wx.OK | wx.ICON_ERROR)
-                dlg.ShowModal()
-            del sp
+            if sp:
+                sp.Close()
+                if sp.error:
+                    dlg = GMD.GenericMessageDialog(
+                        None, sp.error, "Exception!", wx.OK | wx.ICON_ERROR
+                    )
+                    dlg.ShowModal()
+                del sp
 
         pool.close()
         try:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -1986,12 +1986,14 @@ class SurfaceCreationOptionsPanel(wx.Panel):
         # Retrieve existing masks
         project = prj.Project()
         index_list = project.mask_dict.keys()
-        self.mask_list = [project.mask_dict[index].name for index in sorted(index_list)]
+        self.mask_list = ["All"] + [project.mask_dict[index].name for index in sorted(index_list)]
+        # Store the actual mask indices for lookup (None for "All")
+        self.mask_indices = [None] + list(sorted(index_list))
 
         active_mask = 0
-        for idx in project.mask_dict:
-            if project.mask_dict[idx] is slc.Slice().current_mask:
-                active_mask = idx
+        for i, idx in enumerate(self.mask_indices):
+            if idx is not None and project.mask_dict[idx] is slc.Slice().current_mask:
+                active_mask = i
                 break
 
         # Mask selection combo
@@ -2055,18 +2057,23 @@ class SurfaceCreationOptionsPanel(wx.Panel):
         sizer.Fit(self)
 
     def OnSetMask(self, evt: wx.CommandEvent) -> None:
-        new_evt = MaskEvent(myEVT_MASK_SET, -1, self.combo_mask.GetSelection())
-        self.GetEventHandler().ProcessEvent(new_evt)
+        selection = self.combo_mask.GetSelection()
+        mask_index = self.mask_indices[selection]
+        # Only send event if a specific mask is selected (not "All")
+        if mask_index is not None:
+            new_evt = MaskEvent(myEVT_MASK_SET, -1, mask_index)
+            self.GetEventHandler().ProcessEvent(new_evt)
 
-    def GetValue(self) -> dict[str, str | int | bool]:
-        mask_index = self.combo_mask.GetSelection()
+    def GetValue(self) -> dict[str, str | int | bool | None]:
+        selection = self.combo_mask.GetSelection()
+        mask_index = self.mask_indices[selection]
         surface_name = self.text.GetValue()
         quality = const.SURFACE_QUALITY_LIST[self.combo_quality.GetSelection()]
         fill_border_holes = self.check_box_border_holes.GetValue()
         fill_holes = self.check_box_holes.GetValue()
         keep_largest = self.check_box_largest.GetValue()
         return {
-            "index": mask_index,
+            "index": mask_index,  # None if "All" is selected
             "name": surface_name,
             "quality": quality,
             "fill_border_holes": fill_border_holes,

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -2006,6 +2006,11 @@ class SurfaceCreationOptionsPanel(wx.Panel):
             combo_mask.SetWindowVariant(wx.WINDOW_VARIANT_SMALL)
         self.combo_mask = combo_mask
 
+        # Disable surface name field if "All" is initially selected
+        if active_mask == 0:
+            text.Enable(False)
+            text.SetValue(_("Batch mode"))
+
         # LINE 3: Surface quality
         label_quality = wx.StaticText(self, -1, _("Surface quality:"))
 
@@ -2059,6 +2064,21 @@ class SurfaceCreationOptionsPanel(wx.Panel):
     def OnSetMask(self, evt: wx.CommandEvent) -> None:
         selection = self.combo_mask.GetSelection()
         mask_index = self.mask_indices[selection]
+
+        # Disable "New surface name" field when "All" is selected (index 0)
+        if selection == 0:  # "All" is always at index 0
+            self.text.Enable(False)
+            self.text.SetValue(_("Batch mode"))  # Optional: show why it's disabled
+        else:
+            self.text.Enable(True)
+            # Restore default name if it was showing "Batch mode"
+            if self.text.GetValue() == _("Batch mode"):
+                import invesalius.constants as const
+                import invesalius.data.surface as surface
+
+                default_name = const.SURFACE_NAME_PATTERN % (surface.Surface.general_index + 2)
+                self.text.SetValue(default_name)
+
         # Only send event if a specific mask is selected (not "All")
         if mask_index is not None:
             new_evt = MaskEvent(myEVT_MASK_SET, -1, mask_index)

--- a/invesalius/gui/task_surface.py
+++ b/invesalius/gui/task_surface.py
@@ -198,7 +198,17 @@ class InnerTaskPanel(scrolled.ScrolledPanel):
 
             surface_options = dialog.GetValue()
 
-            Publisher.sendMessage("Create surface from index", surface_parameters=surface_options)
+            # Check if "All" was selected (index is None)
+            if surface_options["options"]["index"] is None:
+                # Create surfaces for all masks
+                Publisher.sendMessage(
+                    "Create surfaces for all masks", surface_parameters=surface_options
+                )
+            else:
+                # Create surface for single selected mask
+                Publisher.sendMessage(
+                    "Create surface from index", surface_parameters=surface_options
+                )
         dialog.Destroy()
         if evt:
             evt.Skip()


### PR DESCRIPTION
## Summary

Adds an **"All"** option to the **Mask of Reference** dropdown in **Tools → Surface → New**, enabling batch surface generation for all existing masks.

## Changes

* Added **"All"** as the first mask selection option, represented internally by `None`.
* Added routing between single-mask and batch surface creation.
* Batch processing creates one surface per non-empty mask using the selected quality settings.
* Surfaces inherit their corresponding mask names.
* Empty masks are skipped gracefully.
* Preserves the existing single-mask workflow and Publisher/Subscriber flow.

## Files Changed

* `invesalius/gui/dialogs.py` — "All" option and mask index mapping.
* `invesalius/gui/task_surface.py` — single vs. batch creation routing.
* `invesalius/data/slice_.py` — batch surface generation

## Related

Addresses mentor feedback for improving multi-mask surface generation.
