### PR TITLE
Fix TIFF export writing to a different filename than the user chose

### DIFF
--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -1093,7 +1093,8 @@ class Viewer(wx.Panel):
                     writer = vtkPostScriptWriter()
                 elif filetype == const.FILETYPE_TIF:
                     writer = vtkTIFFWriter()
-                    filename = "{}.tif".format(filename.strip(".tif"))
+                    if not filename.lower().endswith((".tif", ".tiff")):
+                        filename += ".tif"
 
                 writer.SetInputData(image)
                 writer.SetFileName(filename.encode(const.FS_ENCODE))

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1043,7 +1043,8 @@ class Viewer(wx.Panel):
                 writer = vtkPostScriptWriter()
             elif filetype == const.FILETYPE_TIF:
                 writer = vtkTIFFWriter()
-                filename = "{}.tif".format(filename.strip(".tif"))
+                if not filename.lower().endswith((".tif", ".tiff")):
+                    filename += ".tif"
 
             writer.SetInputData(image)
             writer.SetFileName(filename.encode(const.FS_ENCODE))


### PR DESCRIPTION
Exporting a picture as TIFF can write to a different file than the one the user picked in the save dialog.

Both `viewer_slice.py` and `viewer_volume.py` normalise the extension like this:

```python
filename = "{}.tif".format(filename.strip(".tif"))
```

`strip` takes a set of characters, not a suffix, so it keeps removing `.`, `t`, `i` and `f` from both ends of the whole path:

```
/home/u/roi.tif        -> /home/u/ro.tif
/home/u/brain_ct.tif   -> /home/u/brain_c.tif
/home/u/scan_left.tif  -> /home/u/scan_le.tif
```

The export then reports success, because the `os.path.exists(filename)` check right after it looks at the mangled name, which does exist. The user is left looking for a file that was never written under the name they chose.

There is a second, smaller effect on Linux and macOS: `ExportPicture` appends `tiff` (`INDEX_TO_EXTENSION[5]`), and the strip turns that `.tiff` back into `.tif`, so the saved name silently differs from the one the dialog showed.

The replacement keeps the original intent, which is to make sure the file ends in a TIFF extension, and leaves an existing one alone:

```python
if not filename.lower().endswith((".tif", ".tiff")):
    filename += ".tif"
```

I could not run InVesalius on this machine (no VTK/wxPython build here), so I checked the string handling on its own against the paths above rather than through the GUI. `ruff check` on both files reports the same four pre-existing findings before and after the change.
