### PR TITLE
ENH: Show wait cursor while processing neuronavigation markers

### DIFF
--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -4473,14 +4473,21 @@ class ObjectCalibrationDialog(wx.Dialog):
             ShowNavigationTrackerWarning(0, "choose")
             return
 
-        marker_visibilities, coord, coord_raw = self.tracker.GetTrackerCoordinates(
-            # XXX: Always use static reference mode when getting the coordinates. This is what the
-            #      code did previously, as well. At some point, it should probably be thought through
-            #      if this is actually what we want or if it should be changed somehow.
-            #
-            ref_mode_id=const.STATIC_REF,
-            n_samples=const.CALIBRATION_TRACKER_SAMPLES,
-        )
+        # Show a wait cursor while collecting tracker samples.
+        # GetTrackerCoordinates blocks the main thread for ~100-300ms (10 samples × sleep).
+        # Without this, the dialog appears frozen with no feedback to the user.
+        wx.BeginBusyCursor()
+        try:
+            marker_visibilities, coord, coord_raw = self.tracker.GetTrackerCoordinates(
+                # XXX: Always use static reference mode when getting the coordinates. This is what the
+                #      code did previously, as well. At some point, it should probably be thought through
+                #      if this is actually what we want or if it should be changed somehow.
+                #
+                ref_mode_id=const.STATIC_REF,
+                n_samples=const.CALIBRATION_TRACKER_SAMPLES,
+            )
+        finally:
+            wx.EndBusyCursor()
 
         # If coil or probe markers are not visible, show a warning and return early.
         probe_visible, head_visible, *coils_visible = marker_visibilities

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -1377,7 +1377,25 @@ class TrackerPage(wx.Panel):
         #      is more concerned with the calibration than the navigation.
         #
         ref_mode_id = self.navigation.GetReferenceMode()
-        success = self.tracker.SetTrackerFiducial(ref_mode_id, fiducial_index)
+
+        # Disable buttons and show a wait cursor while collecting tracker samples.
+        # GetTrackerCoordinates blocks the main thread for ~100-300ms (10 samples × sleep).
+        # Without this, additional clicks are enqueued and processed after unblocking,
+        # causing duplicate registrations or apparent freezes.
+        for btn in self.fiducial_buttons:
+            btn.Disable()
+        self.register_button.Disable()
+
+        wx.BeginBusyCursor()
+        try:
+            success = self.tracker.SetTrackerFiducial(ref_mode_id, fiducial_index)
+        finally:
+            wx.EndBusyCursor()
+            # Re-enable buttons only if registration is still ongoing.
+            if self.registration_on:
+                for btn in self.fiducial_buttons:
+                    btn.Enable()
+                self.register_button.Enable()
 
         # Setting the fiducial is not successful if head or probe markers are not visible.
         # In that case, return early and do not move to the next fiducial.


### PR DESCRIPTION
## Fix: Add busy cursor and button guard during fiducial registration

### Problem

When recording tracker fiducials during neuronavigation registration, `GetTrackerCoordinates` blocks the main UI thread for ~100–300ms while collecting hardware samples (10 readings × 10ms sleep, up to 30 attempts). During this time:
- The cursor showed no feedback, making the application appear frozen
- Any additional button clicks were queued by wxPython and processed after the thread unblocked, causing duplicate registrations or crashes

### Changes

**`invesalius/gui/task_navigator.py` — `TrackerPage.SetTrackerFiducial`**
- Wrap the blocking `tracker.SetTrackerFiducial` call with `wx.BeginBusyCursor()` / `wx.EndBusyCursor()` inside a `try/finally` block
- Disable all fiducial buttons and the "Record Fiducial" button before sampling, and re-enable them afterwards (only if registration is still ongoing, to avoid conflict with `StopRegistration`)

**`invesalius/gui/dialogs.py` — `ObjectCalibrationDialog.SetObjectFiducial`**
- Same pattern: wrap `GetTrackerCoordinates` with `wx.BeginBusyCursor()` / `wx.EndBusyCursor()` inside `try/finally`

### Approach

Follows the existing `wx.BeginBusyCursor()` / `wx.EndBusyCursor()` pattern already used throughout the project (e.g. `slice_.py`). No new dependencies or architectural changes required.

### Testing
With NDI Polaris tracking device, I ran the navigation workflow and collected tracker and object fiducials: cursor
switches to busy during acquisition and buttons stay disabled until it completes.