### PR TITLE
Refactor Robot class into Singleton and update UI for dual robot support

### DIFF
--- a/invesalius/data/markers/marker_transformator.py
+++ b/invesalius/data/markers/marker_transformator.py
@@ -45,7 +45,7 @@ class MarkerTransformator:
     def UpdateSelectedMarker(self, marker):
         self.selected_marker = marker
 
-    def UpdateZOffsetTargetByRobot(self, z_offset):
+    def UpdateZOffsetTargetByRobot(self, z_offset, robot_id=None):
         marker = self.target
         if not marker or not self.robot_track_status:
             return

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -1170,7 +1170,7 @@ class Viewer(wx.Panel):
         print("updated to ", dist_threshold)
         self.distance_threshold = dist_threshold
 
-    def OnUpdateRobotWarning(self, robot_warning):
+    def OnUpdateRobotWarning(self, robot_warning, robot_id=None):
         if self.robot_warnings_text is not None:
             self.robot_warnings_text.SetValue(robot_warning)
 

--- a/invesalius/data/visualization/robot_force_visualizer.py
+++ b/invesalius/data/visualization/robot_force_visualizer.py
@@ -114,7 +114,7 @@ class RobotForceVisualizer:
         # Approximate text width adjustment for centering
         self.text.SetDisplayPosition(text_x - 25, text_y - 10)
 
-    def OnUpdateRobotForceData(self, force_feedback):
+    def OnUpdateRobotForceData(self, force_feedback, robot_id=None):
         if not self.visible:
             return
         self.update_force(force_feedback)

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -7190,7 +7190,10 @@ class RobotCoregistrationDialog(wx.Dialog):
     def SetAcquiredPoints(self, num_points: int) -> None:
         self.txt_number.SetLabel(str(num_points))
 
-    def PointRegisteredByRobot(self) -> None:
+    def PointRegisteredByRobot(self, robot_id=None) -> None:
+        if robot_id is not None and robot_id != self.robot.robot_id:
+            return
+
         # Increment the number of acquired points.
         num_points = self.GetAcquiredPoints()
         num_points += 1
@@ -7227,7 +7230,10 @@ class RobotCoregistrationDialog(wx.Dialog):
 
         # TODO: make a colored circle to sinalize that the transformation was made (green) (red if not)
 
-    def UpdateRobotTransformationMatrix(self, data: Any) -> None:
+    def UpdateRobotTransformationMatrix(self, data, robot_id=None) -> None:
+        if robot_id is not None and robot_id != self.robot.robot_id:
+            return
+
         self.matrix_tracker_to_robot = np.array(data)
 
     def SaveRegistration(self, evt: wx.CommandEvent) -> None:

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -6945,69 +6945,6 @@ class SetTrackerDeviceToRobot(wx.Dialog):
         return self.tracker_id
 
 
-class SetRobotIP(wx.Dialog):
-    def __init__(self, title: str = _("Set Robot IP")):
-        wx.Dialog.__init__(
-            self,
-            wx.GetApp().GetTopWindow(),
-            -1,
-            title,
-            size=wx.Size(1000, 200),
-            style=wx.DEFAULT_DIALOG_STYLE
-            | wx.FRAME_FLOAT_ON_PARENT
-            | wx.STAY_ON_TOP
-            | wx.RESIZE_BORDER,
-        )
-        self.robot_ip = None
-        self._init_gui()
-
-    def _init_gui(self) -> None:
-        # ComboBox for spatial tracker device selection
-        tooltip = _("Choose or type the robot IP")
-        robot_ip_options = [_("Select robot IP:")] + const.ROBOT_IPS
-        choice_IP = wx.ComboBox(
-            self, -1, "", choices=robot_ip_options, style=wx.CB_DROPDOWN | wx.TE_PROCESS_ENTER
-        )
-        choice_IP.SetToolTip(tooltip)
-        choice_IP.SetSelection(const.DEFAULT_TRACKER)
-        choice_IP.Bind(wx.EVT_COMBOBOX, partial(self.OnChoiceIP, ctrl=choice_IP))
-        choice_IP.Bind(wx.EVT_TEXT, partial(self.OnTxt_Ent, ctrl=choice_IP))
-
-        btn_ok = wx.Button(self, wx.ID_OK)
-        btn_ok.SetHelpText("")
-        btn_ok.SetDefault()
-
-        btn_cancel = wx.Button(self, wx.ID_CANCEL)
-        btn_cancel.SetHelpText("")
-
-        btnsizer = wx.StdDialogButtonSizer()
-        btnsizer.AddButton(btn_ok)
-        btnsizer.AddButton(btn_cancel)
-        btnsizer.Realize()
-
-        main_sizer = wx.BoxSizer(wx.VERTICAL)
-
-        main_sizer.Add((5, 5))
-        main_sizer.Add(choice_IP, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
-        main_sizer.Add((15, 15))
-        main_sizer.Add(btnsizer, 0, wx.EXPAND)
-        main_sizer.Add((5, 5))
-
-        self.SetSizer(main_sizer)
-        main_sizer.Fit(self)
-
-        self.CenterOnParent()
-
-    def OnTxt_Ent(self, evt: wx.CommandEvent, ctrl: wx.TextEntry) -> None:
-        self.robot_ip = str(ctrl.GetValue())
-
-    def OnChoiceIP(self, evt: wx.CommandEvent, ctrl: wx.ComboBox) -> None:
-        self.robot_ip = ctrl.GetStringSelection()
-
-    def GetValue(self) -> str | None:
-        return self.robot_ip
-
-
 class RobotCoregistrationDialog(wx.Dialog):
     def __init__(
         self,

--- a/invesalius/gui/interactive_shell.py
+++ b/invesalius/gui/interactive_shell.py
@@ -27,7 +27,7 @@ import invesalius.session as ses
 from invesalius.i18n import tr as _
 from invesalius.navigation.markers import MarkersControl
 from invesalius.navigation.navigation import Navigation
-from invesalius.navigation.robot import Robot
+from invesalius.navigation.robot import Robot, Robots
 from invesalius.navigation.tracker import Tracker
 from invesalius.pubsub import pub as Publisher
 
@@ -114,7 +114,8 @@ class InteractiveShellFrame(wx.Frame):
         if mode == const.MODE_NAVIGATOR:
             navigation_context["markers"] = MarkersControl()
             navigation_context["navigation"] = Navigation()
-            navigation_context["robot"] = Robot()
+            navigation_context["robots"] = Robots()
+            navigation_context["robot"] = Robots().GetRobot(0)
             navigation_context["tracker"] = Tracker()
 
         Publisher.sendMessage("Update shell context", new_context=navigation_context)

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -2168,27 +2168,8 @@ class RobotSetupPanel(wx.Panel):
             self.pressure_lbl.SetForegroundColour(self._pressure_lbl_default_fg)
             self.pressure_val_lbl.SetForegroundColour(self._pressure_val_default_fg)
 
-        # Recommended hint styling: green if near 5.0 N, grey otherwise
-        if abs(value - self.pressure_recommended) <= self.pressure_match_tol:
-            self.pressure_rec_lbl.SetForegroundColour(wx.Colour(0, 140, 0))  # green
-            try:
-                f = self.pressure_rec_lbl.GetFont()
-                f.SetWeight(wx.FONTWEIGHT_BOLD)
-                self.pressure_rec_lbl.SetFont(f)
-            except Exception:
-                pass
-        else:
-            self.pressure_rec_lbl.SetForegroundColour(wx.Colour(90, 90, 90))
-            try:
-                f = self.pressure_rec_lbl.GetFont()
-                f.SetWeight(wx.FONTWEIGHT_NORMAL)
-                self.pressure_rec_lbl.SetFont(f)
-            except Exception:
-                pass
-
         self.pressure_lbl.Refresh()
         self.pressure_val_lbl.Refresh()
-        self.pressure_rec_lbl.Refresh()
 
 
 class TrackerTab(wx.Panel):

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1237,6 +1237,7 @@ class ObjectTab(wx.Panel):
                 self.robot_0_lbl.SetLabel("Robot 0 is connected. Coil attached: ")
             else:
                 self.choice_robot_0_coil.Show(False)
+                self.choice_robot_0_coil.SetSelection(wx.NOT_FOUND)
                 self.robot_0_lbl.SetLabel("Robot 0 is not connected.")
         elif robot_id == 1:
             if enabled:
@@ -1244,6 +1245,7 @@ class ObjectTab(wx.Panel):
                 self.robot_1_lbl.SetLabel("Robot 1 is connected. Coil attached: ")
             else:
                 self.choice_robot_1_coil.Show(False)
+                self.choice_robot_1_coil.SetSelection(wx.NOT_FOUND)
                 self.robot_1_lbl.SetLabel("Robot 1 is not connected.")
         self.Layout()
 

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1018,7 +1018,8 @@ class ObjectTab(wx.Panel):
         self.tracker = tracker
         self.pedal_connector = pedal_connector
         self.navigation = navigation
-        self.robot = Robot()
+        self.robots = Robots()
+        self.robot = self.robots.GetRobot(0)
         self.coil_registrations = {}
         self.__bind_events()
 
@@ -1775,116 +1776,106 @@ class RobotSetupPanel(wx.Panel):
     def __init__(self, parent, robot):
         wx.Panel.__init__(self, parent)
 
-        self.session = ses.Session()
-        self.robot = robot
-
         self.__bind_events()
 
+        self.robot = robot
+        self.robot_name = f"ID {self.robot.robot_id}"
+        self.robot_ip = robot.robot_ip
+        self.session = ses.Session()
+        self.use_pressure_sensor = self.robot.robot_init_config.get("use_pressure_sensor", False)
+
+        self.main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.__build_ui()
+
+        self.SetSizerAndFit(self.main_sizer)
+        self.Layout()
+
+        self.robot.CheckConnection()
+
+    def __build_ui(self):
         lbl_rob = wx.StaticText(self, -1, _("IP for robot device: "))
 
-        # ComboBox for spatial tracker device selection
-        tooltip = _("Choose or type the robot IP")
         robot_ip_options = self.robot.robot_ip_options
-        choice_IP = wx.ComboBox(
+        tooltip = _("Choose or type the robot IP")
+        self.choice_IP = wx.ComboBox(
             self, -1, "", choices=robot_ip_options, style=wx.CB_DROPDOWN | wx.TE_PROCESS_ENTER
         )
-        choice_IP.SetToolTip(tooltip)
+        self.choice_IP.SetToolTip(tooltip)
 
-        if self.robot.robot_ip in self.robot.robot_ip_options:
-            choice_IP.SetSelection(robot_ip_options.index(self.robot.robot_ip))
-            self.robot.robot_ip = choice_IP.GetValue()
+        if self.robot.robot_ip in robot_ip_options:
+            self.choice_IP.SetSelection(robot_ip_options.index(self.robot.robot_ip))
+            self.robot_ip = self.choice_IP.GetValue()
+        elif self.robot.robot_ip:
+            self.choice_IP.SetValue(self.robot.robot_ip)
+            self.robot_ip = self.choice_IP.GetValue()
+        elif self.choice_IP.IsTextEmpty() and self.choice_IP.IsListEmpty():
+            self.choice_IP.ChangeValue(_("Select or type robot IP"))
+        elif self.choice_IP.IsTextEmpty():
+            self.choice_IP.SetSelection(0)
+            self.robot_ip = self.choice_IP.GetValue()
 
-        elif self.robot.robot_ip is not None:
-            choice_IP.SetValue(self.robot.robot_ip)
-            self.robot.robot_ip = choice_IP.GetValue()
+        self.choice_IP.Bind(wx.EVT_COMBOBOX, partial(self.OnChoiceIP, ctrl=self.choice_IP))
+        self.choice_IP.Bind(wx.EVT_TEXT, partial(self.OnTxt_Ent, ctrl=self.choice_IP))
 
-        elif choice_IP.IsTextEmpty() and choice_IP.IsListEmpty():
-            choice_IP.ChangeValue(_("Select or type robot IP"))
+        self.btn_rob_add_ip = wx.BitmapButton(self, -1, wx.ArtProvider.GetBitmap(wx.ART_PLUS))
+        self.btn_rob_add_ip.SetToolTip(_("Add a new IP to the list"))
+        self.btn_rob_add_ip.Bind(wx.EVT_BUTTON, self.OnAddIP)
 
-        elif choice_IP.IsTextEmpty():
-            choice_IP.SetSelection(0)
-            self.robot.robot_ip = choice_IP.GetValue()
+        self.btn_rob_rem_ip = wx.BitmapButton(self, -1, wx.ArtProvider.GetBitmap(wx.ART_MINUS))
+        self.btn_rob_rem_ip.SetToolTip(_("Remove the selected IP from the list"))
+        self.btn_rob_rem_ip.Bind(wx.EVT_BUTTON, self.OnRemoveIP)
 
-        choice_IP.Bind(wx.EVT_COMBOBOX, partial(self.OnChoiceIP, ctrl=choice_IP))
-        choice_IP.Bind(wx.EVT_TEXT, partial(self.OnTxt_Ent, ctrl=choice_IP))
-        self.choice_IP = choice_IP
+        self.btn_rob = wx.Button(self, -1, _("Connect"))
+        self.btn_rob.SetToolTip(_("Connect to the selected IP"))
+        self.btn_rob.Bind(wx.EVT_BUTTON, self.OnRobotConnect)
 
-        # ADD ip Robot
-        btn_rob_add_ip = wx.BitmapButton(self, -1, wx.ArtProvider.GetBitmap(wx.ART_PLUS))
-        btn_rob_add_ip.SetToolTip("Add a new IP to the list")
-        btn_rob_add_ip.Enable(1)
-        btn_rob_add_ip.Bind(wx.EVT_BUTTON, self.OnAddIP)
-        self.btn_rob_add_ip = btn_rob_add_ip
+        self.status_text = wx.StaticText(self, -1, _("Status"))
 
-        # Remove ip Robot
-        btn_rob_rem_ip = wx.BitmapButton(self, -1, wx.ArtProvider.GetBitmap(wx.ART_MINUS))
-        btn_rob_rem_ip.SetToolTip("Remove the selected IP from the list")
-        btn_rob_rem_ip.Enable(1)
-        btn_rob_rem_ip.Bind(wx.EVT_BUTTON, self.OnRemoveIP)
-        self.btn_rob_rem_ip = btn_rob_rem_ip
-
-        # Connect Robot button
-        btn_rob = wx.Button(self, -1, _("Connect"))
-        btn_rob.SetToolTip("Connect to the selected IP")
-        btn_rob.Enable(1)
-        btn_rob.Bind(wx.EVT_BUTTON, self.OnRobotConnect)
-        self.btn_rob = btn_rob
-
-        status_text = wx.StaticText(self, -1, "Status")
-        self.status_text = status_text
-
-        btn_rob_con = wx.Button(self, -1, _("Register"))
-        btn_rob_con.SetToolTip("Register robot tracking")
-        btn_rob_con.Enable(1)
-        btn_rob_con.Bind(wx.EVT_BUTTON, self.OnRobotRegister)
+        self.btn_rob_con = wx.Button(self, -1, _("Register"))
+        self.btn_rob_con.SetToolTip(_("Register robot tracking"))
+        self.btn_rob_con.Bind(wx.EVT_BUTTON, self.OnRobotRegister)
 
         if self.robot.IsConnected():
             self.status_text.SetLabelText(_("Robot is connected!"))
-
             if self.robot.matrix_tracker_to_robot is None:
-                btn_rob_con.Show()
+                self.btn_rob_con.Show()
             else:
-                btn_rob_con.SetLabel("Register Again")
-                btn_rob_con.Show()
-
+                self.btn_rob_con.SetLabel(_("Register Again"))
+                self.btn_rob_con.Show()
         else:
             self.status_text.SetLabelText(_("Robot is not connected!"))
-            btn_rob_con.Hide()
-
-        self.btn_rob_con = btn_rob_con
+            self.btn_rob_con.Hide()
 
         rob_ip_sizer = wx.FlexGridSizer(rows=1, cols=5, hgap=3, vgap=3)
         rob_ip_sizer.AddGrowableCol(3, 1)
         rob_ip_sizer.AddMany(
             [
                 (lbl_rob, 0, wx.ALIGN_CENTER_VERTICAL),
-                (btn_rob_add_ip, 0, wx.ALIGN_CENTER_VERTICAL),
-                (btn_rob_rem_ip, 0, wx.ALIGN_CENTER_VERTICAL),
-                (choice_IP, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND),
-                (btn_rob, 0, wx.ALIGN_CENTER_VERTICAL),
+                (self.btn_rob_add_ip, 0, wx.ALIGN_CENTER_VERTICAL),
+                (self.btn_rob_rem_ip, 0, wx.ALIGN_CENTER_VERTICAL),
+                (self.choice_IP, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND),
+                (self.btn_rob, 0, wx.ALIGN_CENTER_VERTICAL),
             ]
         )
 
         rob_status_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        rob_status_sizer.Add(status_text, 1, wx.LEFT | wx.ALIGN_CENTER_VERTICAL)
+        rob_status_sizer.Add(self.status_text, 1, wx.LEFT | wx.ALIGN_CENTER_VERTICAL)
         rob_status_sizer.AddStretchSpacer(1)
-        rob_status_sizer.Add(btn_rob_con, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL)
+        rob_status_sizer.Add(self.btn_rob_con, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL)
 
         # --- Pressure force setpoint (slider) ---
         # Config and scaling (slider is integer)
-        # Recommended value
         self.pressure_recommended = 10.0
         self.pressure_match_tol = 0.1  # within 0.1 N counts as "at recommended"
 
         self.pressure_min = 0.0
         self.pressure_max = 40.0
         self.pressure_step = 1
-        self.pressure_scale = int(1 / self.pressure_step)  # 10 for 0.1 resolution
-
+        self.pressure_scale = int(1 / self.pressure_step)  # 1 for 1 resolution
         self.pressure_setpoint = self.session.GetConfig(
             "pressure_setpoint", self.pressure_recommended
         )
-        # Clamp to range in case config has out-of-range value
+
         self.pressure_setpoint = max(
             self.pressure_min, min(self.pressure_max, float(self.pressure_setpoint))
         )
@@ -1896,19 +1887,6 @@ class RobotSetupPanel(wx.Panel):
         self.pressure_warn_threshold = 20.0
         self._pressure_lbl_default_fg = self.pressure_lbl.GetForegroundColour()
         self._pressure_val_default_fg = self.pressure_val_lbl.GetForegroundColour()
-
-        # Recommended hint label (small/italic)
-        self.pressure_rec_lbl = wx.StaticText(
-            self, -1, _("Recommended: {value} N").format(value=f"{self.pressure_recommended:.1f}")
-        )
-        try:
-            f = self.pressure_rec_lbl.GetFont()
-            f.MakeSmaller()
-            f.MakeItalic()
-            self.pressure_rec_lbl.SetFont(f)
-        except Exception:
-            pass
-        self.pressure_rec_lbl.SetForegroundColour(wx.Colour(90, 90, 90))  # subtle grey
 
         # Apply initial color based on loaded value
         self._apply_pressure_color(self.pressure_setpoint)
@@ -1922,8 +1900,9 @@ class RobotSetupPanel(wx.Panel):
             style=wx.SL_HORIZONTAL | wx.SL_AUTOTICKS,
             size=wx.Size(-1, 23),
         )
+
         self.pressure_slider.SetToolTip(_("Set the desired pressure/force setpoint"))
-        # Tick frequency every 1.0 N
+
         try:
             self.pressure_slider.SetTickFreq(self.pressure_scale, 1)
         except Exception:
@@ -1933,49 +1912,35 @@ class RobotSetupPanel(wx.Panel):
 
         # quick-set button
         self.btn_set_rec = wx.Button(self, -1, _("Set 10 N"), size=wx.Size(70, 23))
-        self.btn_set_rec.SetToolTip(_("Set pressure to the recommended 5.0 N"))
+        self.btn_set_rec.SetToolTip(_("Set pressure to the recommended 10 N"))
         self.btn_set_rec.Bind(wx.EVT_BUTTON, self.OnSetRecommendedPressure)
 
-        # --- Pressure sensor sub-box ---
-        pressure_box = wx.StaticBox(self, -1, _("Pressure Control"))
-
-        # --- Toggle pressure sensor button ---
-        self.chk_enable_pressure = wx.CheckBox(self, -1, _("Enable pressure sensor"))
-
-        use_pressure_sensor = self.robot.use_pressure_sensor
-        self.chk_enable_pressure.SetValue(use_pressure_sensor)
+        self.chk_enable_pressure = wx.CheckBox(self, -1)
+        self.chk_enable_pressure.SetToolTip(_("Enable pressure sensor"))
+        self.chk_enable_pressure.SetValue(self.robot.use_pressure_sensor)
         self.chk_enable_pressure.Bind(wx.EVT_CHECKBOX, self.OnTogglePressureSensor)
         self.chk_enable_pressure.Enable(self.robot.IsConnected())
-        self._update_pressure_controls_state(self.robot.IsConnected() and use_pressure_sensor)
+        self._update_pressure_controls_state(
+            self.robot.IsConnected() and self.robot.use_pressure_sensor
+        )
 
-        # Row with label, slider, numeric value
         pressure_row = wx.BoxSizer(wx.HORIZONTAL)
-        pressure_row.Add(self.pressure_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
-        pressure_row.Add(self.pressure_slider, 1, wx.EXPAND | wx.RIGHT, 8)
-        pressure_row.Add(self.pressure_val_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        pressure_row.Add(self.chk_enable_pressure, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 2)
+        pressure_row.Add(self.pressure_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
+        pressure_row.Add(self.pressure_slider, 1, wx.EXPAND | wx.RIGHT, 6)
+        pressure_row.Add(self.pressure_val_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
         pressure_row.Add(self.btn_set_rec, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # Hint below
-        pressure_hint_row = wx.BoxSizer(wx.HORIZONTAL)
-        pressure_hint_row.Add((self.pressure_lbl.GetSize().Width, -1), 0)  # indent under label
-        pressure_hint_row.Add(self.pressure_rec_lbl, 0, wx.TOP, 2)
+        self.pressure_row = pressure_row
 
-        pressure_sizer = wx.StaticBoxSizer(pressure_box, wx.VERTICAL)
-        pressure_sizer.Add(self.chk_enable_pressure, 0, wx.ALL, 5)
-        pressure_sizer.Add(pressure_row, 0, wx.EXPAND)
-        pressure_sizer.Add(pressure_hint_row, 0, wx.TOP, 4)
+        rob_static_sizer = wx.StaticBoxSizer(
+            wx.VERTICAL, self, _(f"Setup Robot - {self.robot_name}")
+        )
+        rob_static_sizer.Add(rob_ip_sizer, 0, wx.ALL | wx.EXPAND, 4)
+        rob_static_sizer.Add(rob_status_sizer, 0, wx.ALL | wx.EXPAND, 4)
+        rob_static_sizer.Add(pressure_row, 0, wx.ALL | wx.EXPAND, 4)
 
-        rob_static_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("Setup robot"))
-        rob_static_sizer.Add(rob_ip_sizer, 0, wx.ALL | wx.EXPAND, 7)
-        rob_static_sizer.Add(rob_status_sizer, 0, wx.ALL | wx.EXPAND, 7)
-        rob_static_sizer.Add(pressure_sizer, 0, wx.ALL | wx.EXPAND, 10)
-
-        main_sizer = wx.BoxSizer(wx.VERTICAL)
-        main_sizer.Add(rob_static_sizer, 0, wx.ALL | wx.EXPAND, 7)
-        self.SetSizerAndFit(main_sizer)
-        self.Layout()
-
-        self.robot.CheckConnection()  # Check if robot is connected and update GUI accordingly
+        self.main_sizer.Add(rob_static_sizer, 0, wx.ALL | wx.EXPAND, 7)
 
     def __bind_events(self):
         Publisher.subscribe(self.OnRobotEnabled, "Enable robot")

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1202,7 +1202,10 @@ class ObjectTab(wx.Panel):
         Publisher.subscribe(self.OnSetCoilCount, "Reset coil selection")
         Publisher.subscribe(self.OnEnableRobot, "Enable robot")
 
-    def OnEnableRobot(self, enabled=False):
+    def OnEnableRobot(self, enabled=False, robot_id=None):
+        if robot_id is not None and robot_id != self.robot.robot_id:
+            return
+
         if enabled:
             self.choice_robot_coil.Show(True)
             self.robot_lbl.SetLabel("Robot is connected. Coil attached to robot: ")
@@ -2056,7 +2059,10 @@ class RobotSetupPanel(wx.Panel):
         else:
             self.ShowParent()
 
-    def OnRobotStatus(self, status):
+    def OnRobotStatus(self, status, robot_id=None):
+        if robot_id is not None and robot_id != self.robot.robot_id:
+            return
+
         if self.robot.robot_ip is not None:
             self.status_text.SetLabelText(_(f"{status} to robot on {self.robot.robot_ip}"))
         else:
@@ -2070,7 +2076,10 @@ class RobotSetupPanel(wx.Panel):
         self._update_pressure_controls_state(use_pressure_sensor and self.robot.IsConnected())
         self.Layout()
 
-    def OnRobotEnabled(self, enabled=False):
+    def OnRobotEnabled(self, enabled=False, robot_id=None):
+        if robot_id is not None and robot_id != self.robot.robot_id:
+            return
+
         if enabled:
             self.status_text.SetLabelText(_("Setup robot transformation matrix:"))
             self.btn_rob_con.Show()

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -70,7 +70,7 @@ class Preferences(wx.Dialog):
             )
 
             self.navigation_tab = NavigationTab(self.book, navigation)
-            self.tracker_tab = TrackerTab(self.book, tracker, robots)
+            self.tracker_tab = TrackerTab(self.book, tracker, robots, navigation)
             self.object_tab = ObjectTab(self.book, navigation, tracker, pedal_connector, robots)
 
             self.book.AddPage(self.navigation_tab, _("Navigation"))
@@ -2222,7 +2222,7 @@ class RobotSetupPanel(wx.Panel):
 
 
 class TrackerTab(wx.Panel):
-    def __init__(self, parent, tracker, robots):
+    def __init__(self, parent, tracker, robots, navigation):
         wx.Panel.__init__(self, parent)
 
         self.session = ses.Session()
@@ -2231,6 +2231,7 @@ class TrackerTab(wx.Panel):
 
         self.tracker = tracker
         self.robots = robots
+        self.navigation = navigation
 
         self.n_coils = 1
         self.LoadConfig()
@@ -2310,7 +2311,7 @@ class TrackerTab(wx.Panel):
 
         # Ensure at least two robots exist in Robots manager for the UI
         while len(self.robots.robots_by_id) < 2:
-            self.robots.AddRobot(tracker=self.tracker, navigation=None, icp=None)
+            self.robots.AddRobot(tracker=self.tracker, navigation=self.navigation, icp=None)
 
         robot_0 = self.robots.GetRobot(0)
         robot_1 = self.robots.GetRobot(1)

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -71,7 +71,7 @@ class Preferences(wx.Dialog):
 
             self.navigation_tab = NavigationTab(self.book, navigation)
             self.tracker_tab = TrackerTab(self.book, tracker, robots)
-            self.object_tab = ObjectTab(self.book, navigation, tracker, pedal_connector)
+            self.object_tab = ObjectTab(self.book, navigation, tracker, pedal_connector, robots)
 
             self.book.AddPage(self.navigation_tab, _("Navigation"))
             self.book.AddPage(self.tracker_tab, _("Tracker"))
@@ -1008,7 +1008,7 @@ class NavigationTab(wx.Panel):
 
 
 class ObjectTab(wx.Panel):
-    def __init__(self, parent, navigation, tracker, pedal_connector):
+    def __init__(self, parent, navigation, tracker, pedal_connector, robots):
         wx.Panel.__init__(self, parent)
 
         self.session = ses.Session()
@@ -1018,7 +1018,7 @@ class ObjectTab(wx.Panel):
         self.tracker = tracker
         self.pedal_connector = pedal_connector
         self.navigation = navigation
-        self.robots = Robots()
+        self.robots = robots
         self.robot = self.robots.GetRobot(0)
         self.coil_registrations = {}
         self.__bind_events()

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -18,7 +18,7 @@ from invesalius import inv_paths, utils
 from invesalius.gui.language_dialog import ComboBoxLanguage
 from invesalius.i18n import tr as _
 from invesalius.navigation.navigation import Navigation
-from invesalius.navigation.robot import Robot
+from invesalius.navigation.robot import Robot, Robots
 from invesalius.navigation.tracker import Tracker
 from invesalius.net.neuronavigation_api import NeuronavigationApi
 from invesalius.net.pedal_connection import PedalConnector
@@ -51,7 +51,17 @@ class Preferences(wx.Dialog):
         mode = session.GetConfig("mode")
         if mode == const.MODE_NAVIGATOR:
             tracker = Tracker()
-            robot = Robot()
+            robots = Robots()
+            # If the robot is not initialized yet (maybe NavigationHub hasn't run),
+            # this gets the first robot or creates one.
+            if len(robots.robots_by_id) == 0:
+                robots.AddRobot(
+                    tracker=tracker,
+                    navigation=Navigation(
+                        pedal_connector=None, neuronavigation_api=NeuronavigationApi()
+                    ),
+                    icp=None,
+                )
             neuronavigation_api = NeuronavigationApi()
             pedal_connector = PedalConnector(neuronavigation_api, self)
             navigation = Navigation(
@@ -60,7 +70,7 @@ class Preferences(wx.Dialog):
             )
 
             self.navigation_tab = NavigationTab(self.book, navigation)
-            self.tracker_tab = TrackerTab(self.book, tracker, robot)
+            self.tracker_tab = TrackerTab(self.book, tracker, robots)
             self.object_tab = ObjectTab(self.book, navigation, tracker, pedal_connector)
 
             self.book.AddPage(self.navigation_tab, _("Navigation"))
@@ -2217,7 +2227,7 @@ class RobotSetupPanel(wx.Panel):
 
 
 class TrackerTab(wx.Panel):
-    def __init__(self, parent, tracker, robot):
+    def __init__(self, parent, tracker, robots):
         wx.Panel.__init__(self, parent)
 
         self.session = ses.Session()
@@ -2225,7 +2235,7 @@ class TrackerTab(wx.Panel):
         self.__bind_events()
 
         self.tracker = tracker
-        self.robot = robot
+        self.robots = robots
 
         self.n_coils = 1
         self.LoadConfig()
@@ -2303,14 +2313,29 @@ class TrackerTab(wx.Panel):
         tracker_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, _("Setup tracker"))
         tracker_sizer.Add(ref_sizer, 1, wx.ALL | wx.FIXED_MINSIZE, 20)
 
-        # Robot setup panel (child component)
-        self.robot_setup_panel = RobotSetupPanel(self, robot)
+        # Ensure at least two robots exist in Robots manager for the UI
+        while len(self.robots.robots_by_id) < 2:
+            self.robots.AddRobot(tracker=self.tracker, navigation=None, icp=None)
+
+        robot_0 = self.robots.GetRobot(0)
+        robot_1 = self.robots.GetRobot(1)
+
+        # Robot setup panel (child component) for ID 0
+        self.robot_setup_panel_0 = RobotSetupPanel(self, robot_0)
+
+        # Robot setup panel (child component) for ID 1
+        self.robot_setup_panel_1 = RobotSetupPanel(self, robot_1)
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         main_sizer.Add(tracker_sizer, 0, wx.ALL | wx.EXPAND, 7)
-        main_sizer.Add(self.robot_setup_panel, 0, wx.ALL | wx.EXPAND, 0)
+        main_sizer.Add(self.robot_setup_panel_0, 0, wx.ALL | wx.EXPAND, 0)
+        main_sizer.Add(self.robot_setup_panel_1, 0, wx.ALL | wx.EXPAND, 0)
+
+        self.main_sizer = main_sizer
         self.SetSizerAndFit(main_sizer)
         self.Layout()
+
+        self.UpdateRobotPanelsVisibility()
 
     def __bind_events(self):
         Publisher.subscribe(self.ShowParent, "Show preferences dialog")
@@ -2328,6 +2353,8 @@ class TrackerTab(wx.Panel):
             self.n_coils = 1
 
         if self.n_coils != old_n_coils:  # if n_coils was changed reset connection
+            self.UpdateRobotPanelsVisibility()
+
             clear_all = True
             tracker_id = self.tracker.tracker_id
             self.tracker.DisconnectTracker()
@@ -2376,6 +2403,16 @@ class TrackerTab(wx.Panel):
 
     def ShowParent(self):  # show preferences dialog box
         self.GetGrandParent().Show()
+
+    def UpdateRobotPanelsVisibility(self):
+        if self.n_coils > 1:
+            self.main_sizer.Show(self.robot_setup_panel_1)
+        else:
+            self.main_sizer.Hide(self.robot_setup_panel_1)
+
+        self.Layout()
+        if self.GetParent():
+            self.GetParent().Layout()
 
 
 class LanguageTab(wx.Panel):

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1019,7 +1019,13 @@ class ObjectTab(wx.Panel):
         self.pedal_connector = pedal_connector
         self.navigation = navigation
         self.robots = robots
-        self.robot = self.robots.GetRobot(0)
+
+        # Ensure at least two robots exist for the UI
+        while len(self.robots.robots_by_id) < 2:
+            self.robots.AddRobot(tracker=self.tracker, navigation=self.navigation, icp=None)
+
+        self.robot_0 = self.robots.GetRobot(0)
+        self.robot_1 = self.robots.GetRobot(1)
         self.coil_registrations = {}
         self.__bind_events()
 
@@ -1150,34 +1156,52 @@ class ObjectTab(wx.Panel):
             self,
             _("Robot coil selection"),
         )
-        self.inner_robot_sizer = inner_robot_sizer = wx.FlexGridSizer(2, 1, 1)
+        self.inner_robot_sizer = inner_robot_sizer = wx.FlexGridSizer(4, 1, 1)
 
-        self.robot_lbl = wx.StaticText(self, -1, _("Robot is connected. Coil attached to robot: "))
-        self.choice_robot_coil = choice_robot_coil = wx.ComboBox(
+        # Robot 0
+        self.robot_0_lbl = wx.StaticText(self, -1, _("Robot 0 is connected. Coil attached: "))
+        self.choice_robot_0_coil = wx.ComboBox(
             self,
             -1,
-            f"{self.robot.GetCoilName() or ''}",
+            f"{self.robot_0.GetCoilName() or ''}",
             size=wx.Size(90, 23),
-            choices=list(
-                self.navigation.coil_registrations
-            ),  # List of coils selected for navigation
+            choices=list(self.navigation.coil_registrations),
             style=wx.CB_DROPDOWN | wx.CB_READONLY,
         )
-
-        choice_robot_coil.SetToolTip(
-            "Specify which coil is attached to the robot",
+        self.choice_robot_0_coil.SetToolTip("Specify which coil is attached to Robot 0")
+        self.choice_robot_0_coil.Bind(
+            wx.EVT_COMBOBOX, lambda evt: self.OnChoiceRobotCoil(evt, self.robot_0)
         )
 
-        choice_robot_coil.Bind(wx.EVT_COMBOBOX, self.OnChoiceRobotCoil)
+        if not self.robot_0.IsConnected():
+            self.robot_0_lbl.SetLabel("Robot 0 is not connected")
+            self.choice_robot_0_coil.Show(False)
 
-        if not self.robot.IsConnected():
-            self.robot_lbl.SetLabel("Robot is not connected")
-            choice_robot_coil.Show(False)  # Hide the combobox
+        # Robot 1
+        self.robot_1_lbl = wx.StaticText(self, -1, _("Robot 1 is connected. Coil attached: "))
+        self.choice_robot_1_coil = wx.ComboBox(
+            self,
+            -1,
+            f"{self.robot_1.GetCoilName() or ''}",
+            size=wx.Size(90, 23),
+            choices=list(self.navigation.coil_registrations),
+            style=wx.CB_DROPDOWN | wx.CB_READONLY,
+        )
+        self.choice_robot_1_coil.SetToolTip("Specify which coil is attached to Robot 1")
+        self.choice_robot_1_coil.Bind(
+            wx.EVT_COMBOBOX, lambda evt: self.OnChoiceRobotCoil(evt, self.robot_1)
+        )
+
+        if not self.robot_1.IsConnected():
+            self.robot_1_lbl.SetLabel("Robot 1 is not connected")
+            self.choice_robot_1_coil.Show(False)
 
         inner_robot_sizer.AddMany(
             [
-                (self.robot_lbl, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
-                (choice_robot_coil, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
+                (self.robot_0_lbl, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
+                (self.choice_robot_0_coil, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
+                (self.robot_1_lbl, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
+                (self.choice_robot_1_coil, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, 5),
             ]
         )
 
@@ -1203,18 +1227,22 @@ class ObjectTab(wx.Panel):
         Publisher.subscribe(self.OnEnableRobot, "Enable robot")
 
     def OnEnableRobot(self, enabled=False, robot_id=None):
-        if robot_id is not None and robot_id != self.robot.robot_id:
-            return
+        if robot_id == 0:
+            if enabled:
+                self.choice_robot_0_coil.Show(True)
+                self.robot_0_lbl.SetLabel("Robot 0 is connected. Coil attached: ")
+            else:
+                self.robot_0_lbl.SetLabel("Robot 0 is not connected.")
+        elif robot_id == 1:
+            if enabled:
+                self.choice_robot_1_coil.Show(True)
+                self.robot_1_lbl.SetLabel("Robot 1 is connected. Coil attached: ")
+            else:
+                self.robot_1_lbl.SetLabel("Robot 1 is not connected.")
 
-        if enabled:
-            self.choice_robot_coil.Show(True)
-            self.robot_lbl.SetLabel("Robot is connected. Coil attached to robot: ")
-        else:
-            self.robot_lbl.SetLabel("Robot is not connected.")
-
-    def OnChoiceRobotCoil(self, event):
+    def OnChoiceRobotCoil(self, event, robot):
         robot_coil_name = event.GetEventObject().GetStringSelection()
-        self.robot.SetCoilName(robot_coil_name)
+        robot.SetCoilName(robot_coil_name)
         Publisher.sendMessage("Coil selection done", done=True)
         Publisher.sendMessage("Update robot buttons")
 
@@ -1330,7 +1358,10 @@ class ObjectTab(wx.Panel):
         self.robot_sizer.ShowItems(show_multicoil)
 
         # Show the robot coil combobox only if the robot is connected
-        self.choice_robot_coil.Show(show_multicoil and self.robot.IsConnected())
+        if hasattr(self, "choice_robot_0_coil"):
+            self.choice_robot_0_coil.Show(show_multicoil and self.robot_0.IsConnected())
+        if hasattr(self, "choice_robot_1_coil"):
+            self.choice_robot_1_coil.Show(show_multicoil and self.robot_1.IsConnected())
 
         self.Layout()
 
@@ -1408,7 +1439,11 @@ class ObjectTab(wx.Panel):
 
     def CoilSelectionDone(self):
         if self.navigation.n_coils == 1:  # Tell the robot the coil name
-            self.robot.SetCoilName(next(iter(self.navigation.coil_registrations)))
+            coil_name = next(iter(self.navigation.coil_registrations))
+            if hasattr(self, "robot_0"):
+                self.robot_0.SetCoilName(coil_name)
+            if hasattr(self, "robot_1"):
+                self.robot_1.SetCoilName(coil_name)
 
         Publisher.sendMessage("Coil selection done", done=True)
         Publisher.sendMessage("Update status text in GUI", label=_("Ready"))
@@ -1483,9 +1518,13 @@ class ObjectTab(wx.Panel):
         )
 
         # Update robot coil combobox
-        if self.choice_robot_coil is not None:
-            self.choice_robot_coil.Set(list(navigation.coil_registrations))
-            self.choice_robot_coil.SetStringSelection(self.robot.GetCoilName() or "")
+        if hasattr(self, "choice_robot_0_coil") and self.choice_robot_0_coil is not None:
+            self.choice_robot_0_coil.Set(list(navigation.coil_registrations))
+            self.choice_robot_0_coil.SetStringSelection(self.robot_0.GetCoilName() or "")
+
+        if hasattr(self, "choice_robot_1_coil") and self.choice_robot_1_coil is not None:
+            self.choice_robot_1_coil.Set(list(navigation.coil_registrations))
+            self.choice_robot_1_coil.SetStringSelection(self.robot_1.GetCoilName() or "")
 
         if n_coils_selected == n_coils:
             self.CoilSelectionDone()

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -99,6 +99,8 @@ class Preferences(wx.Dialog):
         self.Layout()
         self.__bind_events()
 
+        Publisher.sendMessage("Stop navigation")
+
     def __bind_events(self):
         Publisher.subscribe(self.LoadPreferences, "Load Preferences")
 

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1523,11 +1523,19 @@ class ObjectTab(wx.Panel):
         # Update robot coil combobox
         if hasattr(self, "choice_robot_0_coil") and self.choice_robot_0_coil is not None:
             self.choice_robot_0_coil.Set(list(navigation.coil_registrations))
-            self.choice_robot_0_coil.SetStringSelection(self.robot_0.GetCoilName() or "")
+            coil_0 = self.robot_0.GetCoilName()
+            if coil_0 and coil_0 in navigation.coil_registrations:
+                self.choice_robot_0_coil.SetStringSelection(coil_0)
+            else:
+                self.choice_robot_0_coil.SetSelection(wx.NOT_FOUND)
 
         if hasattr(self, "choice_robot_1_coil") and self.choice_robot_1_coil is not None:
             self.choice_robot_1_coil.Set(list(navigation.coil_registrations))
-            self.choice_robot_1_coil.SetStringSelection(self.robot_1.GetCoilName() or "")
+            coil_1 = self.robot_1.GetCoilName()
+            if coil_1 and coil_1 in navigation.coil_registrations:
+                self.choice_robot_1_coil.SetStringSelection(coil_1)
+            else:
+                self.choice_robot_1_coil.SetSelection(wx.NOT_FOUND)
 
         if n_coils_selected == n_coils:
             self.CoilSelectionDone()

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -1156,7 +1156,9 @@ class ObjectTab(wx.Panel):
             self,
             _("Robot coil selection"),
         )
-        self.inner_robot_sizer = inner_robot_sizer = wx.FlexGridSizer(4, 1, 1)
+        self.inner_robot_sizer = inner_robot_sizer = wx.FlexGridSizer(
+            rows=2, cols=2, vgap=5, hgap=5
+        )
 
         # Robot 0
         self.robot_0_lbl = wx.StaticText(self, -1, _("Robot 0 is connected. Coil attached: "))
@@ -1232,13 +1234,16 @@ class ObjectTab(wx.Panel):
                 self.choice_robot_0_coil.Show(True)
                 self.robot_0_lbl.SetLabel("Robot 0 is connected. Coil attached: ")
             else:
+                self.choice_robot_0_coil.Show(False)
                 self.robot_0_lbl.SetLabel("Robot 0 is not connected.")
         elif robot_id == 1:
             if enabled:
                 self.choice_robot_1_coil.Show(True)
                 self.robot_1_lbl.SetLabel("Robot 1 is connected. Coil attached: ")
             else:
+                self.choice_robot_1_coil.Show(False)
                 self.robot_1_lbl.SetLabel("Robot 1 is not connected.")
+        self.Layout()
 
     def OnChoiceRobotCoil(self, event, robot):
         robot_coil_name = event.GetEventObject().GetStringSelection()
@@ -1442,8 +1447,6 @@ class ObjectTab(wx.Panel):
             coil_name = next(iter(self.navigation.coil_registrations))
             if hasattr(self, "robot_0"):
                 self.robot_0.SetCoilName(coil_name)
-            if hasattr(self, "robot_1"):
-                self.robot_1.SetCoilName(coil_name)
 
         Publisher.sendMessage("Coil selection done", done=True)
         Publisher.sendMessage("Update status text in GUI", label=_("Ready"))

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -2145,11 +2145,9 @@ class RobotSetupPanel(wx.Panel):
             gray_color = wx.Colour(150, 150, 150)
             self.pressure_lbl.SetForegroundColour(gray_color)
             self.pressure_val_lbl.SetForegroundColour(gray_color)
-            self.pressure_rec_lbl.SetForegroundColour(gray_color)
 
         self.pressure_lbl.Refresh()
         self.pressure_val_lbl.Refresh()
-        self.pressure_rec_lbl.Refresh()
 
     def OnTogglePressureSensor(self, evt):
         enabled = self.chk_enable_pressure.GetValue()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2730,6 +2730,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         self.navigation = nav_hub.navigation
         self.markers = nav_hub.markers
         self.robot = nav_hub.robot
+        self.robots = nav_hub.robots
 
         if has_mTMS:
             self.mTMS = mTMS()
@@ -3688,11 +3689,28 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
         select_main_coil = self.select_main_coil
         if done:
             select_main_coil.Clear()
-            robot_coil = self.robot.GetCoilName()
-            choices = [
-                f"{coil} (robot)" if coil == robot_coil else coil
-                for coil in self.navigation.coil_registrations
-            ]
+
+            coil_to_robots = {}
+            if hasattr(self, "robots") and self.robots is not None:
+                for r_id, r in self.robots.robots_by_id.items():
+                    r_coil = r.GetCoilName()
+                    if r_coil:
+                        if r_coil not in coil_to_robots:
+                            coil_to_robots[r_coil] = []
+                        coil_to_robots[r_coil].append(str(r_id))
+            elif hasattr(self, "robot") and self.robot is not None:
+                r_coil = self.robot.GetCoilName()
+                if r_coil:
+                    coil_to_robots[r_coil] = ["0"]
+
+            choices = []
+            for coil in self.navigation.coil_registrations:
+                if coil in coil_to_robots:
+                    r_str = ", ".join(coil_to_robots[coil])
+                    choices.append(f"{coil} (robot {r_str})")
+                else:
+                    choices.append(coil)
+
             select_main_coil.AppendItems(choices)
             try:
                 main_coil_index = list(self.navigation.coil_registrations).index(
@@ -3713,7 +3731,9 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
     def OnChooseMainCoil(self, evt, ctrl):
         choice = evt.GetSelection()
         main_coil = ctrl.GetString(choice)
-        if main_coil.endswith(" (robot)"):
+        if " (robot " in main_coil:
+            main_coil = main_coil.split(" (robot ")[0]
+        elif main_coil.endswith(" (robot)"):
             main_coil = main_coil[:-8]
         self.navigation.SetMainCoil(main_coil)
         ctrl.SetSelection(choice)

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3006,6 +3006,7 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
 
         # Update main_coil combobox
         Publisher.subscribe(self.UpdateMainCoilCombobox, "Coil selection done")
+        Publisher.subscribe(self.UpdateMainCoilCombobox, "Update option main coil")
 
         # Update marker_list_ctrl
         Publisher.subscribe(self._AddMarker, "Add marker")

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2075,7 +2075,7 @@ class RobotButtonsPanel(wx.Panel):
         # Enable 'reset errors' robot button if robot is connected.
         self.EnableRobotResetErrorsButton(enabled=robot_connected)
 
-    def OnEnableRobotButtons(self, enabled=False):
+    def OnEnableRobotButtons(self, enabled=False, robot_id=None):
         self.UpdateRobotButtons()
 
     # 'Track target with robot' button

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -43,7 +43,7 @@ from invesalius.i18n import tr as _
 from invesalius.navigation.image import Image
 from invesalius.navigation.iterativeclosestpoint import IterativeClosestPoint
 from invesalius.navigation.markers import MarkersControl
-from invesalius.navigation.robot import Robot, Robots
+from invesalius.navigation.robot import Robots
 from invesalius.navigation.tracker import Tracker
 from invesalius.net.neuronavigation_api import NeuronavigationApi
 from invesalius.net.pedal_connection import PedalConnector
@@ -67,11 +67,12 @@ class NavigationHub(metaclass=Singleton):
         )
         self.robots = Robots()
         # Initialize the first robot by default
-        self.robot = self.robots.AddRobot(
-            tracker=self.tracker,
-            navigation=self.navigation,
-            icp=self.icp,
-        )
+        if len(self.robots.robots_by_id) == 0:
+            self.robot = self.robots.AddRobot(
+                tracker=self.tracker,
+                navigation=self.navigation,
+                icp=self.icp,
+            )
         self.markers = MarkersControl(robot=self.robot)
         self.mep_visualizer = MEPVisualizer()
         Publisher.sendMessage("Add navigation context to interactive shell")

--- a/invesalius/navigation/navigation.py
+++ b/invesalius/navigation/navigation.py
@@ -43,7 +43,7 @@ from invesalius.i18n import tr as _
 from invesalius.navigation.image import Image
 from invesalius.navigation.iterativeclosestpoint import IterativeClosestPoint
 from invesalius.navigation.markers import MarkersControl
-from invesalius.navigation.robot import Robot
+from invesalius.navigation.robot import Robot, Robots
 from invesalius.navigation.tracker import Tracker
 from invesalius.net.neuronavigation_api import NeuronavigationApi
 from invesalius.net.pedal_connection import PedalConnector
@@ -65,7 +65,9 @@ class NavigationHub(metaclass=Singleton):
         self.navigation = Navigation(
             pedal_connector=self.pedal_connector, neuronavigation_api=self.neuronavigation_api
         )
-        self.robot = Robot(
+        self.robots = Robots()
+        # Initialize the first robot by default
+        self.robot = self.robots.AddRobot(
             tracker=self.tracker,
             navigation=self.navigation,
             icp=self.icp,

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -158,6 +158,9 @@ class Robot:
             Publisher.sendMessage(
                 "Neuronavigation to Robot: Request config", robot_id=self.robot_id
             )
+        else:
+            self.SetCoilName(None)
+            Publisher.sendMessage("Update option main coil", done=True)
 
     def RegisterRobot(self):
         Publisher.sendMessage("End busy cursor")

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -129,7 +129,10 @@ class Robot:
         success = self.robot_ip is not None and self.matrix_tracker_to_robot is not None
         return success
 
-    def OnRobotConnectionStatus(self, data):
+    def OnRobotConnectionStatus(self, data, robot_id=None):
+        if robot_id is not None and robot_id != self.robot_id:
+            return
+
         self.is_robot_connected = True if data == "Connected" else False
 
         # Send to preference active robot connection status
@@ -177,7 +180,10 @@ class Robot:
         self.SaveConfig()
         self.InitializeRobot()
 
-    def AbortRobotConfiguration(self):
+    def AbortRobotConfiguration(self, robot_id=None):
+        if robot_id is not None and robot_id != self.robot_id:
+            return
+
         if self.robot_coregistration_dialog:
             self.robot_coregistration_dialog.Destroy()
 
@@ -297,7 +303,10 @@ class Robot:
                 "Robot to Neuronavigation: Update robot warning", robot_warning=""
             )
 
-    def SetObjectiveByRobot(self, objective):
+    def SetObjectiveByRobot(self, objective, robot_id=None):
+        if robot_id is not None and robot_id != self.robot_id:
+            return
+
         if objective is None:
             return
 
@@ -315,7 +324,10 @@ class Robot:
             Publisher.sendMessage("Press robot button", pressed=False)
             Publisher.sendMessage("Press move away button", pressed=False)
 
-    def OnRobotInitialConfig(self, config):
+    def OnRobotInitialConfig(self, config, robot_id=None):
+        if robot_id is not None and robot_id != self.robot_id:
+            return
+
         if not config:
             return
 

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -36,16 +36,16 @@ class RobotObjective(Enum):
     MOVE_AWAY_FROM_HEAD = 2
 
 
-# Only one robot will be initialized per time. Therefore, we use
-# Singleton design pattern for implementing it
-class Robot(metaclass=Singleton):
-    def __init__(self, tracker, navigation, icp):
+# The Robot class represents a single robot instance.
+class Robot:
+    def __init__(self, robot_id, tracker, navigation, icp, coil_name=None):
+        self.robot_id = robot_id
         self.tracker = tracker
         self.navigation = navigation
         self.icp = icp
         self.enabled_in_gui = False
 
-        self.coil_name = None
+        self.coil_name = coil_name
         self.use_pressure_sensor = False
         self.is_robot_connected = False
         self.robot_ip = None
@@ -70,7 +70,7 @@ class Robot(metaclass=Singleton):
 
         self.__bind_events()
 
-        Publisher.sendMessage("Neuronavigation to Robot: Request config")
+        Publisher.sendMessage("Neuronavigation to Robot: Request config", robot_id=self.robot_id)
 
     def __bind_events(self):
         Publisher.subscribe(
@@ -88,25 +88,29 @@ class Robot(metaclass=Singleton):
 
     def SaveConfig(self, key=None, value=None):
         session = ses.Session()
+        config_key = f"robot_{self.robot_id}"
         if key is None or value is None:
             # Save the whole state
             state = {
                 "robot_ip": self.robot_ip,
                 "robot_ip_options": self.robot_ip_options,
-                "tracker_to_robot": self.matrix_tracker_to_robot.tolist(),
+                "tracker_to_robot": self.matrix_tracker_to_robot.tolist()
+                if self.matrix_tracker_to_robot is not None
+                else None,
                 "use_pressure_sensor": self.use_pressure_sensor,
             }
             if self.coil_name is not None:
                 state["robot_coil"] = self.coil_name
         else:
-            state = session.GetConfig("robot", {})
+            state = session.GetConfig(config_key, {})
             state[key] = value
 
-        session.SetConfig("robot", state)
+        session.SetConfig(config_key, state)
 
     def LoadConfig(self):
         session = ses.Session()
-        state = session.GetConfig("robot", {})
+        config_key = f"robot_{self.robot_id}"
+        state = session.GetConfig(config_key, {})
 
         self.coil_name = state.get("robot_coil", None)
 
@@ -137,7 +141,9 @@ class Robot(metaclass=Singleton):
 
             # Ensure we fetch the robot-side config early so features like the force/pressure
             # overlay can be initialized without requiring the Preferences dialog to be opened.
-            Publisher.sendMessage("Neuronavigation to Robot: Request config")
+            Publisher.sendMessage(
+                "Neuronavigation to Robot: Request config", robot_id=self.robot_id
+            )
 
     def RegisterRobot(self):
         Publisher.sendMessage("End busy cursor")
@@ -189,12 +195,17 @@ class Robot(metaclass=Singleton):
             self.is_robot_connected = False
             Publisher.sendMessage("Enable robot", enabled=self.is_robot_connected)
 
-        Publisher.sendMessage("Neuronavigation to Robot: Connect to robot", robot_IP=self.robot_ip)
+        Publisher.sendMessage(
+            "Neuronavigation to Robot: Connect to robot",
+            robot_IP=self.robot_ip,
+            robot_id=self.robot_id,
+        )
 
     def InitializeRobot(self):
         Publisher.sendMessage(
             "Neuronavigation to Robot: Set robot transformation matrix",
             data=self.matrix_tracker_to_robot.tolist(),
+            robot_id=self.robot_id,
         )
         self.SetCoilName(self.coil_name) if self.coil_name is not None else "default_coil"
         Publisher.sendMessage("Robot transformation matrix set")
@@ -214,6 +225,7 @@ class Robot(metaclass=Singleton):
         Publisher.sendMessage(
             "Neuronavigation to Robot: Set coil index",
             coil_idx=coil_idx,
+            robot_id=self.robot_id,
         )
         self.SaveConfig("robot_coil", name)
 
@@ -252,12 +264,15 @@ class Robot(metaclass=Singleton):
         Publisher.sendMessage(
             "Neuronavigation to Robot: Set target",
             target=m_target.tolist(),
+            robot_id=self.robot_id,
         )
 
     def TrackerFiducialsSet(self):
         tracker_fiducials = self.tracker.GetMatrixTrackerFiducials()
         Publisher.sendMessage(
-            "Neuronavigation to Robot: Set tracker fiducials", tracker_fiducials=tracker_fiducials
+            "Neuronavigation to Robot: Set tracker fiducials",
+            tracker_fiducials=tracker_fiducials,
+            robot_id=self.robot_id,
         )
 
     def SetObjective(self, objective):
@@ -267,7 +282,11 @@ class Robot(metaclass=Singleton):
             return
 
         self.objective = objective
-        Publisher.sendMessage("Neuronavigation to Robot: Set objective", objective=objective.value)
+        Publisher.sendMessage(
+            "Neuronavigation to Robot: Set objective",
+            objective=objective.value,
+            robot_id=self.robot_id,
+        )
 
         if self.objective == RobotObjective.NONE:
             Publisher.sendMessage(
@@ -308,18 +327,21 @@ class Robot(metaclass=Singleton):
         if active:
             pressure_setpoint = ses.Session().GetConfig("pressure_setpoint", 5.0)
             Publisher.sendMessage(
-                "Neuronavigation to Robot: Pressure set point", pressure=pressure_setpoint
+                "Neuronavigation to Robot: Pressure set point",
+                pressure=pressure_setpoint,
+                robot_id=self.robot_id,
             )
 
         if notify_robot:
             Publisher.sendMessage(
                 "Neuronavigation to Robot: Update config",
                 use_pressure_sensor=self.use_pressure_sensor,
+                robot_id=self.robot_id,
             )
 
     def UnsetTarget(self, marker):
         self.target = None
-        Publisher.sendMessage("Neuronavigation to Robot: Unset target")
+        Publisher.sendMessage("Neuronavigation to Robot: Unset target", robot_id=self.robot_id)
 
     def SetTarget(self, marker):
         coord = marker.position + marker.orientation
@@ -332,13 +354,21 @@ class Robot(metaclass=Singleton):
         self.SendTargetToRobot()
 
     def SetPressureSetpoint(self, pressure):
-        Publisher.sendMessage("Neuronavigation to Robot: Pressure set point", pressure=pressure)
+        Publisher.sendMessage(
+            "Neuronavigation to Robot: Pressure set point",
+            pressure=pressure,
+            robot_id=self.robot_id,
+        )
 
     def CheckConnection(self):
-        Publisher.sendMessage("Neuronavigation to Robot: Check connection robot")
+        Publisher.sendMessage(
+            "Neuronavigation to Robot: Check connection robot", robot_id=self.robot_id
+        )
 
     def SetFreeDrive(self, enabled):
-        Publisher.sendMessage("Neuronavigation to Robot: Set free drive", set=enabled)
+        Publisher.sendMessage(
+            "Neuronavigation to Robot: Set free drive", set=enabled, robot_id=self.robot_id
+        )
 
     def ResetErrors(self):
         if self.objective == RobotObjective.TRACK_TARGET:
@@ -346,4 +376,33 @@ class Robot(metaclass=Singleton):
 
         Publisher.sendMessage(
             "Neuronavigation to Robot: Reset errors",
+            robot_id=self.robot_id,
         )
+
+
+class Robots(metaclass=Singleton):
+    """
+    Manager class for multiple Robot instances.
+    Maintains a mapping of robot_id to Robot and coil_name to Robot.
+    """
+
+    def __init__(self):
+        self.robots_by_id = {}
+        self.robots_by_coil = {}
+        self.n_robots_created = 0
+
+    def AddRobot(self, tracker, navigation, icp, coil_name=None):
+        robot_id = self.n_robots_created
+        self.n_robots_created += 1
+
+        new_robot = Robot(robot_id, tracker, navigation, icp, coil_name)
+        self.robots_by_id[robot_id] = new_robot
+        if coil_name:
+            self.robots_by_coil[coil_name] = new_robot
+        return new_robot
+
+    def GetActiveRobot(self, main_coil_name):
+        return self.robots_by_coil.get(main_coil_name)
+
+    def GetRobot(self, robot_id):
+        return self.robots_by_id.get(robot_id)

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -112,6 +112,10 @@ class Robot:
         config_key = f"robot_{self.robot_id}"
         state = session.GetConfig(config_key, {})
 
+        # Fallback to legacy "robot" config for the primary robot (id 0) to maintain backward compatibility
+        if not state and self.robot_id == 0:
+            state = session.GetConfig("robot", {})
+
         self.coil_name = state.get("robot_coil", None)
 
         self.robot_ip = state.get("robot_ip", None)

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -22,6 +22,7 @@ from enum import Enum
 import numpy as np
 import wx
 
+import invesalius.constants as const
 import invesalius.data.coregistration as dcr
 import invesalius.gui.dialogs as dlg
 import invesalius.session as ses
@@ -120,6 +121,10 @@ class Robot:
 
         self.robot_ip = state.get("robot_ip", None)
         self.robot_ip_options = state.get("robot_ip_options", [])
+
+        if not self.robot_ip_options:
+            self.robot_ip_options = list(const.ROBOT_IPS)
+
         self.use_pressure_sensor = state.get("use_pressure_sensor", False)
 
         self.matrix_tracker_to_robot = state.get("tracker_to_robot", None)

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -244,6 +244,9 @@ class Robot:
         self.SaveConfig("robot_coil", name)
 
     def SendTargetToRobot(self):
+        if not self.IsReady():
+            return
+
         # If the target is not set, return early.
         if self.target is None or self.navigation.main_coil != self.coil_name:
             return False

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -136,8 +136,10 @@ class Robot:
         self.is_robot_connected = True if data == "Connected" else False
 
         # Send to preference active robot connection status
-        Publisher.sendMessage("Update robot status connection", status=data)
-        Publisher.sendMessage("Enable robot", enabled=self.is_robot_connected)
+        Publisher.sendMessage("Update robot status connection", status=data, robot_id=self.robot_id)
+        Publisher.sendMessage(
+            "Enable robot", enabled=self.is_robot_connected, robot_id=self.robot_id
+        )
 
         # If the robot is connected, we add the robot IP to the list of options if it's not already there, and request the robot-side config.
         if self.is_robot_connected:
@@ -203,7 +205,9 @@ class Robot:
 
         if self.IsConnected():
             self.is_robot_connected = False
-            Publisher.sendMessage("Enable robot", enabled=self.is_robot_connected)
+            Publisher.sendMessage(
+                "Enable robot", enabled=self.is_robot_connected, robot_id=self.robot_id
+            )
 
         Publisher.sendMessage(
             "Neuronavigation to Robot: Connect to robot",

--- a/invesalius/session.py
+++ b/invesalius/session.py
@@ -108,7 +108,6 @@ class Session(metaclass=Singleton):
         self._config = CONFIG_INIT
         self._config["mode"] = const.MODE_RP
         self._config["project_status"] = const.PROJECT_STATUS_CLOSED
-        self._config["robot"] = {"robot_ip_options": const.ROBOT_IPS}
 
         self.WriteConfigFile()
 
@@ -119,7 +118,6 @@ class Session(metaclass=Singleton):
             config_init = CONFIG_INIT
             config_init["mode"] = const.MODE_RP
             config_init["project_status"] = const.PROJECT_STATUS_CLOSED
-            config_init["robot"] = {"robot_ip_options": const.ROBOT_IPS}
             self._config = deep_merge_dict(config_init, self._config.copy())
             self.WriteConfigFile()
 


### PR DESCRIPTION
- Introduced a Robots Singleton to manage multiple robot instances globally, extracting the base Robot class and updating NavigationHub to leverage this new architecture
- Updated the Preferences UI to seamlessly support dual RobotSetupPanels, allowing users to handle multiple robots simultaneously
- Redesigned the RobotSetupPanel layout to be more compact, optimizing screen space for multiple panels