### PR TITLE
Feature/undo gui polish

### DIFF
--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -49,6 +49,10 @@ class EditionHistoryNode:
         np.save(self.filename, array)
         print("Saving history", self.index, self.orientation, self.filename, self.clean)
 
+    @property
+    def action_name(self):
+        return f"{self.orientation.capitalize()} Slice {self.index + 1}"
+
     def commit_history(self, mvolume):
         array = np.load(self.filename)
         if self.orientation == "AXIAL":
@@ -95,6 +99,14 @@ class DeltaHistoryNode:
 
         self.fd = None
         self.filename = None
+
+    @property
+    def action_name(self):
+        if self.tool_id == "POLYGON":
+            return "3D Polygon Cut"
+        elif self.tool_id == "BRUSH":
+            return "3D Brush Edit"
+        return "3D Volume Edit"
 
     def serialize_to_disk(self):
         """Compresses and writes delta arrays to a temporary file for crash recovery / memory spillover."""
@@ -154,9 +166,18 @@ class EditionHistory:
         Publisher.sendMessage("Enable undo", value=False)
         Publisher.sendMessage("Enable redo", value=False)
 
-    def new_node(self, index, orientation, array, p_array, clean):
+    def notify_history_change(self):
+        items = []
+        for i, node in enumerate(self.history):
+            name = getattr(node, "action_name", f"Edit {i + 1}")
+            items.append((i, name))
+        Publisher.sendMessage("Update history stack", items=items, current_index=self.index)
+
+    def new_node(self, index, orientation, array, p_array, clean=False, tool_id="VOLUME"):
         if orientation == "VOLUME":
-            node = DeltaHistoryNode(index, orientation, p_array, array, clean=clean)
+            node = DeltaHistoryNode(
+                index, orientation, p_array, array, tool_id=tool_id, clean=clean
+            )
             self.add(node)
         else:
             # Saving the previous state, used to undo/redo correctly for 2D slices.
@@ -179,6 +200,19 @@ class EditionHistory:
         print("INDEX", self.index, len(self.history), self.history)
         Publisher.sendMessage("Enable undo", value=True)
         Publisher.sendMessage("Enable redo", value=False)
+        self.notify_history_change()
+
+    def jump_to(self, target_index, mvolume, actual_slices=None):
+        if target_index == self.index or target_index < -1 or target_index >= len(self.history):
+            return
+
+        while self.index > target_index and self.index >= 0:
+            self.undo(mvolume, actual_slices)
+
+        while self.index < target_index and self.index < len(self.history) - 1:
+            self.redo(mvolume, actual_slices)
+
+        self.notify_history_change()
 
     def undo(self, mvolume, actual_slices=None):
         h = self.history
@@ -353,8 +387,8 @@ class Mask:
             self.volume.set_colour(colour)
             Publisher.sendMessage("Render volume viewer")
 
-    def save_history(self, index, orientation, array, p_array, clean=False):
-        self.history.new_node(index, orientation, array, p_array, clean)
+    def save_history(self, index, orientation, array, p_array, clean=False, tool_id="VOLUME"):
+        self.history.new_node(index, orientation, array, p_array, clean, tool_id)
 
     def undo_history(self, actual_slices):
         import invesalius.data.slice_ as slc
@@ -368,6 +402,7 @@ class Mask:
 
         Publisher.sendMessage("Update slice viewer")
         Publisher.sendMessage("Reload actual slice")
+        self.history.notify_history_change()
 
         # Marking the project as changed
         session = ses.Session()
@@ -385,8 +420,25 @@ class Mask:
 
         Publisher.sendMessage("Update slice viewer")
         Publisher.sendMessage("Reload actual slice")
+        self.history.notify_history_change()
 
         # Marking the project as changed
+        session = ses.Session()
+        session.ChangeProject()
+
+    def jump_to_history(self, target_index, actual_slices=None):
+        import invesalius.data.slice_ as slc
+
+        self.history.jump_to(target_index, self.matrix, actual_slices)
+        self.modified_time = time.monotonic()
+
+        slc.Slice().discard_all_buffers()
+        if self.volume is not None and ses.Session().mask_3d_preview:
+            self._update_imagedata(update_volume_viewer=True)
+
+        Publisher.sendMessage("Update slice viewer")
+        Publisher.sendMessage("Reload actual slice")
+
         session = ses.Session()
         session.ChangeProject()
 

--- a/invesalius/data/mask3d_editor_state.py
+++ b/invesalius/data/mask3d_editor_state.py
@@ -226,7 +226,7 @@ class Mask3DEditorState:
         self.mask_data[1:, 1:, 1:] = out
         cur_mask = slc.Slice().current_mask
         if cur_mask is not None:
-            cur_mask.save_history(0, "VOLUME", self.mask_data, orig_mask)
+            cur_mask.save_history(0, "VOLUME", self.mask_data, orig_mask, tool_id="POLYGON")
         self.update_views(out)
 
     def brush_stroke(self, world_coord):
@@ -313,6 +313,8 @@ class Mask3DEditorState:
     def end_brush_stroke(self):
         cur_mask = slc.Slice().current_mask
         if cur_mask is not None:
-            cur_mask.save_history(0, "VOLUME", self.mask_data, self.original_mask_data)
+            cur_mask.save_history(
+                0, "VOLUME", self.mask_data, self.original_mask_data, tool_id="BRUSH"
+            )
             self.mask_data = cur_mask.matrix.copy()
             cur_mask.modified(all_volume=True)

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -384,6 +384,14 @@ class InnerFoldPanel(wx.Panel):
         fold_panel.AddFoldPanelWindow(item, wtw, spacing=0, leftSpacing=0, rightSpacing=0)
         self.__id_watershed = item.GetId()
 
+        # Fold 4 - Edition History
+        item = fold_panel.AddFoldPanel(_("Edition History"), collapsed=True)
+        htw = HistoryPanel(item)
+
+        fold_panel.ApplyCaptionStyle(item, style)
+        fold_panel.AddFoldPanelWindow(item, htw, spacing=0, leftSpacing=0, rightSpacing=0)
+        self.__id_history = item.GetId()
+
         sizer.Add(fold_panel, 1, wx.EXPAND)
 
         fold_panel.Expand(fold_panel.GetFoldPanel(2))
@@ -1290,3 +1298,90 @@ class WatershedTool(EditionTools):
 
     def OnExpandWatershed(self, evt):
         Publisher.sendMessage("Expand watershed to 3D AXIAL")
+
+
+class HistoryPanel(wx.Panel):
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent)
+        try:
+            default_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
+        except AttributeError:
+            default_colour = wx.SystemSettings_GetColour(wx.SYS_COLOUR_MENUBAR)
+        self.SetBackgroundColour(default_colour)
+
+        # Buttons line: Undo and Redo
+        btn_undo = wx.Button(self, -1, _("Undo"), size=(70, -1))
+        btn_redo = wx.Button(self, -1, _("Redo"), size=(70, -1))
+        btn_undo.Enable(False)
+        btn_redo.Enable(False)
+
+        line_btns = wx.BoxSizer(wx.HORIZONTAL)
+        line_btns.Add(btn_undo, 1, wx.RIGHT, 5)
+        line_btns.Add(btn_redo, 1, wx.LEFT, 5)
+
+        # History List Box
+        lbl_history = wx.StaticText(self, -1, _("History Stack:"))
+        list_history = wx.ListBox(self, -1, choices=[], style=wx.LB_SINGLE)
+        list_history.SetMinSize((-1, 120))
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(line_btns, 0, wx.EXPAND | wx.ALL, 5)
+        sizer.Add(lbl_history, 0, wx.LEFT | wx.TOP, 5)
+        sizer.Add(list_history, 1, wx.EXPAND | wx.ALL, 5)
+
+        self.SetSizerAndFit(sizer)
+
+        self.btn_undo = btn_undo
+        self.btn_redo = btn_redo
+        self.list_history = list_history
+        self.history_items = []
+
+        btn_undo.Bind(wx.EVT_BUTTON, self.OnUndo)
+        btn_redo.Bind(wx.EVT_BUTTON, self.OnRedo)
+        list_history.Bind(wx.EVT_LISTBOX_DCLICK, self.OnJumpTo)
+        list_history.Bind(wx.EVT_LISTBOX, self.OnJumpTo)
+
+        Publisher.subscribe(self.OnUpdateHistoryStack, "Update history stack")
+        Publisher.subscribe(self.OnEnableUndo, "Enable undo")
+        Publisher.subscribe(self.OnEnableRedo, "Enable redo")
+
+    def OnEnableUndo(self, value):
+        self.btn_undo.Enable(value)
+
+    def OnEnableRedo(self, value):
+        self.btn_redo.Enable(value)
+
+    def OnUndo(self, evt):
+        Publisher.sendMessage("Undo edition")
+
+    def OnRedo(self, evt):
+        Publisher.sendMessage("Redo edition")
+
+    def OnUpdateHistoryStack(self, items, current_index):
+        self.history_items = items
+        self.list_history.Clear()
+
+        labels = ["0. Initial State"]
+        for idx, name in items:
+            labels.append(f"{idx + 1}. {name}")
+
+        self.list_history.Set(labels)
+
+        active_pos = current_index + 1
+        if 0 <= active_pos < len(labels):
+            self.list_history.SetSelection(active_pos)
+
+    def OnJumpTo(self, evt):
+        sel = self.list_history.GetSelection()
+        if sel != wx.NOT_FOUND:
+            target_index = sel - 1
+            cur_mask = slice_.Slice().current_mask
+            if cur_mask is not None:
+                buffer_slices = slice_.Slice().buffer_slices
+                actual_slices = {
+                    "AXIAL": buffer_slices["AXIAL"].index,
+                    "CORONAL": buffer_slices["CORONAL"].index,
+                    "SAGITAL": buffer_slices["SAGITAL"].index,
+                    "VOLUME": 0,
+                }
+                cur_mask.jump_to_history(target_index, actual_slices)

--- a/tests/test_delta_undo.py
+++ b/tests/test_delta_undo.py
@@ -83,3 +83,33 @@ def test_edition_history_volume_deltas():
     history.redo(matrix)
     assert np.array_equal(matrix, orig_2)
     assert history.index == 0
+
+
+def test_edition_history_jump_to():
+    history = EditionHistory(size=10)
+    matrix = np.zeros((30, 30, 30), dtype=np.uint8)
+
+    # Initial state (State -1)
+    state_init = matrix.copy()
+
+    # Stroke 1: State -1 -> State 0
+    matrix[5:10, 5:10, 5:10] = 255
+    state_0 = matrix.copy()
+    history.new_node(0, "VOLUME", state_0, state_init, clean=False, tool_id="BRUSH")
+
+    # Stroke 2: State 0 -> State 1
+    matrix[15:20, 15:20, 15:20] = 255
+    state_1 = matrix.copy()
+    history.new_node(0, "VOLUME", state_1, state_0, clean=False, tool_id="POLYGON")
+
+    assert history.index == 1
+
+    # Jump directly back to Initial State (index -1)
+    history.jump_to(-1, matrix)
+    assert history.index == -1
+    assert np.array_equal(matrix, state_init)
+
+    # Jump forward directly to State 1 (index 1)
+    history.jump_to(1, matrix)
+    assert history.index == 1
+    assert np.array_equal(matrix, state_1)


### PR DESCRIPTION
### Description

This pull request is submitted as part of Google Summer of Code (GSoC).
This PR introduces the Undo/Redo Visual History Panel and Click-to-Jump stack management for Mask Editing in InVesalius.

Previously, users could only step backward or forward one operation at a time via keybindings without visual tracking of their history. This PR builds a dedicated wxPython History Panel embedded in the task sidebar, displaying a live history stack and enabling users to jump directly to any prior state with a single click.

### Key Features

**wxPython History Panel:** Added a dedicated History Panel under the Manual Edition fold menu featuring Undo/Redo buttons and a live wx.ListBox tracking all edits.
**Click-to-Jump Stack Management:** Implemented jump_to(target_index) in EditionHistory, enabling instant sub-millisecond navigation to any historical state.
**Descriptive Action Metadata:** Added tool_id action tagging (3D Brush Edit, 3D Polygon Cut, 2D Slice Edit) to provide clear history labels.
**PubSub Synchronisation:** Connected live PubSub event broadcasting (Update history stack) to keep the GUI list in sync across all edit, undo, redo, and jump events.
**Automated Unit Test Coverage:** Expanded `tests/test_delta_undo.py` to test jump_to execution and history state transitions.

### Testing

Tested 3D Brush strokes, 3D Polygon Cuts, and 2D slice edits, verifying that every action creates a labeled item in the History Panel.
Tested Click-to-Jump by selecting earlier history items in the list, confirming both 2D slices and 3D volume viewer instantly jump to the selected state.
Executed the automated test suite via `.venv/bin/pytest tests/test_delta_undo.py` (4 passed). 

### Note
This PR is built upon branch feature/delta-undo-engine and can be merged after PR #1449 is merged.
