### PR TITLE
Fix: Sync navigation UI button state and prevent unexpected robot objective resets

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -660,7 +660,7 @@ class Controller:
 
     def CloseProject(self) -> None:
         Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
-        Publisher.sendMessage("Stop navigation")
+        Publisher.sendMessage("Press start navigation button", pressed=False)
         Publisher.sendMessage("Hide content panel")
         Publisher.sendMessage("Close project data")
 

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -660,7 +660,7 @@ class Controller:
 
     def CloseProject(self) -> None:
         Publisher.sendMessage("Enable style", style=const.STATE_DEFAULT)
-        Publisher.sendMessage("Press start navigation button", pressed=False)
+        Publisher.sendMessage("Stop navigation")
         Publisher.sendMessage("Hide content panel")
         Publisher.sendMessage("Close project data")
 

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -1127,12 +1127,12 @@ class SurfaceManager:
             dialog.running = False
 
     def on_publish_surface(self):
-        Publisher.sendMessage("Stop navigation")
+        Publisher.sendMessage("Press start navigation button", pressed=False)
         wx.Yield()
         progress = dialogs.PublishingSurfacesProgressWindow(maximum=100)
         self._publish_surfaces_worker(progress)
         progress.Close()
-        Publisher.sendMessage("Start navigation")
+        Publisher.sendMessage("Press start navigation button", pressed=True)
 
     def _publish_surfaces_worker(self, progress):
         proj = prj.Project()

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -90,7 +90,7 @@ class Preferences(wx.Dialog):
         self.Layout()
         self.__bind_events()
 
-        Publisher.sendMessage("Stop navigation")
+        Publisher.sendMessage("Press start navigation button", pressed=False)
 
     def __bind_events(self):
         Publisher.subscribe(self.LoadPreferences, "Load Preferences")
@@ -2389,7 +2389,7 @@ class TrackerTab(wx.Panel):
             choice = None
 
         # Stop navigation to avoid tracker to be disconnected while navigating
-        Publisher.sendMessage("Stop navigation")
+        Publisher.sendMessage("Press start navigation button", pressed=False)
 
         self.tracker.DisconnectTracker()
         self.tracker.ResetTrackerFiducials()

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -2405,6 +2405,7 @@ class ControlPanel(wx.Panel):
     def __bind_events(self):
         Publisher.subscribe(self.OnStartNavigation, "Start navigation")
         Publisher.subscribe(self.OnStopNavigation, "Stop navigation")
+        Publisher.subscribe(self.PressStartNavigationButton, "Press start navigation button")
         Publisher.subscribe(self.OnCheckStatus, "Navigation status")
         Publisher.subscribe(self.SetTarget, "Set target")
         Publisher.subscribe(self.UnsetTarget, "Unset target")
@@ -2493,6 +2494,10 @@ class ControlPanel(wx.Panel):
 
             # Ensure that the target is sent to robot when navigation starts.
             self.robots.SendTargetToAll()
+
+    def PressStartNavigationButton(self, pressed):
+        self.btn_nav.SetValue(pressed)
+        self.OnStartNavigationButton(evt=None, btn_nav=self.btn_nav)
 
     def OnStartNavigationButton(self, evt, btn_nav):
         nav_id = btn_nav.GetValue()

--- a/invesalius/navigation/robot.py
+++ b/invesalius/navigation/robot.py
@@ -58,6 +58,7 @@ class Robot:
 
         self.objective = RobotObjective.NONE
         self.target = None
+        self.target_marker_id = None
 
         # If tracker already has fiducials set, send them to the robot; this can happen, e.g.,
         # when a pre-existing state is loaded at start-up.
@@ -379,13 +380,16 @@ class Robot:
 
     def UnsetTarget(self, marker):
         self.target = None
+        self.target_marker_id = None
         Publisher.sendMessage("Neuronavigation to Robot: Unset target", robot_id=self.robot_id)
 
     def SetTarget(self, marker):
         # Set robot objective to NONE when a new target is selected. This prevents the robot from
         # automatically moving to the new target (which would be the case if robot objective was previously
         # set to TRACK_TARGET). Preventing the automatic moving makes robot movement more explicit and predictable.
-        self.SetObjective(RobotObjective.NONE)
+        if getattr(self, "target_marker_id", None) != marker.marker_uuid:
+            self.SetObjective(RobotObjective.NONE)
+            self.target_marker_id = marker.marker_uuid
 
         coord = marker.position + marker.orientation
 


### PR DESCRIPTION
1. Navigation Button State Synchronization (UI)

- Issue: When navigation was stopped programmatically (e.g., when opening preferences, closing a project, or publishing surfaces), dispatching the "Stop navigation" message directly did not update the visual state of the "Start navigation" toggle button in the UI.
- Solution: Replaced direct "Stop navigation" calls with "Press start navigation button" passing pressed=False. This centralizes the logic and ensures that the UI toggle button correctly reflects the current navigation status, preventing visual desynchronization.
2. Prevent Unexpected Robot Objective Resets (Robot Tracking)

- Issue: Whenever SetTarget was called, the robot objective was forced to NONE, even if the updated target was the exact same marker as before. This unintentionally interrupted the robot's continuous tracking behavior when a target's coordinates were simply being updated.
- Solution: Introduced a target_marker_id attribute in the Robot class to keep track of the current target's UUID. Now, the robot's objective is only reset to NONE if a different marker is selected, preserving movement continuity when updating an existing target.