### PR TITLE
Refactor: add safe lifecycle disposal for volume viewer

### DIFF
--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -135,6 +135,10 @@ class Viewer(wx.Panel):
         x = int(display_size[0] / 2)
         y = int(display_size[1] / 2)
         wx.Panel.__init__(self, parent, size=wx.Size(x, y))
+        self._disposed = False
+        self._call_laters = []
+        self._ruler_observer_tag = None
+        self._cube_render_observer_tag = None
         self.SetBackgroundColour(wx.Colour(0, 0, 0))
 
         self.interaction_style = st.StyleStateManager()
@@ -394,7 +398,70 @@ class Viewer(wx.Panel):
         self._update_fps_visibility()
         # Request the orientation cube visibility status with a small delay
         # to ensure the interactor has time to initialize during app startup.
-        wx.CallLater(1000, Publisher.sendMessage, "Send orientation cube visibility status")
+        self._call_later(1000, Publisher.sendMessage, "Send orientation cube visibility status")
+
+    def _call_later(self, delay, callable_, *args, **kwargs):
+        if self._disposed:
+            return None
+
+        timer = wx.CallLater(delay, callable_, *args, **kwargs)
+        self._call_laters.append(timer)
+        return timer
+
+    def dispose(self):
+        if self._disposed:
+            return
+
+        self._disposed = True
+        Publisher.unsubscribe_owner(self)
+
+        for timer in self._call_laters:
+            try:
+                if timer.IsRunning():
+                    timer.Stop()
+            except RuntimeError:
+                pass
+        self._call_laters.clear()
+
+        if self.slice_plane:
+            self.slice_plane.dispose()
+            self.slice_plane = None
+
+        self.marker_visualizer.dispose()
+        self.coil_visualizer.dispose()
+        self.probe_visualizer.dispose()
+        self.robot_force_visualizer.dispose()
+        self.vector_field_visualizer.dispose()
+
+        if self.orientation_widget is not None:
+            try:
+                self.orientation_widget.SetEnabled(0)
+            except Exception:
+                pass
+
+        if self._cube_render_observer_tag is not None:
+            try:
+                self.ren.RemoveObserver(self._cube_render_observer_tag)
+            except Exception:
+                pass
+            self._cube_render_observer_tag = None
+
+        if self._ruler_observer_tag is not None:
+            try:
+                self.interactor.RemoveObserver(self._ruler_observer_tag)
+            except Exception:
+                pass
+            self._ruler_observer_tag = None
+
+        try:
+            self.interactor.Disable()
+        except Exception:
+            pass
+
+    def OnDestroy(self, evt):
+        if evt.GetEventObject() is self:
+            self.dispose()
+        evt.Skip()
 
     def _update_fps_visibility(self):
         show_fps = (
@@ -412,7 +479,11 @@ class Viewer(wx.Panel):
 
     def EnableRuler(self):
         self.ruler = GenericLeftRulerVolume(self)
-        self.interactor.AddObserver(vtkCommand.AnyEvent, self.OnInteractorEvent)
+        if self._ruler_observer_tag is not None:
+            self.interactor.RemoveObserver(self._ruler_observer_tag)
+        self._ruler_observer_tag = self.interactor.AddObserver(
+            vtkCommand.AnyEvent, self.OnInteractorEvent
+        )
         Publisher.sendMessage("Send ruler visibility status")
 
     def ShowRuler(self):
@@ -477,11 +548,11 @@ class Viewer(wx.Panel):
         """
         Build and enable the 3D orientation cube (anatomical directions).
         """
-        if not getattr(self, "_cube_request_on", False):
+        if self._disposed or not getattr(self, "_cube_request_on", False):
             return
 
         if not self.interactor:
-            wx.CallLater(100, self._ShowOrientationCube)
+            self._call_later(100, self._ShowOrientationCube)
             return
 
         if not self.interactor.GetInitialized():
@@ -491,7 +562,7 @@ class Viewer(wx.Panel):
             retries = getattr(self, "_cube_retries", 0)
             if retries < 200:
                 self._cube_retries = retries + 1
-                wx.CallLater(100, self._ShowOrientationCube)
+                self._call_later(100, self._ShowOrientationCube)
             else:
                 import logging
 
@@ -1070,13 +1141,11 @@ class Viewer(wx.Panel):
             self.raycasting_volume = False
 
         if self.slice_plane:
-            self.slice_plane.Disable()
-            self.slice_plane.DeletePlanes()
-            del self.slice_plane
+            self.slice_plane.dispose()
+            self.slice_plane = None
             Publisher.sendMessage("Uncheck image plane menu")
             self.mouse_pressed = 0
             self.on_wl = False
-            self.slice_plane = 0
 
         self.interaction_style.Reset()
         self.SetInteractorStyle(const.STATE_DEFAULT)
@@ -3116,7 +3185,7 @@ class Viewer(wx.Panel):
     def __bind_events_wx(self):
         # self.Bind(wx.EVT_SIZE, self.OnSize)
         #  self.canvas.subscribe_event('LeftButtonPressEvent', self.on_insert_point)
-        pass
+        self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
 
     def on_insert_point(self, evt):
         pos = evt.position
@@ -3502,6 +3571,8 @@ class Viewer(wx.Panel):
             self.UpdateRender()
 
     def LoadSlicePlane(self):
+        if self.slice_plane:
+            self.slice_plane.dispose()
         self.slice_plane = SlicePlane()
 
     def LoadVolume(self, volume, colour, ww, wl):
@@ -3974,10 +4045,13 @@ class Viewer(wx.Panel):
             # This is needed because when loading from .inv3, the render window may not be ready yet
             import wx
 
-            wx.CallLater(500, self._RetryEnableSSAO)  # Retry after 500ms
+            self._call_later(500, self._RetryEnableSSAO)  # Retry after 500ms
 
     def _RetryEnableSSAO(self):
         """Retry enabling SSAO after a delay to ensure render window is ready"""
+        if self._disposed:
+            return
+
         render_window = self.interactor.GetRenderWindow()
         if render_window:
             if not render_window.GetNeverRendered():
@@ -3987,7 +4061,7 @@ class Viewer(wx.Panel):
                 # Render window still not rendered, retry again after another delay
                 import wx
 
-                wx.CallLater(500, self._RetryEnableSSAO)
+                self._call_later(500, self._RetryEnableSSAO)
 
     def Reposition3DPlane(self, plane_label):
         if not self.surface_added and not self.raycasting_volume:
@@ -4006,6 +4080,7 @@ class Viewer(wx.Panel):
 
 class SlicePlane:
     def __init__(self):
+        self._disposed = False
         project = prj.Project()
         self.original_orientation = project.original_orientation
         self.Create()
@@ -4017,6 +4092,16 @@ class SlicePlane:
         Publisher.subscribe(self.Disable, "Disable plane")
         Publisher.subscribe(self.ChangeSlice, "Change slice from slice plane")
         Publisher.subscribe(self.UpdateAllSlice, "Update all slice")
+
+    def dispose(self):
+        if self._disposed:
+            return
+
+        self._disposed = True
+        Publisher.unsubscribe_owner(self)
+        for plane in (self.plane_x, self.plane_y, self.plane_z):
+            plane.Off()
+        self.DeletePlanes()
 
     def Create(self):
         plane_x = self.plane_x = vtkImagePlaneWidget()
@@ -4145,6 +4230,6 @@ class SlicePlane:
         Publisher.sendMessage("Update slice 3D", widget=self.plane_z, orientation="AXIAL")
 
     def DeletePlanes(self):
-        del self.plane_x
-        del self.plane_y
-        del self.plane_z
+        self.plane_x = None
+        self.plane_y = None
+        self.plane_z = None

--- a/invesalius/data/visualization/coil_visualizer.py
+++ b/invesalius/data/visualization/coil_visualizer.py
@@ -68,6 +68,9 @@ class CoilVisualizer:
         Publisher.subscribe(self.UpdateCoilPoses, "Update coil poses")
         Publisher.subscribe(self.UpdateVectorField, "Update vector field")
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def LoadConfig(self):
         session = ses.Session()
 

--- a/invesalius/data/visualization/marker_visualizer.py
+++ b/invesalius/data/visualization/marker_visualizer.py
@@ -151,6 +151,9 @@ class MarkerVisualizer:
             self.UpdateVectorFieldAssemblyVisibility, "Set vector field assembly visibility"
         )
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def UpdateNavigationStatus(self, nav_status, vis_status):
         self.is_navigating = nav_status
 

--- a/invesalius/data/visualization/probe_visualizer.py
+++ b/invesalius/data/visualization/probe_visualizer.py
@@ -28,6 +28,9 @@ class ProbeVisualizer:
         Publisher.subscribe(self.UpdateProbePose, "Update probe pose")
         Publisher.subscribe(self.OnNavigationStatus, "Navigation status")
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def OnNavigationStatus(self, nav_status, vis_status):
         self.is_navigating = nav_status
 

--- a/invesalius/data/visualization/robot_force_visualizer.py
+++ b/invesalius/data/visualization/robot_force_visualizer.py
@@ -60,6 +60,9 @@ class RobotForceVisualizer:
         )
         Publisher.subscribe(self.set_visibility, "Set visibility robot force visualizer")
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def _create_segment(self, i):
         theta_start = (2 * math.pi / self.num_segments) * i
         theta_end = theta_start + (2 * math.pi / self.num_segments) * 0.9

--- a/invesalius/data/visualization/vector_field_visualizer.py
+++ b/invesalius/data/visualization/vector_field_visualizer.py
@@ -20,6 +20,9 @@ class VectorFieldVisualizer:
     def __bind_events(self):
         Publisher.subscribe(self.SetVectorField, "Set vector field")
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def SetVectorField(self, vector_field):
         """
         Store the vector field to be visualized.

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -207,12 +207,14 @@ class Panel(wx.Panel):
             Publisher.sendMessage("Hide raycasting widget")
 
     def _Exit(self):
+        self.p4.dispose()
         self.aui_manager.UnInit()
 
 
 class VolumeInteraction(wx.Panel):
     def __init__(self, parent, id):
         super().__init__(parent, id)
+        self._disposed = False
         self.can_show_raycasting_widget = 0
         self.__init_aui_manager()
         # sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -226,7 +228,7 @@ class VolumeInteraction(wx.Panel):
         self.aui_manager = wx.aui.AuiManager()
         self.aui_manager.SetManagedWindow(self)
 
-        p1 = volume_viewer.Viewer(self)
+        self.viewer = volume_viewer.Viewer(self)
         s1 = (
             wx.aui.AuiPaneInfo().Centre().CloseButton(False).MaximizeButton(False).CaptionVisible(0)
         )
@@ -243,7 +245,7 @@ class VolumeInteraction(wx.Panel):
             .Hide()
         )
 
-        self.aui_manager.AddPane(p1, s1)
+        self.aui_manager.AddPane(self.viewer, s1)
         self.aui_manager.AddPane(self.clut_raycasting, self.s2)
         self.aui_manager.Update()
 
@@ -251,6 +253,7 @@ class VolumeInteraction(wx.Panel):
         self.clut_raycasting.Bind(EVT_CLUT_POINT_RELEASE, self.OnPointChanged)
         self.clut_raycasting.Bind(EVT_CLUT_CURVE_SELECT, self.OnCurveSelected)
         self.clut_raycasting.Bind(EVT_CLUT_CURVE_WL_CHANGE, self.OnChangeCurveWL)
+        self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
         # self.Bind(wx.EVT_SIZE, self.OnSize)
         # self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
 
@@ -312,7 +315,21 @@ class VolumeInteraction(wx.Panel):
         self.clut_raycasting.Refresh()
 
     def _Exit(self):
+        self.dispose()
+
+    def dispose(self):
+        if self._disposed:
+            return
+
+        self._disposed = True
+        Publisher.unsubscribe_owner(self)
+        self.viewer.dispose()
         self.aui_manager.UnInit()
+
+    def OnDestroy(self, evt):
+        if evt.GetEventObject() is self:
+            self.dispose()
+        evt.Skip()
 
 
 RAYCASTING_TOOLS = wx.NewIdRef()
@@ -333,13 +350,23 @@ class VolumeViewerCover(wx.Panel):
         wx.Panel.__init__(self, parent)
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(VolumeInteraction(self, -1), 1, wx.EXPAND | wx.GROW)
-        sizer.Add(VolumeToolPanel(self), 0, wx.EXPAND | wx.GROW)
+        self.volume_interaction = VolumeInteraction(self, -1)
+        self.volume_tool_panel = VolumeToolPanel(self)
+        sizer.Add(self.volume_interaction, 1, wx.EXPAND | wx.GROW)
+        sizer.Add(self.volume_tool_panel, 0, wx.EXPAND | wx.GROW)
         sizer.Fit(self)
 
         self.SetSizer(sizer)
         self.Update()
         self.SetAutoLayout(1)
+
+    @property
+    def viewer(self):
+        return self.volume_interaction.viewer
+
+    def dispose(self):
+        self.volume_interaction.dispose()
+        self.volume_tool_panel.dispose()
 
 
 class VolumeToolPanel(wx.Panel):
@@ -455,6 +482,9 @@ class VolumeToolPanel(wx.Panel):
         Publisher.subscribe(self.Uncheck, "Uncheck image plane menu")
         Publisher.subscribe(self.OnSSAOPreferenceChanged, "SSAO preference changed")
 
+    def dispose(self):
+        Publisher.unsubscribe_owner(self)
+
     def DisablePreset(self):
         self.off_item.Check(1)
 
@@ -465,7 +495,13 @@ class VolumeToolPanel(wx.Panel):
         self.button_colour.Bind(csel.EVT_COLOURSELECT, self.OnSelectColour)
         self.button_stereo.Bind(wx.EVT_LEFT_DOWN, self.OnButtonStereo)
         self.button_ssao.Bind(wx.EVT_BUTTON, self.OnButtonSSAO)
+        self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
         # self.button_target.Bind(wx.EVT_LEFT_DOWN, self.OnButtonTarget)
+
+    def OnDestroy(self, evt):
+        if evt.GetEventObject() is self:
+            self.dispose()
+        evt.Skip()
 
     def OnButtonRaycasting(self, evt):
         # MENU RELATED TO RAYCASTING TYPES

--- a/invesalius/pubsub/pub.py
+++ b/invesalius/pubsub/pub.py
@@ -17,7 +17,7 @@
 #    detalhes.
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from pubsub import pub as Publisher
 from pubsub.core.listener import Listener, UserListener
@@ -31,6 +31,8 @@ __all__ = [
     "sendMessage_no_hook",
     # adding hooks
     "add_sendMessage_hook",
+    # unsubscribing by owner
+    "unsubscribe_owner",
 ]
 
 Hook = Callable[[str, dict], None]
@@ -63,6 +65,16 @@ def subscribe(listener: UserListener, topicName: str, **curriedArgs) -> Tuple[Li
 def unsubscribe(*args, **kwargs) -> None:
     """Unsubscribe from a topic."""
     Publisher.unsubscribe(*args, **kwargs)
+
+
+def unsubscribe_owner(owner: object) -> List[Listener]:
+    """Unsubscribe every bound method belonging to an object."""
+
+    def belongs_to_owner(listener: Listener) -> bool:
+        callback = listener.getCallable()
+        return getattr(callback, "__self__", None) is owner
+
+    return Publisher.unsubAll(listenerFilter=belongs_to_owner)
 
 
 def sendMessage(topicName: str, **msgdata) -> None:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -10,6 +10,7 @@ from invesalius.pubsub.pub import (
     sendMessage_no_hook,
     subscribe,
     unsubscribe,
+    unsubscribe_owner,
 )
 
 
@@ -76,3 +77,52 @@ def test_send_message_hook_is_called(mocker):
     # Since hook1 was overwritten, it should NOT be called
     mock_hook1.assert_not_called()
     mock_hook2.assert_called_once_with("test_topic", {"key": "value"})
+
+
+def test_unsubscribe_owner_filters_bound_methods_by_owner(mock_publisher, mocker):
+    class Subscriber:
+        def callback(self):
+            pass
+
+    owner = Subscriber()
+    other = Subscriber()
+    mock_publisher.unsubAll.return_value = ["unsubscribed_listener"]
+
+    result = unsubscribe_owner(owner)
+
+    listener_filter = mock_publisher.unsubAll.call_args.kwargs["listenerFilter"]
+    owned_listener = mocker.Mock()
+    owned_listener.getCallable.return_value = owner.callback
+    other_listener = mocker.Mock()
+    other_listener.getCallable.return_value = other.callback
+    dead_listener = mocker.Mock()
+    dead_listener.getCallable.return_value = None
+
+    assert listener_filter(owned_listener) is True
+    assert listener_filter(other_listener) is False
+    assert listener_filter(dead_listener) is False
+    assert result == ["unsubscribed_listener"]
+
+
+def test_unsubscribe_owner_keeps_other_instances_subscribed():
+    class Subscriber:
+        def __init__(self):
+            self.values = []
+
+        def callback(self, value):
+            self.values.append(value)
+
+    owner = Subscriber()
+    other = Subscriber()
+    subscribe(owner.callback, "unsubscribe_owner_test")
+    subscribe(other.callback, "unsubscribe_owner_test")
+
+    try:
+        unsubscribe_owner(owner)
+        sendMessage_no_hook("unsubscribe_owner_test", value=42)
+
+        assert owner.values == []
+        assert other.values == [42]
+    finally:
+        unsubscribe_owner(owner)
+        unsubscribe_owner(other)


### PR DESCRIPTION
## Summary

Adds an explicit disposal lifecycle to the volume viewer and its owned
visualization components.

The volume viewer and its visualizers subscribe to several PubSub topics,
but previously had no centralized way to remove those listeners when a
viewer was destroyed. This could leave callbacks associated with obsolete
wx/VTK objects and make dynamic viewer recreation unsafe.

## Changes

- Add `unsubscribe_owner()` to the InVesalius PubSub wrapper.
- Preserve the existing `Publisher.subscribe(...)` calls and class hierarchy.
- Add idempotent `dispose()` methods to:
  - volume viewer;
  - marker visualizer;
  - coil visualizer;
  - probe visualizer;
  - robot force visualizer;
  - vector field visualizer;
  - slice plane;
  - volume interaction and tool panels.
- Cancel pending `wx.CallLater` callbacks during viewer disposal.
- Remove registered VTK observers and disable viewer widgets/interactor.
- Expose the volume viewer through `VolumeInteraction.viewer`.
- Propagate disposal through the volume viewer GUI hierarchy.
- Add tests ensuring owner-based unsubscription does not affect other
  instances of the same class.

## Motivation

This prepares the volume viewer for future dynamic creation and destruction,
including support for an optional second navigation viewer, without
accumulating PubSub listeners or callbacks targeting destroyed objects.

## Tests

- `uv run --frozen pytest`
- 99 tests passed.
- Pre-commit hooks passed automatically during commits.