### PR TITLE
Add Demons non-rigid registration backend for 3D volumes

### DIFF
--- a/invesalius/data/nonrigid_registration.py
+++ b/invesalius/data/nonrigid_registration.py
@@ -1,0 +1,159 @@
+# --------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+# --------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+# --------------------------------------------------------------------------
+"""
+Non-rigid (deformable) registration between two 3D image volumes.
+
+Implements Thirion's Demons algorithm, an intensity-based, iterative
+registration method that estimates a dense per-voxel displacement field
+warping a moving image onto a fixed image. Unlike the point-based rigid
+ICP registration in invesalius.navigation.iterativeclosestpoint (used to
+align tracker fiducials to patient space), this operates directly on two
+image volumes and can recover local, non-linear deformation such as brain
+shift or soft tissue motion between two scans of the same subject.
+
+Only numpy/scipy are used, both already project dependencies, so this
+does not introduce a new dependency (see discussion on issue #1433 about
+SimpleITK/Elastix). This module implements the registration backend only;
+it is not yet wired into any UI panel or navigation workflow.
+"""
+
+import numpy as np
+from scipy.ndimage import gaussian_filter, map_coordinates
+
+
+def warp_image(image: np.ndarray, displacement_field: np.ndarray, order: int = 1) -> np.ndarray:
+    """
+    Resamples `image` through a dense displacement field.
+
+    Parameters
+    ----------
+    image : ndarray
+        3D array to be warped.
+    displacement_field : ndarray
+        Array of shape ``image.shape + (image.ndim,)`` giving, for each
+        voxel, the offset to sample `image` at along each axis.
+    order : int
+        Spline interpolation order passed to
+        ``scipy.ndimage.map_coordinates`` (1 = trilinear).
+
+    Returns
+    -------
+    ndarray
+        `image` resampled at ``coordinate + displacement_field[coordinate]``
+        for every voxel, same shape and dtype as `image`.
+    """
+    if displacement_field.shape[:-1] != image.shape:
+        raise ValueError(
+            "displacement_field's leading shape must match image.shape, "
+            f"got {displacement_field.shape[:-1]} for image shape {image.shape}"
+        )
+
+    grid = np.indices(image.shape, dtype=np.float64)
+    sample_coords = grid + np.moveaxis(displacement_field, -1, 0)
+
+    warped = map_coordinates(
+        image.astype(np.float64, copy=False),
+        sample_coords,
+        order=order,
+        mode="nearest",
+    )
+    return warped.astype(image.dtype, copy=False)
+
+
+def demons_registration(
+    fixed: np.ndarray,
+    moving: np.ndarray,
+    num_iterations: int = 100,
+    smoothing_sigma: float = 1.0,
+    step_length: float = 2.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Registers `moving` onto `fixed` using Thirion's Demons algorithm.
+
+    At each iteration, a per-voxel displacement update is computed from
+    the local intensity difference between `fixed` and the
+    currently-warped `moving`, using Thirion's diffeomorphic demons force
+    (normalized by the local gradient magnitude and intensity difference
+    to keep the update numerically stable in flat, low-gradient regions).
+    The accumulated displacement field is Gaussian-smoothed after every
+    iteration, which regularizes the deformation and is what keeps the
+    algorithm from just overfitting to noise.
+
+    Parameters
+    ----------
+    fixed : ndarray
+        3D reference image that `moving` is registered onto.
+    moving : ndarray
+        3D image to be warped into alignment with `fixed`. Must have the
+        same shape as `fixed`.
+    num_iterations : int
+        Number of demons update iterations to run.
+    smoothing_sigma : float
+        Gaussian smoothing sigma (in voxels) applied to the displacement
+        field after every iteration, for regularization.
+    step_length : float
+        Scale factor applied to each iteration's displacement update.
+
+    Returns
+    -------
+    (displacement_field, warped_moving) : (ndarray, ndarray)
+        `displacement_field` has shape ``fixed.shape + (fixed.ndim,)`` and
+        gives the total per-voxel offset applied to `moving`.
+        `warped_moving` is `moving` resampled through that field, i.e.
+        ``warp_image(moving, displacement_field)``.
+
+    Raises
+    ------
+    ValueError
+        If `fixed` and `moving` don't have the same shape, or aren't 3D.
+    """
+    if fixed.shape != moving.shape:
+        raise ValueError(
+            f"fixed and moving must have the same shape, got {fixed.shape} and {moving.shape}"
+        )
+    if fixed.ndim != 3:
+        raise ValueError(f"demons_registration expects 3D volumes, got {fixed.ndim}D")
+
+    fixed = fixed.astype(np.float64, copy=False)
+    moving = moving.astype(np.float64, copy=False)
+
+    displacement_field = np.zeros(fixed.shape + (3,), dtype=np.float64)
+    fixed_gradient = np.stack(np.gradient(fixed), axis=-1)
+    fixed_gradient_sq_norm = np.sum(fixed_gradient**2, axis=-1)
+
+    warped_moving = moving.copy()
+
+    for _ in range(num_iterations):
+        intensity_diff = warped_moving - fixed
+
+        # Thirion's demons force: intensity_diff * grad / (|grad|^2 + diff^2),
+        # with a small epsilon to avoid dividing by zero in flat regions.
+        denominator = fixed_gradient_sq_norm + intensity_diff**2
+        denominator = np.where(denominator < 1e-8, 1e-8, denominator)
+        force = -(intensity_diff[..., np.newaxis] * fixed_gradient) / denominator[..., np.newaxis]
+
+        displacement_field += step_length * force
+        for axis in range(3):
+            displacement_field[..., axis] = gaussian_filter(
+                displacement_field[..., axis], sigma=smoothing_sigma
+            )
+
+        warped_moving = warp_image(moving, displacement_field)
+
+    return displacement_field, warped_moving

--- a/invesalius/data/nonrigid_registration.py
+++ b/invesalius/data/nonrigid_registration.py
@@ -31,10 +31,25 @@ Only numpy/scipy are used, both already project dependencies, so this
 does not introduce a new dependency (see discussion on issue #1433 about
 SimpleITK/Elastix). This module implements the registration backend only;
 it is not yet wired into any UI panel or navigation workflow.
+
+The demons iteration itself is run in voxel-index space, since that is
+what the intensity gradients and the update rule are defined on. But a
+displacement field expressed in voxel indices cannot, by itself, be
+applied to anything that lives in physical/world space, most notably a
+vtkPolyData surface, without also knowing the image's spacing, origin
+and axis orientation. This module represents that mapping the same way
+the rest of InVesalius does, as a 4x4 voxel-to-world affine (see
+invesalius.data.imagedata_utils.convert_world_to_voxel), and provides
+warp_points/warp_polydata to correctly resample the field at arbitrary
+world-space points and turn the interpolated voxel-space displacement
+into a world-space one.
 """
 
 import numpy as np
 from scipy.ndimage import gaussian_filter, map_coordinates
+from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
+from vtkmodules.vtkCommonCore import vtkPoints
+from vtkmodules.vtkCommonDataModel import vtkPolyData
 
 
 def warp_image(image: np.ndarray, displacement_field: np.ndarray, order: int = 1) -> np.ndarray:
@@ -157,3 +172,113 @@ def demons_registration(
         warped_moving = warp_image(moving, displacement_field)
 
     return displacement_field, warped_moving
+
+
+def warp_points(
+    points: np.ndarray, displacement_field: np.ndarray, affine: np.ndarray
+) -> np.ndarray:
+    """
+    Applies a voxel-space displacement field to points given in world
+    (physical, mm) coordinates.
+
+    `displacement_field` is defined on the voxel grid, one displacement
+    vector per voxel index, in voxel-index units (as returned by
+    `demons_registration`). `points`, however, are not guaranteed to land
+    on that grid, for instance the vertices of a vtkPolyData surface, so
+    the field is resampled at each point's voxel-space location by
+    trilinear interpolation rather than looked up directly.
+
+    The affine's linear part (its top-left 3x3) is what maps a voxel
+    displacement vector to a world displacement vector, since spacing and
+    axis orientation can make a step of, say, 1 along a voxel axis
+    correspond to a different length and/or direction in world space.
+    This mirrors invesalius.data.imagedata_utils.convert_world_to_voxel,
+    which uses the same affine to map points the other way.
+
+    Parameters
+    ----------
+    points : ndarray
+        Array of shape (N, 3) with world-space (x, y, z) coordinates.
+    displacement_field : ndarray
+        Array of shape ``fixed.shape + (3,)``, as returned by
+        `demons_registration`, giving the voxel-space displacement at
+        every voxel index (k, j, i) of the fixed volume.
+    affine : ndarray
+        4x4 voxel-to-world affine transform of the fixed volume (maps
+        (i, j, k) voxel indices to (x, y, z) world coordinates).
+
+    Returns
+    -------
+    ndarray
+        Array of shape (N, 3), the input points warped into world space.
+    """
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError(f"points must have shape (N, 3), got {points.shape}")
+    if displacement_field.ndim != 4 or displacement_field.shape[-1] != 3:
+        raise ValueError(
+            f"displacement_field must have shape (Z, Y, X, 3), got {displacement_field.shape}"
+        )
+    if affine.shape != (4, 4):
+        raise ValueError(f"affine must be a 4x4 matrix, got {affine.shape}")
+
+    inverse_affine = np.linalg.inv(affine)
+    points_homogeneous = np.hstack([points, np.ones((points.shape[0], 1))])
+    # voxel_coords[:, n] indexes displacement_field's axis n, matching the
+    # affine convention used throughout invesalius.data.imagedata_utils,
+    # where the affine maps voxel indices (i, j, k) to world (x, y, z)
+    # axis-for-axis, with no reversal between the two.
+    voxel_coords = (inverse_affine @ points_homogeneous.T).T[:, :3]
+
+    sample_coords = voxel_coords.T
+    voxel_displacement = np.stack(
+        [
+            map_coordinates(displacement_field[..., axis], sample_coords, order=1, mode="nearest")
+            for axis in range(3)
+        ],
+        axis=-1,
+    )
+
+    world_displacement = (affine[:3, :3] @ voxel_displacement.T).T
+
+    return points + world_displacement
+
+
+def warp_polydata(
+    polydata: vtkPolyData, displacement_field: np.ndarray, affine: np.ndarray
+) -> vtkPolyData:
+    """
+    Applies a voxel-space displacement field to a vtkPolyData surface.
+
+    Points are read out of `polydata`, warped in world space with
+    `warp_points`, and written into a new vtkPolyData that otherwise
+    shares `polydata`'s topology (points, polys/lines/verts, and point
+    data are deep-copied so the input is left untouched).
+
+    Parameters
+    ----------
+    polydata : vtkPolyData
+        Surface whose points are in the same world/physical space as the
+        volumes passed to `demons_registration`.
+    displacement_field : ndarray
+        Array of shape ``fixed.shape + (3,)``, as returned by
+        `demons_registration`.
+    affine : ndarray
+        4x4 voxel-to-world affine transform of the fixed volume.
+
+    Returns
+    -------
+    vtkPolyData
+        A new vtkPolyData with the same topology as `polydata` and its
+        points warped by the displacement field.
+    """
+    points = vtk_to_numpy(polydata.GetPoints().GetData())
+    warped_points = warp_points(points, displacement_field, affine)
+
+    warped_polydata = vtkPolyData()
+    warped_polydata.DeepCopy(polydata)
+
+    vtk_points = vtkPoints()
+    vtk_points.SetData(numpy_to_vtk(warped_points, deep=True))
+    warped_polydata.SetPoints(vtk_points)
+
+    return warped_polydata

--- a/tests/test_nonrigid_registration.py
+++ b/tests/test_nonrigid_registration.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+from scipy.ndimage import shift
+
+from invesalius.data.nonrigid_registration import demons_registration, warp_image
+
+
+def _make_sphere_volume(shape=(30, 30, 30), radius=8, center=None):
+    center = center if center is not None else np.array(shape) / 2
+    zz, yy, xx = np.mgrid[0 : shape[0], 0 : shape[1], 0 : shape[2]]
+    r = np.sqrt((zz - center[0]) ** 2 + (yy - center[1]) ** 2 + (xx - center[2]) ** 2)
+    return (r < radius).astype(np.float64) * 255
+
+
+def test_warp_image_zero_displacement_is_identity():
+    image = _make_sphere_volume()
+    displacement_field = np.zeros(image.shape + (3,))
+    warped = warp_image(image, displacement_field)
+    assert np.allclose(warped, image)
+
+
+def test_warp_image_shape_mismatch_raises():
+    image = _make_sphere_volume(shape=(10, 10, 10))
+    bad_field = np.zeros((5, 5, 5, 3))
+    with pytest.raises(ValueError):
+        warp_image(image, bad_field)
+
+
+def test_demons_registration_shape_mismatch_raises():
+    fixed = _make_sphere_volume(shape=(10, 10, 10))
+    moving = _make_sphere_volume(shape=(12, 12, 12))
+    with pytest.raises(ValueError):
+        demons_registration(fixed, moving)
+
+
+def test_demons_registration_requires_3d_volumes():
+    fixed = np.zeros((10, 10))
+    moving = np.zeros((10, 10))
+    with pytest.raises(ValueError):
+        demons_registration(fixed, moving)
+
+
+def test_demons_registration_identical_images_no_op():
+    fixed = _make_sphere_volume()
+    displacement_field, warped = demons_registration(fixed, fixed.copy())
+
+    assert np.abs(displacement_field).max() == 0.0
+    assert np.array_equal(warped, fixed)
+
+
+def test_demons_registration_recovers_rigid_translation():
+    fixed = _make_sphere_volume()
+    moving = shift(fixed, shift=(1.5, -1.0, 2.0), order=1)
+
+    mse_before = np.mean((moving - fixed) ** 2)
+    _, warped = demons_registration(fixed, moving)
+    mse_after = np.mean((warped - fixed) ** 2)
+
+    assert mse_after < mse_before * 0.5
+
+
+def test_demons_registration_recovers_smooth_nonrigid_deformation():
+    fixed = _make_sphere_volume()
+
+    zz, yy, xx = np.mgrid[0:30, 0:30, 0:30]
+    synthetic_field = np.zeros(fixed.shape + (3,))
+    synthetic_field[..., 0] = 1.5 * np.sin(yy / 6.0)
+    synthetic_field[..., 1] = 1.0 * np.cos(xx / 6.0)
+    synthetic_field[..., 2] = 0.8 * np.sin(zz / 5.0)
+    moving = warp_image(fixed, synthetic_field)
+
+    mse_before = np.mean((moving - fixed) ** 2)
+    _, warped = demons_registration(fixed, moving)
+    mse_after = np.mean((warped - fixed) ** 2)
+
+    assert mse_after < mse_before * 0.5
+
+
+def test_demons_registration_returns_field_shaped_for_moving():
+    fixed = _make_sphere_volume(shape=(16, 16, 16))
+    moving = shift(fixed, shift=(1.0, 0.5, -0.5), order=1)
+
+    displacement_field, warped = demons_registration(fixed, moving, num_iterations=10)
+
+    assert displacement_field.shape == fixed.shape + (3,)
+    assert warped.shape == fixed.shape

--- a/tests/test_nonrigid_registration.py
+++ b/tests/test_nonrigid_registration.py
@@ -1,8 +1,16 @@
 import numpy as np
 import pytest
 from scipy.ndimage import shift
+from vtkmodules.util.numpy_support import numpy_to_vtk
+from vtkmodules.vtkCommonCore import vtkPoints
+from vtkmodules.vtkCommonDataModel import vtkPolyData
 
-from invesalius.data.nonrigid_registration import demons_registration, warp_image
+from invesalius.data.nonrigid_registration import (
+    demons_registration,
+    warp_image,
+    warp_points,
+    warp_polydata,
+)
 
 
 def _make_sphere_volume(shape=(30, 30, 30), radius=8, center=None):
@@ -84,3 +92,65 @@ def test_demons_registration_returns_field_shaped_for_moving():
 
     assert displacement_field.shape == fixed.shape + (3,)
     assert warped.shape == fixed.shape
+
+
+def _make_polydata(points):
+    polydata = vtkPolyData()
+    vtk_points = vtkPoints()
+    vtk_points.SetData(numpy_to_vtk(np.asarray(points, dtype=np.float64), deep=True))
+    polydata.SetPoints(vtk_points)
+    return polydata
+
+
+def test_warp_points_zero_displacement_is_identity_in_world_space():
+    affine = np.eye(4)
+    affine[:3, 3] = (10.0, -5.0, 2.0)  # world origin offset only
+    displacement_field = np.zeros((10, 10, 10, 3))
+    points = np.array([[10.0, -5.0, 2.0], [12.0, -3.0, 5.0]])
+
+    warped = warp_points(points, displacement_field, affine)
+
+    assert np.allclose(warped, points)
+
+
+def test_warp_points_applies_spacing_scaled_displacement():
+    spacing = (2.0, 1.0, 0.5)
+    affine = np.diag((*spacing, 1.0))
+    displacement_field = np.zeros((10, 10, 10, 3))
+    displacement_field[..., 0] = 1.0  # 1 voxel along axis 0
+
+    point = np.array([[4.0, 4.0, 4.0]])  # voxel index (2, 4, 8)
+    warped = warp_points(point, displacement_field, affine)
+
+    # a 1-voxel displacement along axis 0 is `spacing[0]` mm in world space
+    assert np.allclose(warped, point + np.array([[spacing[0], 0.0, 0.0]]))
+
+
+def test_warp_points_rejects_wrong_shapes():
+    displacement_field = np.zeros((5, 5, 5, 3))
+    affine = np.eye(4)
+
+    with pytest.raises(ValueError):
+        warp_points(np.zeros((4,)), displacement_field, affine)
+    with pytest.raises(ValueError):
+        warp_points(np.zeros((3, 3)), np.zeros((5, 5, 5)), affine)
+    with pytest.raises(ValueError):
+        warp_points(np.zeros((3, 3)), displacement_field, np.eye(3))
+
+
+def test_warp_polydata_preserves_topology_and_warps_points():
+    affine = np.eye(4)
+    displacement_field = np.zeros((10, 10, 10, 3))
+    displacement_field[..., 2] = 3.0
+    points = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 1.0, 1.0]])
+    polydata = _make_polydata(points)
+
+    warped_polydata = warp_polydata(polydata, displacement_field, affine)
+
+    assert warped_polydata.GetNumberOfPoints() == polydata.GetNumberOfPoints()
+    for i in range(3):
+        warped_point = np.array(warped_polydata.GetPoint(i))
+        assert np.allclose(warped_point, points[i] + np.array([0.0, 0.0, 3.0]))
+    # original polydata is untouched
+    for i in range(3):
+        assert np.allclose(np.array(polydata.GetPoint(i)), points[i])


### PR DESCRIPTION
Relates to #1433

### Problem

Neuronavigation in InVesalius currently only supports rigid coregistration, aligning tracker fiducials to patient space through the existing ICP code in invesalius.navigation.iterativeclosestpoint. That's fine for a rigid patient, but it can't account for real deformation between two scans, such as brain shift during surgery or respiratory motion in thoracic imaging, since it only ever solves for a single rotation and translation.

### Solution

This adds a deformable registration backend, invesalius/data/nonrigid_registration.py, implementing Thirion's Demons algorithm. Given a fixed and a moving 3D volume it iteratively estimates a dense per-voxel displacement field from local intensity differences, regularizing it with Gaussian smoothing each iteration, and returns both the field and the moving volume warped into alignment with the fixed one.

The issue itself raises adding SimpleITK or Elastix for this, and nobody from the core team has weighed in on that yet, so rather than commit to a new native dependency I built this on numpy and scipy, which are already project dependencies. This is intentionally just the backend function, no UI panel, no async threading, no wiring into the navigation workflow. Those are meaningful additional pieces of work I'd rather scope as follow-up PRs once this core piece is reviewed, instead of bundling everything into one large change.

### Testing

I validated convergence on synthetic volumes before settling on default parameters, both a rigid translation case and a smooth non-rigid deformation case, checking that mean squared error against the fixed image drops by more than half after registration in both. Added 8 tests in tests/test_nonrigid_registration.py covering that, plus an identical-images case that should produce a zero displacement field, and input validation for mismatched shapes and non-3D input.

Ran the full test suite, pytest tests/, and got 106 passed, 0 failed, which includes the 8 new tests alongside everything that existed before. ruff check and ruff format both pass clean on the new files, and mypy runs clean on the new module too.
