### PR TITLE
Reject remote control messages on topics outside an allow-list

### DIFF
--- a/invesalius/net/remote_control.py
+++ b/invesalius/net/remote_control.py
@@ -18,6 +18,7 @@
 #    detalhes.
 # -------------------------------------------------------------------------
 
+import re
 import time
 
 import socketio
@@ -25,12 +26,37 @@ import wx
 
 from invesalius.pubsub import pub as Publisher
 
+# Topics that an external remote peer is allowed to trigger over this
+# connection. Every existing external integration (the robot controller,
+# NeuroSimo) already follows the "<sender> to Neuronavigation: ..." naming
+# convention for messages meant to come from outside InVesalius (see
+# invesalius/navigation/robot.py and invesalius/gui/task_navigator.py), so
+# that convention is used as the default allow-list here rather than
+# forwarding arbitrary topic names, which would let a remote peer invoke
+# any pubsub-driven behavior in the running application, not just the
+# handful of messages this connection is meant to carry.
+DEFAULT_ALLOWED_TOPIC_PATTERN = re.compile(r"^\S+ to Neuronavigation: ")
+
 
 class RemoteControl:
-    def __init__(self, remote_host):
+    def __init__(self, remote_host, allowed_topics=None):
+        """
+        :param remote_host: Address of the Socket.IO server to connect to.
+        :param allowed_topics: Optional explicit set of topic names the
+            remote peer is allowed to trigger. If None (the default),
+            DEFAULT_ALLOWED_TOPIC_PATTERN is used instead.
+        """
         self._remote_host = remote_host
         self._connected = False
         self._sio = None
+        self._allowed_topics = allowed_topics
+
+    def _is_topic_allowed(self, topic):
+        if not isinstance(topic, str):
+            return False
+        if self._allowed_topics is not None:
+            return topic in self._allowed_topics
+        return DEFAULT_ALLOWED_TOPIC_PATTERN.match(topic) is not None
 
     def _on_connect(self):
         print("Connected to {}".format(self._remote_host))
@@ -45,6 +71,10 @@ class RemoteControl:
         data = msg["data"]
         if data is None:
             data = {}
+
+        if not self._is_topic_allowed(topic):
+            print(f"RemoteControl: ignoring message on disallowed topic {topic!r}")
+            return
 
         # print("Received an event into topic '{}' with data {}".format(topic, str(data)))
         Publisher.sendMessage_no_hook(topicName=topic, **data)

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -1,0 +1,137 @@
+import pytest
+
+from invesalius.net.remote_control import RemoteControl
+from invesalius.pubsub import pub as Publisher
+
+
+@pytest.fixture
+def remote_control():
+    return RemoteControl(remote_host="http://example.invalid")
+
+
+@pytest.fixture
+def recorder():
+    calls = []
+
+    def handler(objective, robot_id=None):
+        calls.append({"objective": objective, "robot_id": robot_id})
+
+    topic = "Robot to Neuronavigation: Set objective"
+    Publisher.subscribe(handler, topic)
+    yield calls
+    Publisher.unsubscribe(handler, topic)
+
+
+def test_default_allow_list_forwards_robot_topic(remote_control, recorder):
+    remote_control._to_neuronavigation(
+        {
+            "topic": "Robot to Neuronavigation: Set objective",
+            "data": {"objective": 1, "robot_id": 0},
+        }
+    )
+
+    assert recorder == [{"objective": 1, "robot_id": 0}]
+
+
+def test_default_allow_list_forwards_neurosimo_topic():
+    calls = []
+
+    def handler(value):
+        calls.append(value)
+
+    topic = "NeuroSimo to Neuronavigation: Test topic"
+    Publisher.subscribe(handler, topic)
+    try:
+        rc = RemoteControl(remote_host="http://example.invalid")
+        rc._to_neuronavigation({"topic": topic, "data": {"value": 42}})
+    finally:
+        Publisher.unsubscribe(handler, topic)
+
+    assert calls == [42]
+
+
+def test_default_allow_list_rejects_arbitrary_internal_topic(remote_control):
+    calls = []
+
+    def handler(**kwargs):
+        calls.append(kwargs)
+
+    # "Stop navigation" is a real internal topic with no "<sender> to
+    # Neuronavigation:" prefix, so a remote peer should not be able to
+    # trigger it.
+    Publisher.subscribe(handler, "Stop navigation")
+    try:
+        remote_control._to_neuronavigation({"topic": "Stop navigation", "data": {}})
+    finally:
+        Publisher.unsubscribe(handler, "Stop navigation")
+
+    assert calls == []
+
+
+def test_default_allow_list_rejects_prefix_lookalike(remote_control):
+    calls = []
+
+    def handler(**kwargs):
+        calls.append(kwargs)
+
+    # Doesn't match "<sender> to Neuronavigation: " since there's no
+    # trailing colon-space after "Neuronavigation".
+    topic = "Robot to Neuronavigationally confuse this"
+    Publisher.subscribe(handler, topic)
+    try:
+        remote_control._to_neuronavigation({"topic": topic, "data": {}})
+    finally:
+        Publisher.unsubscribe(handler, topic)
+
+    assert calls == []
+
+
+def test_non_string_topic_is_rejected_without_raising(remote_control):
+    # Should not raise, just be ignored.
+    remote_control._to_neuronavigation({"topic": None, "data": {}})
+    remote_control._to_neuronavigation({"topic": 123, "data": {}})
+
+
+def test_none_data_is_treated_as_no_arguments():
+    calls = []
+
+    def handler():
+        calls.append(True)
+
+    topic = "Robot to Neuronavigation: Ping"
+    Publisher.subscribe(handler, topic)
+    try:
+        rc = RemoteControl(remote_host="http://example.invalid")
+        rc._to_neuronavigation({"topic": topic, "data": None})
+    finally:
+        Publisher.unsubscribe(handler, topic)
+
+    assert calls == [True]
+
+
+def test_explicit_allowed_topics_overrides_default_pattern():
+    calls = []
+
+    def allowed_handler(enabled):
+        calls.append({"enabled": enabled})
+
+    def disallowed_handler(objective, robot_id=None):
+        calls.append({"objective": objective, "robot_id": robot_id})
+
+    allowed_topic = "Set target mode"
+    disallowed_topic = "Robot to Neuronavigation: Set objective"
+
+    Publisher.subscribe(allowed_handler, allowed_topic)
+    Publisher.subscribe(disallowed_handler, disallowed_topic)
+    try:
+        rc = RemoteControl(remote_host="http://example.invalid", allowed_topics={allowed_topic})
+
+        rc._to_neuronavigation({"topic": allowed_topic, "data": {"enabled": True}})
+        rc._to_neuronavigation({"topic": disallowed_topic, "data": {"objective": 1}})
+    finally:
+        Publisher.unsubscribe(allowed_handler, allowed_topic)
+        Publisher.unsubscribe(disallowed_handler, disallowed_topic)
+
+    # Only the explicitly allowed topic should have gone through, even
+    # though the other one matches the default pattern.
+    assert calls == [{"enabled": True}]


### PR DESCRIPTION
Fixes #1462

### Problem

When InVesalius is started with `--remote-host`, or embedded with `main(remote_host=...)` the way `scripts/invesalius_server.py` does, it opens a Socket.IO connection to that host and forwards every message it receives straight into the internal pubsub bus. `RemoteControl._to_neuronavigation` took the topic name and arguments directly from the remote peer's message with no validation at all, so anyone who could reach that connection could trigger any pubsub topic InVesalius has a listener for, with any arguments, not just the handful of messages this channel is actually meant to carry.

### Evidence

I confirmed this against the real class before writing anything. I subscribed a handler with the exact signature `Robot.SetObjectiveByRobot` uses, on the real topic name `"Robot to Neuronavigation: Set objective"`, then called `_to_neuronavigation` directly with a plain dict shaped like what would arrive over the socket. The handler fired immediately with the values I supplied, which is exactly the message that tells a connected robot to start tracking toward a target or move away from the head.

### Fix

Every existing external integration in this codebase already follows a naming convention for messages meant to come from outside InVesalius, `"<sender> to Neuronavigation: ..."`, used consistently by the robot integration in `robot.py` and by the NeuroSimo integration in `task_navigator.py`. Rather than invent a new scheme, `RemoteControl` now checks incoming topics against that existing convention by default and drops anything that doesn't match. A `RemoteControl` can also be constructed with an explicit `allowed_topics` set if a caller wants something tighter than the default pattern. This is additive only, nothing about how a legitimate remote peer using the established convention behaves has changed.

I intentionally didn't try to add authentication to the Socket.IO connection itself in this PR. That would need a shared secret or token scheme coordinated with whatever external service is on the other end, which lives outside this repository, and I don't have a way to verify that side of it. The allow-list closes the part of this I could actually fix and verify on my own; authentication is a reasonable follow-up once someone with visibility into the external side can design it properly.

### Testing

Added 7 tests in tests/test_remote_control.py against the real class. They cover a topic matching the default allow-list pattern going through for both the robot and NeuroSimo conventions, an ordinary internal topic like "Stop navigation" getting dropped, a topic that looks like the pattern but doesn't actually match it getting dropped, a non-string topic being ignored without raising, a None data payload being treated as no arguments, and the explicit allowed_topics override working and being stricter than the default pattern.

To make sure these are real regression tests, I reverted the fix and reran the suite. Four of the seven failed, the ones that specifically test rejection and the constructor's new parameter, confirming they actually catch the vulnerability rather than just asserting something that was already true. Restored the fix and reran, all seven pass.

Ran the full test suite, pytest tests/, and got 105 passed, 0 failed. ruff check and ruff format both pass clean on the two changed files, and mypy runs clean on the module. There's one pre-existing lint finding on a line I didn't touch in the same file, a `.format()` call ruff would rather see as an f-string, which I left alone since it predates this change and isn't related to it.
