### PR TITLE
Fix AttributeError when setting a brain target outside mTMS flows

### DIFF
--- a/invesalius/data/markers/marker.py
+++ b/invesalius/data/markers/marker.py
@@ -79,6 +79,13 @@ class Marker:
     # #TODO: add a reference to original coil marker to relate it to MEP
     # in micro Volts (but scale in milli Volts for display)
     mep_value: float = dataclasses.field(default=None)
+    # mTMS coil-space coordinates, only set for brain targets created through the mTMS
+    # calibration flow (see OnCreateBrainTargetFromLandmark and OnMtmsCoords in
+    # gui/task_navigator.py). Left as None for brain targets created through other flows.
+    x_mtms: float = dataclasses.field(default=None)
+    y_mtms: float = dataclasses.field(default=None)
+    r_mtms: float = dataclasses.field(default=None)
+    intensity_mtms: float = dataclasses.field(default=None)
     brain_target_list: list = dataclasses.field(default_factory=list)
     timestamp: str = dataclasses.field(
         default_factory=lambda: datetime.now().isoformat(timespec="seconds")

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -3553,10 +3553,26 @@ class MarkersPanel(wx.Panel, ColumnSorterMixin):
                 if marker.brain_target_list[i]["mep_value"]
                 else ""
             )
-            list_entry[const.BRAIN_X_MTMS] = marker.brain_target_list[i]["x_mtms"]
-            list_entry[const.BRAIN_Y_MTMS] = marker.brain_target_list[i]["y_mtms"]
-            list_entry[const.BRAIN_R_MTMS] = marker.brain_target_list[i]["r_mtms"]
-            list_entry[const.BRAIN_INTENSITY_MTMS] = marker.brain_target_list[i]["intensity_mtms"]
+            list_entry[const.BRAIN_X_MTMS] = (
+                str(marker.brain_target_list[i]["x_mtms"])
+                if marker.brain_target_list[i]["x_mtms"] is not None
+                else ""
+            )
+            list_entry[const.BRAIN_Y_MTMS] = (
+                str(marker.brain_target_list[i]["y_mtms"])
+                if marker.brain_target_list[i]["y_mtms"] is not None
+                else ""
+            )
+            list_entry[const.BRAIN_R_MTMS] = (
+                str(marker.brain_target_list[i]["r_mtms"])
+                if marker.brain_target_list[i]["r_mtms"] is not None
+                else ""
+            )
+            list_entry[const.BRAIN_INTENSITY_MTMS] = (
+                str(marker.brain_target_list[i]["intensity_mtms"])
+                if marker.brain_target_list[i]["intensity_mtms"] is not None
+                else ""
+            )
             list_entry[const.BRAIN_UUID] = (
                 str(marker.brain_target_list[i]["marker_uuid"])
                 if marker.brain_target_list[i]["marker_uuid"]

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+
+import pytest
+
+from invesalius.data.markers.marker import Marker, MarkerType
+
+
+@pytest.fixture
+def mock_world_conversion():
+    """Isolates Marker.to_brain_targets_dict() from invesalius.data.slice_.Slice(),
+    a process-wide singleton whose state depends on whether a project is loaded."""
+    with patch(
+        "invesalius.data.markers.marker.imagedata_utils.convert_invesalius_to_world"
+    ) as mock_convert:
+        mock_convert.return_value = ((None, None, None), (None, None, None))
+        yield mock_convert
+
+
+def test_marker_has_mtms_fields_by_default():
+    marker = Marker()
+    assert marker.x_mtms is None
+    assert marker.y_mtms is None
+    assert marker.r_mtms is None
+    assert marker.intensity_mtms is None
+
+
+def test_to_brain_targets_dict_without_mtms_data(mock_world_conversion):
+    """Regression test for #1468: creating a brain target through the plain,
+    non-mTMS flow (as in TaskPanel.OnSetBrainTarget) must not raise AttributeError."""
+    marker = Marker(marker_type=MarkerType.BRAIN_TARGET, x=1.0, y=2.0, z=3.0)
+
+    result = marker.to_brain_targets_dict()
+
+    assert result["x_mtms"] is None
+    assert result["y_mtms"] is None
+    assert result["r_mtms"] is None
+    assert result["intensity_mtms"] is None
+
+
+def test_to_brain_targets_dict_with_mtms_data(mock_world_conversion):
+    """Markers created through the mTMS flow still carry their mTMS coordinates through."""
+    marker = Marker(marker_type=MarkerType.BRAIN_TARGET, x=1.0, y=2.0, z=3.0)
+    marker.x_mtms = 10.5
+    marker.y_mtms = -3.2
+    marker.r_mtms = 45.0
+    marker.intensity_mtms = 10
+
+    result = marker.to_brain_targets_dict()
+
+    assert result["x_mtms"] == 10.5
+    assert result["y_mtms"] == -3.2
+    assert result["r_mtms"] == 45.0
+    assert result["intensity_mtms"] == 10
+
+
+def test_to_brain_targets_dict_with_orientation(mock_world_conversion):
+    """Same regression as above, but through the branch taken when alpha/beta/gamma
+    are set (e.g. coil targets promoted to brain targets)."""
+    marker = Marker(
+        marker_type=MarkerType.BRAIN_TARGET,
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        alpha=10.0,
+        beta=20.0,
+        gamma=30.0,
+    )
+
+    result = marker.to_brain_targets_dict()
+
+    assert result["x_mtms"] is None
+    assert result["y_mtms"] is None
+    assert result["r_mtms"] is None
+    assert result["intensity_mtms"] is None
+
+
+def test_duplicate_preserves_mtms_fields():
+    marker = Marker(marker_type=MarkerType.BRAIN_TARGET)
+    marker.x_mtms = 1.0
+    marker.y_mtms = 2.0
+    marker.r_mtms = 3.0
+    marker.intensity_mtms = 4.0
+
+    duplicate = marker.duplicate()
+
+    assert duplicate.x_mtms == 1.0
+    assert duplicate.y_mtms == 2.0
+    assert duplicate.r_mtms == 3.0
+    assert duplicate.intensity_mtms == 4.0


### PR DESCRIPTION
### Problem

Setting a brain target on a marker crashes with an AttributeError. Marker.to_brain_targets_dict() in invesalius/data/markers/marker.py reads self.x_mtms, self.y_mtms, self.r_mtms and self.intensity_mtms, but the Marker dataclass never declared these as fields, so they only existed as attributes when the mTMS specific code in gui/task_navigator.py happened to assign them first.

The plain, non mTMS brain target flow does not go through that code. OnSetBrainTarget builds a fresh marker with CreateMarker() and calls to_brain_targets_dict() on it right away, which raised AttributeError: 'Marker' object has no attribute 'x_mtms' and aborted the whole action.

### Root cause

CreateMarker() only sets position, orientation, colour, size, label, is_target, seed, session_id, marker_type, cortex_position_orientation, z_offset, z_rotation and mep_value on a bare Marker() instance. x_mtms, y_mtms, r_mtms and intensity_mtms are never touched there. The two other call sites of to_brain_targets_dict() in task_navigator.py happen to run right after the mTMS coordinates were assigned onto the marker, which is why only the OnSetBrainTarget path was broken.

### Solution

x_mtms, y_mtms, r_mtms and intensity_mtms are now declared as regular dataclass fields on Marker, defaulting to None, the same way x_cortex, y_cortex and their siblings are already handled. to_brain_targets_dict() keeps returning all four keys unconditionally, now safely as None for markers that were never associated with an mTMS coil.

The brain target sub list in task_navigator.py (populate_sub_list) reads these same four values back out of the serialized dict to display them. It previously assumed they were always set, so it also needed a small guard to fall back to an empty string when they are None, matching the pattern already used there for mep_value and marker_uuid.

### Testing

Added tests/test_marker.py with five tests covering the default field values, to_brain_targets_dict() with and without mTMS data, the alpha/beta/gamma orientation branch, and that duplicate() preserves the mTMS fields. The world coordinate conversion is mocked so the tests do not depend on invesalius.data.slice_.Slice(), a process wide singleton whose state depends on whether a project is loaded.

Ran the full suite locally with pytest: 110 passed, 0 failed, including the 5 new tests. Checked import sorting and formatting with ruff (ruff check --select I and ruff format --check) on all three changed files against LF normalized copies, since this checkout has core.autocrlf on; both passed clean.

### Impact

Only affects Marker and the brain target list display in the navigation marker panel. No changes to persisted project or marker file formats, since brain_target_list entries were already free form dicts and already carried these four keys whenever they were set.

Fixes #1468
